### PR TITLE
Save new LO connections on the Sequence page.

### DIFF
--- a/app/assets/javascripts/sequence.js
+++ b/app/assets/javascripts/sequence.js
@@ -125,7 +125,10 @@ initializeSortAndDrag = function () {
         .then(function (res) { 
           console.log("RESPONSE:", res) 
           html = res.errors ? 
-                  '<h3>ERROR:</h3><div>' + res.errors +'</div>' :
+                  '<div class="modal-header"><h3>ERROR:</h3></div> \
+                  <div class="modal-body">' + res.errors +
+                  '<br><button type="button" type="button" data-dismiss="modal" \
+                  aria-hidden="true">CLOSE</button></div>' :
                   '<div class="modal-header"> \
                   <h3 id="myModalLabel"> LO '+  res.translations.relationship +'</h3> \
                   </div> \
@@ -157,6 +160,8 @@ initializeSortAndDrag = function () {
                       <textarea type="text" name="tree_tree[explanation]"></textarea> \
                     </fieldset> \
                     <button type="submit" >SAVE</button>\
+                    <button type="button" type="button" data-dismiss="modal" \
+                    aria-hidden="true">CANCEL</button> \
                     </div> \
                     </form>' 
           $("#modal-container").html(html)

--- a/app/assets/javascripts/sequence.js
+++ b/app/assets/javascripts/sequence.js
@@ -124,7 +124,9 @@ initializeSortAndDrag = function () {
         })
         .then(function (res) { 
           console.log("RESPONSE:", res) 
-          html = '<div class="modal-header"> \
+          html = res.errors ? 
+                  '<h3>ERROR:</h3><div>' + res.errors +'</div>' :
+                  '<div class="modal-header"> \
                   <h3 id="myModalLabel"> LO '+  res.translations.relationship +'</h3> \
                   </div> \
                   <div class="modal-body"> \
@@ -152,12 +154,11 @@ initializeSortAndDrag = function () {
                     </fieldset> \
                     <fieldset> \
                       <label for="explanation">' + res.translations.explanation + '<br> \
-                      <textarea type="text" name=tree_tree["explanation"]></textarea> \
+                      <textarea type="text" name="tree_tree[explanation]"></textarea> \
                     </fieldset> \
                     <button type="submit" >SAVE</button>\
                     </div> \
-                    </form> \
-                  '
+                    </form>' 
           $("#modal-container").html(html)
         })
         .catch(function (err) { console.log("ERROR:", err) })

--- a/app/assets/javascripts/sequence.js
+++ b/app/assets/javascripts/sequence.js
@@ -51,12 +51,6 @@ $(function() {
     }
  
   }
-
-  makeConnection = function () {
-     $("#modal_popup").modal('hide');
-  }
-
-
 });
 
 initializeSortAndDrag = function () {
@@ -134,7 +128,9 @@ initializeSortAndDrag = function () {
                   <h3 id="myModalLabel"> LO '+  res.translations.relationship +'</h3> \
                   </div> \
                   <div class="modal-body"> \
+                    <form action="/tree_trees" method="POST"> \
                     <div> \
+                      <input type="hidden" name="authenticity_token" value="' + $('[name="csrf-token"]').attr('content') + '"> \
                       <input type="hidden" name="tree_tree[tree_referencer_id]" value=' + res.tree_tree.tree_referencer_id +'> \
                       <input type="hidden" name="tree_tree[tree_referencee_id]" value=' + res.tree_tree.tree_referencee_id + '> \
                     </div> \
@@ -151,15 +147,16 @@ initializeSortAndDrag = function () {
                     <option value="' + res.relation_values.akin + '">'
                     + res.translations.akin 
                     + '</option> \
-                    </select>\
+                    </select> \
                     <div>' + res.referencee_code + '</div><br> \
                     </fieldset> \
                     <fieldset> \
                       <label for="explanation">' + res.translations.explanation + '<br> \
                       <textarea type="text" name=tree_tree["explanation"]></textarea> \
-                    </fieldset>\
-                    <button onclick="makeConnection()" >SAVE</button>\
+                    </fieldset> \
+                    <button type="submit" >SAVE</button>\
                     </div> \
+                    </form> \
                   '
           $("#modal-container").html(html)
         })

--- a/app/controllers/tree_trees_controller.rb
+++ b/app/controllers/tree_trees_controller.rb
@@ -124,7 +124,10 @@ class TreeTreesController < ApplicationController
       flash[:alert] = "Errors prevented the connection from being saved: #{errors.to_s}"
       redirect_to sequence_trees_path
     else
-      flash[:notice] = "Created #{tree_tree_params[:relationship]} relationship."
+      flash[:notice] = "Created relationship: \
+      #{@referencer.subject.code}.#{@referencer.code} \
+      #{translate('trees.labels.relation_types.' + tree_tree_params[:relationship]) } \
+      #{@referencee.subject.code}.#{@referencee.code}."
       redirect_to sequence_trees_path
     end
   end

--- a/app/controllers/tree_trees_controller.rb
+++ b/app/controllers/tree_trees_controller.rb
@@ -1,5 +1,6 @@
 class TreeTreesController < ApplicationController
   # Controller for the LO connections
+  before_action :authenticate_user!
 
   def new
     errors = []

--- a/app/controllers/tree_trees_controller.rb
+++ b/app/controllers/tree_trees_controller.rb
@@ -2,97 +2,122 @@ class TreeTreesController < ApplicationController
   # Controller for the LO connections
 
   def new
-    @tree_tree = TreeTree.new(tree_tree_params)
-    @referencer = Tree.find(tree_tree_params[:tree_referencer_id])
-    Rails.logger.debug('tree_referencer:'+ @referencer.code)
-    @referencee = Tree.find(tree_tree_params[:tree_referencee_id])
-    Rails.logger.debug('tree_referencee:'+ @referencee.code)
-    @explanation = ''
-    puts "referencer subject key: #{@referencer.subject[:base_key] + '.abbr'}, locale: #{@locale_code}"
-    referencer_subject_translation = Translation.where(
-      :key => @referencer.subject[:base_key] + '.name',
-      :locale => @locale_code
-      ).first.value
-    referencee_subject_translation = Translation.where(
-      :key => @referencee.subject[:base_key] + '.name',
-      :locale => @locale_code
-      ).first.value
-    respond_to do |format|
-      format.json {render json: { 
-        :tree_tree => @tree_tree,
-        :referencer_code => referencer_subject_translation + " " + @referencer.code,
-        :referencee_code => referencee_subject_translation + " " + @referencee.code,
-        :translations => {
-          :modal_title => translate('trees.labels.outcome_connections'),
-          :explanation => translate('tree_trees.labels.explanation'),
-          :relationship => I18n.translate('trees.labels.relation'),
-          :akin => I18n.translate('trees.labels.relation_types.akin'),
-          :applies => I18n.translate('trees.labels.relation_types.applies'),
-          :depends => I18n.translate('trees.labels.relation_types.depends')
-        },
-        :relation_values => {
-          :applies => TreeTree::APPLIES_KEY,
-          :akin => TreeTree::AKIN_KEY,
-          :depends => TreeTree::DEPENDS_KEY
-        }
-      } 
-    }
+    errors = []
+    if TreeTree.where(
+      :tree_referencer_id => tree_tree_params[:tree_referencer_id], 
+      :tree_referencee_id => tree_tree_params[:tree_referencee_id]).length > 0
+      errors << "Relationship already exits."
+    end
+    if errors.length == 0 && TreeTree.where(
+      :tree_referencee_id => tree_tree_params[:tree_referencer_id], 
+      :tree_referencer_id => tree_tree_params[:tree_referencee_id]).length > 0
+      errors << "Relationship already exits."
+    end
+    if errors.length == 0
+      @tree_tree = TreeTree.new(tree_tree_params)
+      @referencer = Tree.find(tree_tree_params[:tree_referencer_id])
+      Rails.logger.debug('tree_referencer:'+ @referencer.code)
+      @referencee = Tree.find(tree_tree_params[:tree_referencee_id])
+      Rails.logger.debug('tree_referencee:'+ @referencee.code)
+      @explanation = ''
+      puts "referencer subject key: #{@referencer.subject[:base_key] + '.abbr'}, locale: #{@locale_code}"
+      referencer_subject_translation = Translation.where(
+        :key => @referencer.subject[:base_key] + '.name',
+        :locale => @locale_code
+        ).first.value
+      referencee_subject_translation = Translation.where(
+        :key => @referencee.subject[:base_key] + '.name',
+        :locale => @locale_code
+        ).first.value
+    end
+    if errors.length == 0
+      respond_to do |format|
+        format.json {render json: { 
+          :tree_tree => @tree_tree,
+          :referencer_code => referencer_subject_translation + " " + @referencer.code,
+          :referencee_code => referencee_subject_translation + " " + @referencee.code,
+          :translations => {
+            :modal_title => translate('trees.labels.outcome_connections'),
+            :explanation => translate('tree_trees.labels.explanation'),
+            :relationship => I18n.translate('trees.labels.relation'),
+            :akin => I18n.translate('trees.labels.relation_types.akin'),
+            :applies => I18n.translate('trees.labels.relation_types.applies'),
+            :depends => I18n.translate('trees.labels.relation_types.depends')
+          },
+          :relation_values => {
+            :applies => TreeTree::APPLIES_KEY,
+            :akin => TreeTree::AKIN_KEY,
+            :depends => TreeTree::DEPENDS_KEY
+          }
+        }}
+      end
+    else
+      respond_to do |format|
+        format.json {render json: { errors: errors}}
+      end
     end
   end
  
 
   def create
-    @referencer = Tree.find(tree_tree_params[:tree_referencer_id])
-    Rails.logger.debug('tree_referencer:'+ @referencer.code)
-    @referencee = Tree.find(tree_tree_params[:tree_referencee_id])
-    Rails.logger.debug('tree_referencee:'+ @referencee.code)
-    @explanation = tree_tree_params[:explanation]
-    explanation_key = @treeTypeRec.code + "." + @versionRec.code + "." + @referencer.subject.code + "." + @referencer.code + ".tree." + @referencee.id.to_s
-    @tree_tree = TreeTree.new(
-      :tree_referencer_id => tree_tree_params[:tree_referencer_id], 
-      :tree_referencee_id => tree_tree_params[:tree_referencee_id],
-      :relationship => tree_tree_params[:relationship],
-      :explanation_key => explanation_key
-      )
-     
-     #reciprocal_explanation_key = @treeTypeRec.code + "." + @versionRec.code + "." + @referencee.subject.code + "." + @referencee.code + ".tree." + @referencer.id.to_s
-    @reciprocal_tree_tree = TreeTree.new(
-      :tree_referencer_id => tree_tree_params[:tree_referencee_id], 
-      :tree_referencee_id => tree_tree_params[:tree_referencer_id],
-      :relationship => @tree_tree.reciprocal_relationship(:"#{tree_tree_params[:relationship]}"),
-      :explanation_key => explanation_key
-      )
-
-    @explanation_translation = Translation.where(:locale => @locale_code, 
-      :key => explanation_key)
-    # @reciprocal_explanation_translation = Translation.where(:locale => @locale_code, 
-    #   :key => reciprocal_explanation_key)
-
-    if @explanation_translation.empty?
-      @explanation_translation = Translation.new(
-          :key => explanation_key,
-          :locale => @locale_code,
-          :value => tree_tree_params[:explanation]
-        )
-    else
-      @explanation_translation = @explanation_translation.first
-    end
-
-    puts "TreeTree: #{@tree_tree.inspect} \
-          TreeTree, Recip: #{@reciprocal_tree_tree.inspect} \
-          Translation: #{@explanation_translation.inspect}"
-
     errors = []
-    ActiveRecord::Base.transaction do
-       begin
-         @tree_tree.save!
-         @reciprocal_tree_tree.save!
-         @explanation_translation.save!
-       rescue ActiveRecord::StatementInvalid
-         errors << e
-       end
+    if TreeTree.where(
+      :tree_referencer_id => tree_tree_params[:tree_referencer_id], 
+      :tree_referencee_id => tree_tree_params[:tree_referencee_id]).length > 0
+      errors << "Relationship already exits."
     end
+    if errors.length == 0 && TreeTree.where(
+      :tree_referencee_id => tree_tree_params[:tree_referencer_id], 
+      :tree_referencer_id => tree_tree_params[:tree_referencee_id]).length > 0
+      errors << "Relationship already exits."
+    end
+    if errors.length == 0
+      @referencer = Tree.find(tree_tree_params[:tree_referencer_id])
+      Rails.logger.debug('tree_referencer:'+ @referencer.code)
+      @referencee = Tree.find(tree_tree_params[:tree_referencee_id])
+      Rails.logger.debug('tree_referencee:'+ @referencee.code)
+      @explanation = tree_tree_params[:explanation]
+      explanation_key = @treeTypeRec.code + "." + @versionRec.code + "." + @referencer.subject.code + "." + @referencer.code + ".tree." + @referencee.id.to_s
+      @tree_tree = TreeTree.new(
+        :tree_referencer_id => tree_tree_params[:tree_referencer_id], 
+        :tree_referencee_id => tree_tree_params[:tree_referencee_id],
+        :relationship => tree_tree_params[:relationship],
+        :explanation_key => explanation_key
+        )
+       
+       #reciprocal_explanation_key = @treeTypeRec.code + "." + @versionRec.code + "." + @referencee.subject.code + "." + @referencee.code + ".tree." + @referencer.id.to_s
+      @reciprocal_tree_tree = TreeTree.new(
+        :tree_referencer_id => tree_tree_params[:tree_referencee_id], 
+        :tree_referencee_id => tree_tree_params[:tree_referencer_id],
+        :relationship => @tree_tree.reciprocal_relationship(:"#{tree_tree_params[:relationship]}"),
+        :explanation_key => explanation_key
+        )
 
+      @explanation_translation = Translation.where(:locale => @locale_code, 
+        :key => explanation_key)
+      # @reciprocal_explanation_translation = Translation.where(:locale => @locale_code, 
+      #   :key => reciprocal_explanation_key)
+
+      if @explanation_translation.empty?
+        @explanation_translation = Translation.new(
+            :key => explanation_key,
+            :locale => @locale_code,
+            :value => tree_tree_params[:explanation]
+          )
+      else
+        @explanation_translation = @explanation_translation.first
+      end
+
+      ActiveRecord::Base.transaction do
+         begin
+           @tree_tree.save!
+           @reciprocal_tree_tree.save!
+           @explanation_translation.save!
+         rescue ActiveRecord::StatementInvalid
+           errors << e
+         end
+      end
+    end
     if errors.length > 0
       flash[:alert] = "Errors prevented the connection from being saved: #{errors.to_s}"
       redirect_to sequence_trees_path
@@ -112,41 +137,6 @@ class TreeTreesController < ApplicationController
       :relationship,
       :explanation
     )
