### PR TITLE
Show LO relationships on the Sequence page

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -20,3 +20,4 @@
 //
 // include other js in this directory tree.
 //= require_tree .
+//= require sequence

--- a/app/assets/javascripts/sequence.js
+++ b/app/assets/javascripts/sequence.js
@@ -17,6 +17,8 @@ $(function() {
   	else {
   	   $('#'+subj_abbr+'-column').addClass('hidden')
   	}
+  	$('.sequence-grid').removeClass('cols-0 cols-1 cols-2 cols-3 cols-4 cols-5')
+  	$('.sequence-page .sequence-grid').addClass('cols-' + $('.subj-checkbox input:checked').length )
   }
 
   /**

--- a/app/assets/javascripts/sequence.js
+++ b/app/assets/javascripts/sequence.js
@@ -1,0 +1,41 @@
+//############################
+//# Sequence Page Javascript #
+//############################
+
+
+$(function() {
+
+  /**
+   * Expand and highlight related LOs 
+   */
+
+  related_LO_display = (rel) => {
+    if ($("#lo_" + rel[rel.length - 1]).hasClass('highlight')) {
+	  	$('.sequence-item--collapsable')
+	  	  .removeClass('collapsed')
+	  	  .removeClass('highlight');
+	  	for (let r in rel) {
+	  		$('li[data-lo-id='+rel[r]+']')
+	  		 .find('.connections-icon')
+	  		 .attr('title', 'highlight related LOs');
+	  	}
+    }
+    else {
+      $('.sequence-item--collapsable')
+  	  .addClass('collapsed')
+  	  .removeClass('highlight');
+	  	for (let r in rel) {
+	  	  console.log('highlight ', rel[r])
+	  	  $("#lo_" + rel[r])
+	  		.removeClass('collapsed')
+	  		.addClass('highlight');
+	       $("#lo_" + rel[r])
+	  		 .find('.connections-icon')
+	  		 .attr('title', 'exit highlight mode');
+	  	}
+    }
+ 
+  }
+
+
+});

