### PR TITLE
Fix tree order

### DIFF
--- a/app/controllers/trees_controller.rb
+++ b/app/controllers/trees_controller.rb
@@ -60,7 +60,7 @@ class TreesController < ApplicationController
     listing = listing.where(subject_id: @subj.id) if @subj.present?
     listing = listing.where(grade_band_id: @gb.id) if @gb.present?
     # Note: sort order does matter for sequence of siblings in tree.
-    @trees = listing.joins(:grade_band).order("grade_bands.sort_order, code").all
+    @trees = listing.joins(:grade_band).order("grade_bands.sort_order, trees.sort_order, code").all
 
     # @tree is used for filtering form
     @tree = Tree.new(
@@ -240,7 +240,7 @@ class TreesController < ApplicationController
       @subjects[s.code] = s
       subjIds[s.id.to_s] = s
     end
-    
+
     listing = Tree.where(
       tree_type_id: @treeTypeRec.id,
       version_id: @versionRec.id
@@ -369,7 +369,7 @@ class TreesController < ApplicationController
     @otcJson = otcArrHash.to_json
 
 
-    puts "count: #{@s_o_hash.length}, TREEEEEEEEES:#{@s_o_hash}" 
+    puts "count: #{@s_o_hash.length}, TREEEEEEEEES:#{@s_o_hash}"
     respond_to do |format|
       format.html { render 'sequence'}
     end

--- a/app/controllers/uploads_controller.rb
+++ b/app/controllers/uploads_controller.rb
@@ -348,7 +348,8 @@ class UploadsController < ApplicationController
         @subjectRec,
         @gradeBandRec,
         numCodes.join('.'),
-        depth
+        depth,
+        line_num
       )
       if save_status == BaseRec::REC_ERROR
         @rowErrs << message if message.present?

--- a/app/models/tree.rb
+++ b/app/models/tree.rb
@@ -264,7 +264,8 @@ class Tree < BaseRec
   #   gradeBandRec - grade band record
   #   fullCode - code including parent codes (e.g. 1.1.1.a for a indicator).
   #   depth - record depth - stored in record
-  def self.find_or_add_code_in_tree(treeTypeRec, versionRec, subjectRec, gradeBandRec, fullCode, depth)
+  #   sort_order - originally in record read order, is used to adjust for sort issues, and may be used for moving LOs around
+  def self.find_or_add_code_in_tree(treeTypeRec, versionRec, subjectRec, gradeBandRec, fullCode, depth, sort_order)
     # get the tree records for this hierarchy item
     matched_codes = Tree.where(
       tree_type_id: treeTypeRec.id,
@@ -286,6 +287,7 @@ class Tree < BaseRec
         "#{subjectRec.code}."\
         "#{fullCode}"
       tree.depth = depth
+      tree.sort_order = sort_order
       ret = tree.save
       puts "++++ add tree.base_key: #{tree.base_key}"
       if tree.errors.count > 0

--- a/db/migrate/20191023160310_sequence_trees.rb
+++ b/db/migrate/20191023160310_sequence_trees.rb
@@ -1,0 +1,5 @@
+class SequenceTrees < ActiveRecord::Migration[5.1]
+  def change
+    add_column :trees, :sort_order, :integer, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20191010180347) do
+ActiveRecord::Schema.define(version: 20191023160310) do
 
   create_table "grade_bands", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.integer "tree_type_id", null: false
@@ -98,6 +98,7 @@ ActiveRecord::Schema.define(version: 20191010180347) do
     t.string "base_key"
     t.string "matching_codes", default: "[]"
     t.integer "depth", default: 0
+    t.integer "sort_order", default: 0
     t.index ["grade_band_id"], name: "index_trees_on_grade_band_id"
     t.index ["name_key"], name: "index_trees_on_name_key"
     t.index ["subject_id"], name: "index_trees_on_subject_id"


### PR DESCRIPTION
- Added sort_order field to trees table, so that it is preset to the sequence from upload.
- Curriculum listing uses trees.sort_order before sorting on code