-  end
-
-  def getNamesForSector(sector)
-    # To Do: filter out subjects and grades not diaplayed
-    name_keys = [sector.name_key]
-    sector.sector_trees.each do |st|
-      name_keys << st.explanation_key
-      name_keys << st.tree.name_key
-    end
-    return name_keys
-  end
-
-  def getTranslationsForKeys(keys)
-    translations = {}
-    translationRecs = Translation.where(locale: @locale_code, key: keys)
-    translationRecs.each do |t|
-      translations[t.key] = t.value
-    end
-    return translations
-  end
-
-
-  def outputRowsForSector(sector, translations)
-    rptRows = []
-    rptRows << [sector.code, '', translations[sector.name_key], '-1', '']
-    # filter out records when pulling from the join
-    # To Do: put grade band and subject into sector_trees join record to efficiently filter out selected grade or subject
-    sector.sector_trees.each do |st|
-      if @grade_band_id.present? && st.tree.grade_band_id.to_s != @grade_band_id
-      elsif @subject_id.present? && st.tree.subject_id.to_s != @subject_id
-      else
-        rptRows << [ '', st.tree.codeByLocale(@locale_code), translations[st.tree.name_key], st.tree.id.to_s, translations[st.explanation_key] ]
-      end
-    end
-    return  rptRows
   end
 
 

