### PR TITLE
Allow LOs to be sorted outside of their grade band on the Sequence page

### DIFF
--- a/app/controllers/trees_controller.rb
+++ b/app/controllers/trees_controller.rb
@@ -252,7 +252,7 @@ class TreesController < ApplicationController
       tree_type_id: @treeTypeRec.id,
       version_id: @versionRec.id
     )
-    @trees = listing.joins(:grade_band).order("grade_bands.sort_order, trees.sequence_order, code").all
+    @trees = listing.joins(:grade_band).order("trees.sequence_order, code").all
     @tree = Tree.new(
       tree_type_id: @treeTypeRec.id,
       version_id: @versionRec.id

--- a/app/controllers/uploads_controller.rb
+++ b/app/controllers/uploads_controller.rb
@@ -342,6 +342,8 @@ class UploadsController < ApplicationController
     # update text translation for this locale (if not skipped)
     if !@abortRow
       # insert record into tree
+      sequence_order = 1 + Tree.where(:subject_id=> @subjectRec.id).pluck(:sequence_order).max() 
+      new_seq = depth == 3 ? sequence_order : 0
       new_code, @rowTreeRec, save_status, message = Tree.find_or_add_code_in_tree(
         @treeTypeRec,
         @versionRec,
@@ -350,7 +352,7 @@ class UploadsController < ApplicationController
         numCodes.join('.'),
         depth,
         line_num,
-        line_num
+        new_seq
       )
       if save_status == BaseRec::REC_ERROR
         @rowErrs << message if message.present?


### PR DESCRIPTION
fixes #40 
-Allow LOs to be sorted outside of their grade band on the Sequence page.
-Change how sequence_order property of Trees are set in the uploads_controller.

Rule for upload procedure: Subjects must be loaded in grade order.

**Note:** I think we are already safe here, but we may need to consider the implications of the new upload behavior (for setting sequence_order) when files for the same course in more than one language is available.