### PR TITLE
Hide connections for LOs unless LO is in "show connections mode"

### DIFF
--- a/app/assets/javascripts/sequence.js
+++ b/app/assets/javascripts/sequence.js
@@ -28,8 +28,7 @@ $(function() {
   related_LO_display = function (rel) {
     if ($("#lo_" + rel[rel.length - 1]).hasClass('highlight')) {
 	  	$('.sequence-item--collapsable')
-	  	  .removeClass('collapsed')
-	  	  .removeClass('highlight');
+	  	  .removeClass('collapsed highlight show-connections-condition');
 	  	for (var r in rel) {
 	  		$('li[data-lo-id='+rel[r]+']')
 	  		 .find('.connections-icon')
@@ -39,12 +38,12 @@ $(function() {
     else {
       $('.sequence-item--collapsable')
   	  .addClass('collapsed')
-  	  .removeClass('highlight');
+  	  .removeClass('highlight show-connections-condition');
 	  	for (var r in rel) {
 	  	  console.log('highlight ', rel[r])
 	  	  $("#lo_" + rel[r])
 	  		.removeClass('collapsed')
-	  		.addClass('highlight');
+	  		.addClass('highlight show-connections-condition');
 	       $("#lo_" + rel[r])
 	  		 .find('.connections-icon')
 	  		 .attr('title', 'exit highlight mode');

--- a/app/assets/stylesheets/trees.scss
+++ b/app/assets/stylesheets/trees.scss
@@ -44,6 +44,15 @@
   }
 
   .sequence-page {
+
+    .hide-unless-condition {
+      display: none;
+    }
+
+    .show-connections-condition .hide-unless-condition {
+      display: inline-block;
+    }
+
     .sequence-grid {
       display: grid;
       margin-left: -15px;

--- a/app/assets/stylesheets/trees.scss
+++ b/app/assets/stylesheets/trees.scss
@@ -53,6 +53,10 @@
       display: inline-block;
     }
 
+    .show-connections-condition .hide-unless-condition:first-child {
+      display: inline;
+    }
+
     .sequence-grid {
       display: grid;
       margin-left: -15px;

--- a/app/views/trees/sequence.html.erb
+++ b/app/views/trees/sequence.html.erb
@@ -24,11 +24,11 @@
             <a class="truncate-if-collapsed" href="<%= tree_path(k[:id])%>"><%= k[:text] %></a>
             <% if k[:connections].length > 0 %>
               <div class="connections-div hide-if-collapsed" data-connections="<%= k[:connections].pluck(:tree_referencee_id) %>">
-              <div><strong><%= translate('trees.labels.outcome_connections') %></strong>
+              <div><span class='hide-unless-condition'><strong><%= translate('trees.labels.outcome_connections') %></strong></span>
                 <a class="icon-link" onclick="related_LO_display(<%= k[:connections].pluck(:tree_referencee_id) << k[:id] %> );"><i class="fa fa-plug connections-icon" title="highlight connected LOs"></i></a>
               </div>
                 <% k[:connections].each do |c| %>
-                  <div><strong><%= translate('trees.labels.relation_types.' + c.relationship) %></strong> <% 
+                  <div class="hide-unless-condition"><strong><%= translate('trees.labels.relation_types.' + c.relationship) %></strong> <% 
                   ref = c.tree_referencee.subject.code + '.' + c.tree_referencee[:code]
                   %>
                   <a href="<%= tree_path(c.tree_referencee_id)%>"><%= ref %></a>

--- a/app/views/trees/sequence.html.erb
+++ b/app/views/trees/sequence.html.erb
@@ -24,7 +24,7 @@
             <a class="truncate-if-collapsed" href="<%= tree_path(k[:id])%>"><%= k[:text] %></a>
             <% if k[:connections].length > 0 %>
               <div class="connections-div hide-if-collapsed" data-connections="<%= k[:connections].pluck(:tree_referencee_id) %>">
-              <div><span class='hide-unless-condition'><strong><%= translate('trees.labels.outcome_connections') %></strong></span>
+              <div><strong class='hide-unless-condition'><%= translate('trees.labels.outcome_connections') %></strong>
                 <a class="icon-link" onclick="related_LO_display(<%= k[:connections].pluck(:tree_referencee_id) << k[:id] %> );"><i class="fa fa-plug connections-icon" title="highlight connected LOs"></i></a>
               </div>
                 <% k[:connections].each do |c| %>


### PR DESCRIPTION
On Sequence page, hide connections for LOs unless 'connections' icon is clicked for the LO or one of its connected LOs.