--- a/app/controllers/tree_trees_controller.rb
+++ b/app/controllers/tree_trees_controller.rb
@@ -107,6 +107,7 @@ class TreeTreesController < ApplicationController
           )
       else
         @explanation_translation = @explanation_translation.first
+        @explanation_translation.value = tree_tree_params[:explanation]
       end
 
       ActiveRecord::Base.transaction do
@@ -123,7 +124,7 @@ class TreeTreesController < ApplicationController
       flash[:alert] = "Errors prevented the connection from being saved: #{errors.to_s}"
       redirect_to sequence_trees_path
     else
-      flash[:success] = "Created #{tree_tree_params[:relationship]} relationship."
+      flash[:notice] = "Created #{tree_tree_params[:relationship]} relationship."
       redirect_to sequence_trees_path
     end
   end

--- a/app/controllers/trees_controller.rb
+++ b/app/controllers/trees_controller.rb
@@ -1,7 +1,8 @@
 class TreesController < ApplicationController
 
   before_action :find_tree, only: [:show, :show_outcome, :edit, :update]
-
+  before_action :authenticate_user!, only: [:reorder]
+  
   def index
     index_listing
   end

--- a/app/controllers/trees_controller.rb
+++ b/app/controllers/trees_controller.rb
@@ -258,22 +258,6 @@ class TreesController < ApplicationController
       version_id: @versionRec.id
     )
 