--- a/app/assets/javascripts/sequence.js
+++ b/app/assets/javascripts/sequence.js
@@ -4,6 +4,20 @@
 
 
 $(function() {
+  /**
+   * Hide or show a subject column when the corresponding 
+   * checkbox is checked or unchecked.
+   * @param  {String} subj_abbr Abbreviation for a subject.
+   *                            E.g. 'bio', 'phy', etc.
+   */
+  subject_visibility = (subj_abbr) => {
+  	if ($('#check-' + subj_abbr).prop('checked')) {
+  	   $('#'+subj_abbr+'-column').removeClass('hidden')
+  	}
+  	else {
+  	   $('#'+subj_abbr+'-column').addClass('hidden')
+  	}
+  }
 
   /**
    * Expand and highlight related LOs 

--- a/app/assets/stylesheets/trees.scss
+++ b/app/assets/stylesheets/trees.scss
@@ -46,10 +46,25 @@
   .sequence-page {
     .sequence-grid {
       display: grid;
-      grid-template-columns: 25% 25% 25% 25%;
       margin-left: -15px;
       margin-right: -15px;
       border-top: 1px solid black;
+    }
+
+    .sequence-grid.cols-5 {
+       grid-template-columns: 20% 20% 20% 20% 20%;
+    }
+
+    .sequence-grid.cols-4 {
+       grid-template-columns: 25% 25% 25% 25%;
+    }
+
+    .sequence-grid.cols-3 {
+       grid-template-columns: 33% 33% 33%;
+    }
+
+    .sequence-grid.cols-2 {
+       grid-template-columns: 50% 50%;
     }
     
     .hidden { display: none; }

--- a/app/assets/stylesheets/trees.scss
+++ b/app/assets/stylesheets/trees.scss
@@ -51,7 +51,13 @@
       margin-right: -15px;
       border-top: 1px solid black;
     }
+    
+    .hidden { display: none; }
 
+    .subj-checkbox { 
+      display: inline;
+      margin: 10px; 
+    }
 
     ul {
       list-style-type: none;

--- a/app/assets/stylesheets/trees.scss
+++ b/app/assets/stylesheets/trees.scss
@@ -52,6 +52,7 @@
       border-top: 1px solid black;
     }
 
+
     ul {
       list-style-type: none;
       list-style-position: none;
@@ -73,6 +74,33 @@
         width: 100%;
         padding: 0 5px;
       }
+      .icon-link {
+        color: black;
+      }
+      .icon-link:hover {
+        color: blue;
+      }
+      .highlight .icon-link {
+        color: brown;
+      }
+      .highlight .icon-link:hover {
+        color: yellow;
+      }
+    }
+    .collapsed .hide-if-collapsed {
+      display: none;
+    }
+
+    .collapsed .truncate-if-collapsed {
+      display: inline-block;
+      text-overflow: ellipsis;
+      overflow: hidden;
+      max-height: 20px;
+      white-space: nowrap;
+    }
+
+    .highlight {
+      background: lightblue;
     }
   }
 

--- a/app/controllers/trees_controller.rb
+++ b/app/controllers/trees_controller.rb
@@ -273,6 +273,14 @@ class TreesController < ApplicationController
     componentHash = {}
     newHash = {}
     @s_o_hash = Hash.new  { |h, k| h[k] = [] }
+    @so_code_by_id_hash = Hash.new
+
+    @relations = Hash.new { |h, k| h[k] = [] }
+    relations = TreeTree.all
+    relations.each do |rel|
+      @relations[rel.tree_referencer_id] << rel
+    end
+    puts "+++++++relations: #{@relations.inspect}"
     # create ruby hash from tree records, to easily build tree from record codes
     @trees.each do |tree|
       translation = @translations[tree.name_key]
@@ -306,7 +314,12 @@ class TreesController < ApplicationController
       #   addNodeToArrHash(treeHash[tree.codeArrayAt(0)][:nodes][tree.codeArrayAt(1)], tree.subCode, newHash)
 
       when 4
-        newHash = {text: "#{tree.code}: #{translation}", id: "#{tree.id}", nodes: {}}
+        newHash = {
+          text: "#{tree.code}: #{translation}", 
+          id: "#{tree.id}",
+          connections: @relations[tree.id], 
+          nodes: {}
+        }
         # if treeHash[tree.codeArrayAt(0)].blank?
         #   raise I18n.t('trees.errors.missing_grade_in_tree')
         # elsif treeHash[tree.codeArrayAt(0)][:nodes][tree.codeArrayAt(1)].blank?
@@ -315,6 +328,7 @@ class TreesController < ApplicationController
         #   raise I18n.t('trees.errors.missing_component_in_tree')
         #end
         @s_o_hash[tree.subject.code] << newHash
+        @so_code_by_id_hash[tree.id] = {subj: tree.subject.code, code: tree.code}
         #addNodeToArrHash(treeHash[tree.codeArrayAt(0)][:nodes][tree.codeArrayAt(1)][:nodes][tree.codeArrayAt(2)], tree.subCode, newHash)
 
       # when 5

--- a/app/controllers/trees_controller.rb
+++ b/app/controllers/trees_controller.rb
@@ -240,7 +240,8 @@ class TreesController < ApplicationController
 
     @subjects = {}
     subjIds = {}
-    Subject.all.each do |s|
+    subjects = Subject.all
+    subjects.each do |s|
       @subjects[s.code] = s
       subjIds[s.id.to_s] = s
     end
@@ -260,6 +261,10 @@ class TreesController < ApplicationController
     # Consider having Translations belong_to trees and sectors.
     # Current solution: get translation from hash of pre-cached translations.
     base_keys= @trees.map { |t| "#{t.base_key}.name" }
+    base_keys =  base_keys | subjects.map { |s| "#{s.base_key}.name" }
+    base_keys = base_keys | subjects.map { |s| "#{s.base_key}.abbr" }
+    puts "++++++++BaseKEYS: #{base_keys[base_keys.length - 1 ]}"
+    puts
     @translations = Hash.new
     translations = Translation.where(locale: @locale_code, key: base_keys)
     translations.each do |t|

--- a/app/controllers/trees_controller.rb
+++ b/app/controllers/trees_controller.rb
@@ -273,14 +273,12 @@ class TreesController < ApplicationController
     componentHash = {}
     newHash = {}
     @s_o_hash = Hash.new  { |h, k| h[k] = [] }
-    @so_code_by_id_hash = Hash.new
 
     @relations = Hash.new { |h, k| h[k] = [] }
     relations = TreeTree.all
     relations.each do |rel|
       @relations[rel.tree_referencer_id] << rel
     end
-    puts "+++++++relations: #{@relations.inspect}"
     # create ruby hash from tree records, to easily build tree from record codes
     @trees.each do |tree|
       translation = @translations[tree.name_key]
@@ -328,7 +326,6 @@ class TreesController < ApplicationController
         #   raise I18n.t('trees.errors.missing_component_in_tree')
         #end
         @s_o_hash[tree.subject.code] << newHash
-        @so_code_by_id_hash[tree.id] = {subj: tree.subject.code, code: tree.code}
         #addNodeToArrHash(treeHash[tree.codeArrayAt(0)][:nodes][tree.codeArrayAt(1)][:nodes][tree.codeArrayAt(2)], tree.subCode, newHash)
 
       # when 5
@@ -386,8 +383,6 @@ class TreesController < ApplicationController
     # convert array of areas into json to put into bootstrap treeview
     @otcJson = otcArrHash.to_json
 
-
-    puts "count: #{@s_o_hash.length}, TREEEEEEEEES:#{@s_o_hash}"
     respond_to do |format|
       format.html { render 'sequence'}
     end

--- a/app/controllers/trees_controller.rb
+++ b/app/controllers/trees_controller.rb
@@ -249,8 +249,7 @@ class TreesController < ApplicationController
       tree_type_id: @treeTypeRec.id,
       version_id: @versionRec.id
     )
-    @trees = listing.order(:code).all
-
+    @trees = listing.joins(:grade_band).order("grade_bands.sort_order, trees.sort_order, code").all
     @tree = Tree.new(
       tree_type_id: @treeTypeRec.id,
       version_id: @versionRec.id

--- a/app/views/trees/sequence.html.erb
+++ b/app/views/trees/sequence.html.erb
@@ -14,7 +14,7 @@
   <% end %>
 </div>
 <div id="trees" class="sequence-page">
-  <div class="sequence-grid">
+  <div class="sequence-grid cols-<%= @s_o_hash.keys.count %>">
 	<% @s_o_hash.each do |i, j| %>
     <div id="<%=i%>-column" class="sequence-item subject-column">
       <ul>

--- a/app/views/trees/sequence.html.erb
+++ b/app/views/trees/sequence.html.erb
@@ -2,13 +2,21 @@
 <% content_for(:page_class, 'trees') %>
 
 <br>
-<div class='text-center'>
+<div class='text-center sequence-page'>
   <h2 id="sequencing-header"><%= translate('trees.sequencing.title') %></h2>
+  <% @s_o_hash.keys.each do |i| %>
+    <div class='subj-checkbox'>
+      <label for="check-<%= i %>">      
+        <%= @translations["subject.#{i}.name"] %>
+      </label>
+      <input id="check-<%= i %>" type="checkbox" onchange='subject_visibility("<%= i %>");' checked></input>
+    </div>
+  <% end %>
 </div>
 <div id="trees" class="sequence-page">
   <div class="sequence-grid">
 	<% @s_o_hash.each do |i, j| %>
-    <div class="sequence-item">
+    <div id="<%=i%>-column" class="sequence-item subject-column">
       <ul>
         <li class="sequence-header"><%= Translation.where(locale: @locale_code, key: @subjects[i].base_key + ".name").first.value %></li>
         <% j.each do |k| %>

--- a/app/views/trees/sequence.html.erb
+++ b/app/views/trees/sequence.html.erb
@@ -16,9 +16,9 @@
             <a class="truncate-if-collapsed" href="<%= tree_path(k[:id])%>"><%= k[:text] %></a>
             <% if k[:connections].length > 0 %>
               <div class="connections-div hide-if-collapsed" data-connections="<%= k[:connections].pluck(:tree_referencee_id) %>">
-              <p><strong>Connections:</strong>
+              <div><strong><%= translate('trees.labels.outcome_connections') %></strong>
                 <a class="icon-link" onclick="related_LO_display(<%= k[:connections].pluck(:tree_referencee_id) << k[:id] %> );"><i class="fa fa-plug connections-icon" title="highlight connected LOs"></i></a>
-              </p>
+              </div>
                 <% k[:connections].each do |c| %>
                   <div><strong><%= translate('trees.labels.relation_types.' + c.relationship) %></strong> <% 
                   ref = @so_code_by_id_hash[c.tree_referencee_id]

--- a/app/views/trees/sequence.html.erb
+++ b/app/views/trees/sequence.html.erb
@@ -21,9 +21,9 @@
               </div>
                 <% k[:connections].each do |c| %>
                   <div><strong><%= translate('trees.labels.relation_types.' + c.relationship) %></strong> <% 
-                  ref = @so_code_by_id_hash[c.tree_referencee_id]
+                  ref = c.tree_referencee.subject.code + '.' + c.tree_referencee[:code]
                   %>
-                  <a href="<%= tree_path(c.tree_referencee_id)%>"><%= ref[:subj] + '.' + ref[:code] %></a>
+                  <a href="<%= tree_path(c.tree_referencee_id)%>"><%= ref %></a>
                   </div>
                 <% end %>
               </div>

--- a/app/views/trees/sequence.html.erb
+++ b/app/views/trees/sequence.html.erb
@@ -8,16 +8,30 @@
 <div id="trees" class="sequence-page">
   <div class="sequence-grid">
 	<% @s_o_hash.each do |i, j| %>
-      <div class="sequence-item">
-        <ul>
-          <li class="sequence-header"><%= Translation.where(locale: @locale_code, key: @subjects[i].base_key + ".name").first.value %></li>
+    <div class="sequence-item">
+      <ul>
+        <li class="sequence-header"><%= Translation.where(locale: @locale_code, key: @subjects[i].base_key + ".name").first.value %></li>
         <% j.each do |k| %>
-          <li class="sequence-item"> 
-            <a href="<%= tree_path(k[:id])%>"><%= k[:text] %></a>
+          <li id="lo_<%= k[:id] %>" class="sequence-item sequence-item--collapsable" data-lo-id="<%= k[:id] %>"> 
+            <a class="truncate-if-collapsed" href="<%= tree_path(k[:id])%>"><%= k[:text] %></a>
+            <% if k[:connections].length > 0 %>
+              <div class="connections-div hide-if-collapsed" data-connections="<%= k[:connections].pluck(:tree_referencee_id) %>">
+              <p><strong>Connections:</strong>
+                <a class="icon-link" onclick="related_LO_display(<%= k[:connections].pluck(:tree_referencee_id) << k[:id] %> );"><i class="fa fa-plug connections-icon" title="highlight connected LOs"></i></a>
+              </p>
+                <% k[:connections].each do |c| %>
+                  <div><strong><%= translate('trees.labels.relation_types.' + c.relationship) %></strong> <% 
+                  ref = @so_code_by_id_hash[c.tree_referencee_id]
+                  %>
+                  <a href="<%= tree_path(c.tree_referencee_id)%>"><%= ref[:subj] + '.' + ref[:code] %></a>
+                  </div>
+                <% end %>
+              </div>
+            <% end %>
           </li>
         <% end %>
-        </ul>
-      </div>
+      </ul>
+    </div>
   <% end %>
   </div>
 </div>

--- a/config/locales/pages.en.yml
+++ b/config/locales/pages.en.yml
@@ -147,6 +147,10 @@ en:
       outcome_connections: 'Connections to Other Outcomes:'
       relation: 'Relation'
       how_outcome_related: 'How Outcome is Related:'
+      relation_types:
+        applies: 'Applies to:'
+        depends: 'Depends on:'
+        akin: 'Akin to:'
       current_subject: "This Subject"
       bio: "Biology"
       che: "Chemistry"

--- a/config/locales/pages.tr.yml
+++ b/config/locales/pages.tr.yml
@@ -76,6 +76,10 @@ tr:
       future_vision_hover: "Gelecek Vizyonu"
       related_sectors: 'İlgili Sektörler'
       how_sectors_related: 'Sektör ile ilgili nasıl.'
+      relation_types:
+        applies: 'İçin geçerlidir:'
+        depends: 'Bağlıdır:'
+        akin: 'Yakın:'
       indicator_connections: 'Diğer Öğrenme Bağlantılar:'
       outcome_connections: 'Diğer Öğrenme Çıktıları:'
       relation: 'Ilişki'

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -65,8 +65,7 @@ ActiveRecord::Schema.define(version: 20191023160310) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["key"], name: "index_translations_on_key"
-    t.index ["locale", "key"], name: "index_translations_on_keys"
-    t.index ["value"], name: "index_translations_on_value", length: { value: 256 }
+    t.index ["value"], name: "index_translations_on_value", length: { value: 255 }
   end
 
   create_table "tree_trees", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|


### PR DESCRIPTION
fixes #19 

On the Sequence page: clicking the plug/connect icon next to "Connections" highlights all LOs with a relationship to the one clicked (or returns the display to normal if already in highlight mode).

Adds relational data to the LOs displayed on the Sequence page.

Adds (and utilizes) translations to the locale config for Akin To, Depends on, and Applies to, relationships. Respectively:
- trees.labels.relation_types.akin
- trees.labels.relation_types.depends
- trees.labels.relation_types.applies

Adds subject checkboxes to the Sequence page that control which subjects are displayed, and the width of subject columns (up to five columns).