### PR TITLE
Curriculum page in grade order

### DIFF
--- a/app/controllers/trees_controller.rb
+++ b/app/controllers/trees_controller.rb
@@ -41,7 +41,7 @@ class TreesController < ApplicationController
     listing = listing.where(subject_id: @subj.id) if @subj.present?
     listing = listing.where(grade_band_id: @gb.id) if @gb.present?
     # Note: sort order does matter for sequence of siblings in tree.
-    @trees = listing.order(:code).all
+    @trees = listing.joins(:grade_band).order("grade_bands.sort_order, code").all
 
     @tree = Tree.new(
       tree_type_id: @treeTypeRec.id,

--- a/db/migrate/20191010180347_sort_gradebands.rb
+++ b/db/migrate/20191010180347_sort_gradebands.rb
@@ -1,0 +1,5 @@
+class SortGradebands < ActiveRecord::Migration[5.1]
+  def change
+    add_column :grade_bands, :sort_order, :integer, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,13 +10,14 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20191004210519) do
+ActiveRecord::Schema.define(version: 20191010180347) do
 
   create_table "grade_bands", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.integer "tree_type_id", null: false
     t.string "code"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "sort_order", default: 0
     t.index ["tree_type_id"], name: "index_grade_bands_on_tree_type_id"
   end
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -75,7 +75,8 @@ if GradeBand.count < 13
     begin
       GradeBand.create(
         tree_type_id: @tfv.id,
-        code: g
+        code: g,
+        sort_order: "%02d" % [g]
       )
     rescue
     end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -72,11 +72,12 @@ throw "Invalid Locale Count" if Locale.count != 2
 
 if GradeBand.count < 13
   %w(k 1 2 3 4 5 6 7 8 9 10 11 12).each do |g|
+    gf = (g == 'k') ? 0 : g
     begin
       GradeBand.create(
         tree_type_id: @tfv.id,
         code: g,
-        sort_order: "%02d" % [g]
+        sort_order: "%02d" % [gf]
       )
     rescue
     end

--- a/lib/tasks/set_grade_sort_order.rake
+++ b/lib/tasks/set_grade_sort_order.rake
@@ -1,0 +1,22 @@
+# set_grade_sort_order.rake
+namespace :set_grade_sort_order do
+
+  desc "set the sort_order field for the grade_band table (if not running db:seed)"
+  task run: :environment do
+
+    GradeBand.all.each do |gb|
+      case gb.code
+      when 'k'
+        gb.sort_order = 0
+      else
+        begin
+          gb.sort_order = Integer(gb.code)
+        rescue
+          gb.sort_order = 99
+        end
+      end
+      gb.save
+    end
+  end
+
+end


### PR DESCRIPTION
- added sort_order field to grade_band table
- seeds should populate the grade_band.sort_order field.
- set_grade_sort_order:run rake task to set grade band sort order
- Curriculum page now has single digit grades above double digit grades.