-    # Translations table no longer belonging to I18n Active record gem.
-    # note: Active Record had problems with placeholder conditions in join clause.
-    # Consider having Translations belong_to trees and sectors.
-    # Current solution: get translation from hash of pre-cached translations.
-    base_keys= @trees.map { |t| "#{t.base_key}.name" }
-    base_keys =  base_keys | subjects.map { |s| "#{s.base_key}.name" }
-    base_keys = base_keys | subjects.map { |s| "#{s.base_key}.abbr" }
-    puts "++++++++BaseKEYS: #{base_keys[base_keys.length - 1 ]}"
-    puts
-    @translations = Hash.new
-    translations = Translation.where(locale: @locale_code, key: base_keys)
-    translations.each do |t|
-      # puts "t.key: #{t.key.inspect}, t.value: #{t.value.inspect}"
-      @translations[t.key] = t.value
-    end
-
     treeHash = {}
     areaHash = {}
     componentHash = {}
@@ -284,6 +268,23 @@ class TreesController < ApplicationController
     relations.each do |rel|
       @relations[rel.tree_referencer_id] << rel
     end
+
+    # Translations table no longer belonging to I18n Active record gem.
+    # note: Active Record had problems with placeholder conditions in join clause.
+    # Consider having Translations belong_to trees and sectors.
+    # Current solution: get translation from hash of pre-cached translations.
+    base_keys= @trees.map { |t| "#{t.base_key}.name" }
+    base_keys =  base_keys | subjects.map { |s| "#{s.base_key}.name" }
+    base_keys = base_keys | subjects.map { |s| "#{s.base_key}.abbr" }
+    base_keys = base_keys | relations.map { |r| r.explanation_key }
+
+    @translations = Hash.new
+    translations = Translation.where(locale: @locale_code, key: base_keys)
+    translations.each do |t|
+      # puts "t.key: #{t.key.inspect}, t.value: #{t.value.inspect}"
+      @translations[t.key] = t.value
+    end
+
     # create ruby hash from tree records, to easily build tree from record codes
     @trees.each do |tree|
       translation = @translations[tree.name_key]

--- a/app/models/tree_tree.rb
+++ b/app/models/tree_tree.rb
@@ -5,10 +5,6 @@ class TreeTree < BaseRec
   AKIN_KEY = 'akin'
   APPLIES_KEY = 'applies'
   DEPENDS_KEY = 'depends'
-  recip_lookup = Hash.new 
-  recip_lookup[AKIN_KEY] = AKIN_KEY
-  recip_lookup[APPLIES_KEY] = DEPENDS_KEY
-  recip_lookup[DEPENDS_KEY] = APPLIES_KEY
 
   def reciprocal_relationship(relation)
   	lookup = {

--- a/app/views/trees/sequence.html.erb
+++ b/app/views/trees/sequence.html.erb
@@ -30,7 +30,8 @@
                   <div class="hide-unless-condition"><strong><%= translate('trees.labels.relation_types.' + c.relationship) %></strong> <% 
                   ref = c.tree_referencee.subject.code + '.' + c.tree_referencee[:code]
                   %>
-                  <a href="<%= tree_path(c.tree_referencee_id)%>"><%= ref %></a>
+                  <a href="<%= tree_path(c.tree_referencee_id)%>" 
+                    title= "<%= @translations[c.explanation_key] %>"><%= ref %></a>
                   </div>
                 <% end %>
               </div>

--- a/app/views/trees/sequence.html.erb
+++ b/app/views/trees/sequence.html.erb
@@ -40,8 +40,10 @@
             <% else %>
             <div class="pull-right">
             <% end %>
-            <a class="connect-handle lo-handle" onclick=""><i class="fa fa-link pull-right" title="make a connection between this LO and another"></i></a>
-            <a class="sort-handle lo-handle" onclick=""><i class="fa fa-thumb-tack pull-right" title="resequence this LO within its subject"></i></a>
+              <% if current_user.present? && current_user.is_admin? %>
+                <a class="connect-handle lo-handle" onclick=""><i class="fa fa-link pull-right" title="make a connection between this LO and another"></i></a>
+                <a class="sort-handle lo-handle" onclick=""><i class="fa fa-thumb-tack pull-right" title="resequence this LO within its subject"></i></a>
+              <% end %>
             </div>
           </li>
         <% end %>


### PR DESCRIPTION
resolves #17 

For each LO connection submitted from the Sequencing page:

- Save two TreeTree records. With the connection and the reciprocal relationship, respectively (e.g., if the connection submitted is "bio.9.1.1.1 depends on che.9.1.1.1," create one TreeTree with the "depends" relationship, and also create a TreeTree for the "applies" relationship-- "che.9.1.1.1 applies to bio.9.1.1.1" ). 

- The new, reciprocal TreeTrees have identical values for "explanation_key". 

- Save one new translation with "value" set to the explanation param from the request, "locale" set to the users locale_code at the moment of the request, and "key" set to the explanation_key shared by the new TreeTree records.

- Use the explanation for the LO connections as tooltips on the Sequence page (e.g., when hovering cursor over the link in "Akin to: Bio.9.1.1.1," the explanation for that relationship should become visible)

Handle the following situations:
-Only allow logged-in users to reorder and connect LOs (and only display icons for reordering and creating connections if the user is logged in).
-For now, do not allow duplicate connections between LOs to be created, and show an error message if the user attempts to create one.