### PR TITLE
Edit deactivate connections

### DIFF
--- a/app/assets/javascripts/sequence.js
+++ b/app/assets/javascripts/sequence.js
@@ -53,6 +53,51 @@ $(function() {
   }
 });
 
+add_edit_form = function(res) {
+  edit_mode = res.tree_tree.id != null
+  return '<div class="modal-header"> \
+          <h3 id="myModalLabel"> LO '+  res.translations.relationship +'</h3> \
+          </div> \
+          <div class="modal-body"> \
+          <form action="/tree_trees" method="'
+          + (edit_mode ? 'PATCH' : 'POST') + '"> \
+          <div> \
+          <input type="hidden" name="authenticity_token" value="' + $('[name="csrf-token"]').attr('content') + '"> \
+          <input type="hidden" name="tree_tree[tree_referencer_id]" value=' + res.tree_tree.tree_referencer_id +'> \
+          <input type="hidden" name="tree_tree[tree_referencee_id]" value=' + res.tree_tree.tree_referencee_id + '> \
+          </div> \
+          <fieldset> \
+          <label for="relationship">' + res.translations.relationship + '</label><br>'
+          + res.referencer_code + '<br> \
+          <select id="relationship" name="tree_tree[relationship]"> \
+          <option value="' + res.relation_values.applies 
+          + (res.tree_tree.relationship == 'applies' ? '" selected>': '">')
+          + res.translations.applies 
+          + '</option> \
+          <option value="' + res.relation_values.depends 
+          + (res.tree_tree.relationship == 'depends' ? '" selected>': '">')
+          + res.translations.depends 
+          + '</option> \
+          <option value="' + res.relation_values.akin 
+          + (res.tree_tree.relationship == 'akin' ? '" selected>': '">')
+          + res.translations.akin 
+          + '</option> \
+          </select> \
+          <div>' + res.referencee_code + '</div><br> \
+          </fieldset> \
+          <fieldset> \
+            <label for="explanation">' + res.translations.explanation_label + '<br> \
+            <textarea type="text" name="tree_tree[explanation]">'
+            + (res.translations.explanation != undefined ? res.translations.explanation : '')
+            +'</textarea> \
+          </fieldset> \
+          <button type="submit" >SAVE</button>\
+          <button type="button" type="button" data-dismiss="modal" \
+          aria-hidden="true">CANCEL</button> \
+          </div> \
+          </form>' 
+}
+
 initializeSortAndDrag = function () {
    $('.list-group').sortable({
     placeholder: 'drop-placeholder',
@@ -123,7 +168,7 @@ initializeSortAndDrag = function () {
           "async": false
         })
         .then(function (res) { 
-          console.log("RESPONSE:", res) 
+          console.log("RESPONSE:", res.tree_tree.id) 
           html = '';
           if (res.errors)
            html = '<div class="modal-header"><h3>ERROR:</h3></div> \
@@ -166,7 +211,7 @@ initializeSortAndDrag = function () {
                     aria-hidden="true">CANCEL</button> \
                     </div> \
                     </form>' 
-          $("#modal-container").html(html)
+          $("#modal-container").html(add_edit_form(res))
         })
         .catch(function (err) { console.log("ERROR:", err) })
 

--- a/app/assets/javascripts/sequence.js
+++ b/app/assets/javascripts/sequence.js
@@ -24,30 +24,32 @@ $(function() {
   /**
    * Expand and highlight related LOs 
    */
-
-  related_LO_display = function (rel) {
-    if ($("#lo_" + rel[rel.length - 1]).hasClass('highlight')) {
+  related_LO_display = function (rel, selected_LO) {
+    if ($("#lo_" + selected_LO).hasClass('spotlight')) {
 	  	$('.sequence-item--collapsable')
-	  	  .removeClass('collapsed highlight show-connections-condition');
+	  	  .removeClass('collapsed spotlight spotlight-depends spotlight-akin spotlight-applies show-connections-condition');
 	  	for (var r in rel) {
-	  		$('li[data-lo-id='+rel[r]+']')
+	  		$('li[data-lo-id='+rel[r][1]+']')
 	  		 .find('.connections-icon')
-	  		 .attr('title', 'highlight related LOs');
+	  		 .attr('title', 'show related LOs');
 	  	}
     }
     else {
       $('.sequence-item--collapsable')
   	  .addClass('collapsed')
-  	  .removeClass('highlight show-connections-condition');
+  	  .removeClass('spotlight spotlight-depends spotlight-akin spotlight-applies show-connections-condition');
 	  	for (var r in rel) {
-	  	  console.log('highlight ', rel[r])
-	  	  $("#lo_" + rel[r])
+	  	  console.log('spotlight ', rel[r][1])
+	  	  $("#lo_" + rel[r][1])
 	  		.removeClass('collapsed')
-	  		.addClass('highlight show-connections-condition');
-	       $("#lo_" + rel[r])
-	  		 .find('.connections-icon')
-	  		 .attr('title', 'exit highlight mode');
+	  		.addClass('spotlight-' + rel[r][0] + ' show-connections-condition');
 	  	}
+      $("#lo_" + selected_LO)
+        .removeClass('collapsed')
+        .addClass('spotlight show-connections-condition');
+      $("#lo_" + selected_LO)
+         .find('.connections-icon')
+         .attr('title', 'exit related LOs mode');
     }
  
   }

--- a/app/assets/javascripts/sequence.js
+++ b/app/assets/javascripts/sequence.js
@@ -178,6 +178,20 @@ add_edit_form = function (res) {
           </form>' 
 }
 
+edit_tree_tree = function (tree_tree_id) {
+  $("#modal_popup").modal('show');
+        $.ajax({
+          "type": 'get', 
+          "url": '/tree_trees/'+ tree_tree_id + '/edit/',
+          "async": false
+        })
+        .then(function (res) { 
+          console.log("RESPONSE:", res.tree_tree.id) 
+          $("#modal-container").html(add_edit_form(res))
+        })
+        .catch(function (err) { console.log("ERROR:", err) })
+}
+
 initializeSortAndDrag = function () {
    $('.list-group').sortable({
     placeholder: 'drop-placeholder',

--- a/app/assets/javascripts/sequence.js
+++ b/app/assets/javascripts/sequence.js
@@ -124,12 +124,14 @@ initializeSortAndDrag = function () {
         })
         .then(function (res) { 
           console.log("RESPONSE:", res) 
-          html = res.errors ? 
-                  '<div class="modal-header"><h3>ERROR:</h3></div> \
+          html = '';
+          if (res.errors)
+           html = '<div class="modal-header"><h3>ERROR:</h3></div> \
                   <div class="modal-body">' + res.errors +
                   '<br><button type="button" type="button" data-dismiss="modal" \
-                  aria-hidden="true">CLOSE</button></div>' :
-                  '<div class="modal-header"> \
+                  aria-hidden="true">CLOSE</button></div>'
+          else
+            html = '<div class="modal-header"> \
                   <h3 id="myModalLabel"> LO '+  res.translations.relationship +'</h3> \
                   </div> \
                   <div class="modal-body"> \

--- a/app/assets/javascripts/sequence.js
+++ b/app/assets/javascripts/sequence.js
@@ -53,6 +53,20 @@ $(function() {
     }
  
   }
+
+  showIndicators = function (show) {
+    if (show) {
+      $(".indicators-container").removeClass("hidden")
+      $("#show-indicators").attr("hidden", true)
+      $("#hide-indicators").attr("hidden", false)
+    }
+    else {
+      $(".indicators-container").addClass("hidden")
+      $("#show-indicators").attr("hidden", false)
+      $("#hide-indicators").attr("hidden", true)
+    }
+  }
+
 });
 
 /**

--- a/app/assets/javascripts/sequence.js
+++ b/app/assets/javascripts/sequence.js
@@ -53,15 +53,44 @@ $(function() {
   }
 });
 
-add_edit_form = function(res) {
+patch_from_tree_tree_form = function (tree_tree_id) {
+  token = $("meta[name='csrf-token']").attr('content');
+  explanation = $('form#tree_tree_add_edit [name="tree_tree[explanation]"]').val();
+  relationship = $('form#tree_tree_add_edit #relationship').children("option:selected").val();
+  $.ajax({
+        "type": 'patch', 
+        "url": '/tree_trees/' + tree_tree_id, 
+        "headers": { 'X-CSRF-Token': token },
+        "data": {
+          "source_controller": "tree_trees",
+          "source_action": "update",
+          "tree_tree[explanation]" : explanation,
+          "tree_tree[relationship]" : relationship
+        },
+        "dataType": "json",
+        "async": false
+      })
+      .then(function () { location.reload() })
+      .catch(function (err) { console.log("ERROR:", err) })
+}
+
+add_edit_form = function (res) {
   edit_mode = res.tree_tree.id != null
+  if (edit_mode) {
+    submit_button = '<button type="button" \
+        onclick="patch_from_tree_tree_form('
+        + res.tree_tree.id
+        +')">SAVE</button>'
+  }
+  else {
+    submit_button = '<button type="submit">SAVE</button>'
+  }
   return '<div class="modal-header"> \
           <h3 id="myModalLabel"> LO '+  res.translations.relationship +'</h3> \
           </div> \
           <div class="modal-body"> \
-          <form action="/tree_trees" method="'
-          + (edit_mode ? 'PATCH' : 'POST') + '"> \
-          <div> \
+          <form id="tree_tree_add_edit" action="/tree_trees"' + (edit_mode ? '>' : 'method="POST">') 
+          + '<div> \
           <input type="hidden" name="authenticity_token" value="' + $('[name="csrf-token"]').attr('content') + '"> \
           <input type="hidden" name="tree_tree[tree_referencer_id]" value=' + res.tree_tree.tree_referencer_id +'> \
           <input type="hidden" name="tree_tree[tree_referencee_id]" value=' + res.tree_tree.tree_referencee_id + '> \
@@ -90,9 +119,9 @@ add_edit_form = function(res) {
             <textarea type="text" name="tree_tree[explanation]">'
             + (res.translations.explanation != undefined ? res.translations.explanation : '')
             +'</textarea> \
-          </fieldset> \
-          <button type="submit" >SAVE</button>\
-          <button type="button" type="button" data-dismiss="modal" \
+          </fieldset>'
+          + submit_button 
+          + '<button type="button" type="button" data-dismiss="modal" \
           aria-hidden="true">CANCEL</button> \
           </div> \
           </form>' 
@@ -169,48 +198,6 @@ initializeSortAndDrag = function () {
         })
         .then(function (res) { 
           console.log("RESPONSE:", res.tree_tree.id) 
-          html = '';
-          if (res.errors)
-           html = '<div class="modal-header"><h3>ERROR:</h3></div> \
-                  <div class="modal-body">' + res.errors +
-                  '<br><button type="button" type="button" data-dismiss="modal" \
-                  aria-hidden="true">CLOSE</button></div>'
-          else
-            html = '<div class="modal-header"> \
-                  <h3 id="myModalLabel"> LO '+  res.translations.relationship +'</h3> \
-                  </div> \
-                  <div class="modal-body"> \
-                    <form action="/tree_trees" method="POST"> \
-                    <div> \
-                      <input type="hidden" name="authenticity_token" value="' + $('[name="csrf-token"]').attr('content') + '"> \
-                      <input type="hidden" name="tree_tree[tree_referencer_id]" value=' + res.tree_tree.tree_referencer_id +'> \
-                      <input type="hidden" name="tree_tree[tree_referencee_id]" value=' + res.tree_tree.tree_referencee_id + '> \
-                    </div> \
-                    <fieldset> \
-                    <label for="relationship">' + res.translations.relationship + '</label><br>'
-                    + res.referencer_code + '<br> \
-                    <select id="relationship" name="tree_tree[relationship]"> \
-                    <option value="' + res.relation_values.applies + '">'
-                    + res.translations.applies 
-                    + '</option> \
-                    <option value="' + res.relation_values.depends + '">'
-                    + res.translations.depends 
-                    + '</option> \
-                    <option value="' + res.relation_values.akin + '">'
-                    + res.translations.akin 
-                    + '</option> \
-                    </select> \
-                    <div>' + res.referencee_code + '</div><br> \
-                    </fieldset> \
-                    <fieldset> \
-                      <label for="explanation">' + res.translations.explanation + '<br> \
-                      <textarea type="text" name="tree_tree[explanation]"></textarea> \
-                    </fieldset> \
-                    <button type="submit" >SAVE</button>\
-                    <button type="button" type="button" data-dismiss="modal" \
-                    aria-hidden="true">CANCEL</button> \
-                    </div> \
-                    </form>' 
           $("#modal-container").html(add_edit_form(res))
         })
         .catch(function (err) { console.log("ERROR:", err) })

--- a/app/assets/stylesheets/trees.scss
+++ b/app/assets/stylesheets/trees.scss
@@ -127,11 +127,11 @@
       .icon-link:hover {
         color: blue;
       }
-      .highlight .icon-link {
-        color: brown;
+      .spotlight .connections-icon {
+        color: blue;
       }
-      .highlight .icon-link:hover {
-        color: yellow;
+      .spotlight .connections-icon:hover {
+        color: brown;
       }
       .lo-handle {
         cursor: pointer;
@@ -152,8 +152,28 @@
       white-space: nowrap;
     }
 
-    .highlight {
-      background: lightblue;
+    .spotlight {
+      border-color: blue;
+      outline: 3px solid blue;
+      z-index: 100;
+    }
+    .spotlight-akin {
+      background: #eeeefe;
+    }
+    .spotlight-applies {
+      background: lightyellow;
+    }
+    .spotlight-depends {
+      background: orange;
+      a {
+        color: purple;
+        i {
+          color: black;
+        }
+        i:hover {
+          color: blue;
+        }
+      }
     }
 
     .ui-draggable-helper {

--- a/app/assets/stylesheets/trees.scss
+++ b/app/assets/stylesheets/trees.scss
@@ -45,6 +45,10 @@
 
   .sequence-page {
 
+    .negative-margin-left {
+      margin-left: -.9em;
+    }
+
     .drop-placeholder {
       background-color: lightgray;
       height: 3.5em;
@@ -116,14 +120,9 @@
       border-bottom: 1px solid black;
       a {
         width: 100%;
-        padding: 0 5px;
       }
       .icon-link {
         color: black;
-        i { 
-
-          margin: 0 5px;  
-        }
       }
       .icon-link:hover {
         color: blue;

--- a/app/assets/stylesheets/trees.scss
+++ b/app/assets/stylesheets/trees.scss
@@ -166,7 +166,7 @@
     .spotlight-depends {
       background: orange;
       a {
-        color: purple;
+        color: darkblue;
         i {
           color: black;
         }

--- a/app/assets/stylesheets/trees.scss
+++ b/app/assets/stylesheets/trees.scss
@@ -44,7 +44,9 @@
   }
 
   .sequence-page {
-
+    .block {
+      display: block;
+    }
     .negative-margin-left {
       margin-left: -.9em;
     }
@@ -151,10 +153,16 @@
       max-width: 72%;
       white-space: nowrap;
     }
-
+    .relationship-color-key {
+      width: 1em;
+      height: 1em;
+      margin: 0 2px;
+      display: inline-block;
+      border: 1px solid black;
+    }
     .spotlight {
-      border-color: blue;
-      outline: 3px solid blue;
+      border-color: black;
+      outline: 3px solid black;
       z-index: 100;
     }
     .spotlight-akin {

--- a/app/controllers/tree_trees_controller.rb
+++ b/app/controllers/tree_trees_controller.rb
@@ -175,8 +175,13 @@ class TreeTreesController < ApplicationController
     puts "params: #{params}"
     errors = []
     notices = []
-    if @tree_tree.active != tree_tree_params[:active]
-      notices << (tree_tree_params[:active] == 'true' ? "Activated" : "Deactivated")
+    if @tree_tree.active.to_s != tree_tree_params[:active] 
+      n = (tree_tree_params[:active] == 'true' ? "Activated" : "Deactivated") 
+      n += " " + @tree_tree.tree_referencer.subject.code + "." + 
+      @tree_tree.tree_referencer.code + " to " + 
+      @tree_tree.tree_referencee.subject.code + "." + 
+      @tree_tree.tree_referencee.code + " connection."
+      notices << n
     end  
     #TreeTree records should be created with an explanation_key, but since this 
     #column is not currently reqired, if @tree_tree is lacking an explanation_key for 
@@ -253,7 +258,7 @@ class TreeTreesController < ApplicationController
       notices << "Updated relationship: \
       #{@tree_tree.tree_referencer.subject.code}.#{@tree_tree.tree_referencer.code} \
       #{translate('trees.labels.relation_types.' + tree_tree_params[:relationship]) } \
-      #{@tree_tree.tree_referencee.subject.code}.#{@tree_tree.tree_referencee.code}."
+      #{@tree_tree.tree_referencee.subject.code}.#{@tree_tree.tree_referencee.code}." if tree_tree_params[:relationship]
       flash[:notice] = notices.to_s
     end
     respond_to do |format|

--- a/app/controllers/tree_trees_controller.rb
+++ b/app/controllers/tree_trees_controller.rb
@@ -90,7 +90,7 @@ class TreeTreesController < ApplicationController
       @reciprocal_tree_tree = TreeTree.new(
         :tree_referencer_id => tree_tree_params[:tree_referencee_id], 
         :tree_referencee_id => tree_tree_params[:tree_referencer_id],
-        :relationship => @tree_tree.reciprocal_relationship(:"#{tree_tree_params[:relationship]}"),
+        :relationship => TreeTree.reciprocal_relationship(:"#{tree_tree_params[:relationship]}"),
         :explanation_key => explanation_key
         )
 

--- a/app/controllers/trees_controller.rb
+++ b/app/controllers/trees_controller.rb
@@ -265,7 +265,7 @@ class TreesController < ApplicationController
     newHash = {}
 
     @relations = Hash.new { |h, k| h[k] = [] }
-    relations = TreeTree.all
+    relations = TreeTree.active
     relations.each do |rel|
       @relations[rel.tree_referencer_id] << rel
     end

--- a/app/controllers/trees_controller.rb
+++ b/app/controllers/trees_controller.rb
@@ -240,6 +240,7 @@ class TreesController < ApplicationController
     index_prep
 
     @s_o_hash = Hash.new  { |h, k| h[k] = [] }
+    @indicator_hash = Hash.new { |h, k| h[k] = [] }
     @subjects = {}
     subjIds = {}
     subjects = Subject.all
@@ -319,11 +320,12 @@ class TreesController < ApplicationController
       #   addNodeToArrHash(treeHash[tree.codeArrayAt(0)][:nodes][tree.codeArrayAt(1)], tree.subCode, newHash)
 
       when 4
+        tcode = tree.subject.code + tree.code.split('.').join('')
         newHash = {
+          code: tcode,
           text: "#{tree.code}: #{translation}", 
           id: "#{tree.id}",
-          connections: @relations[tree.id], 
-          nodes: {}
+          connections: @relations[tree.id]
         }
         # if treeHash[tree.codeArrayAt(0)].blank?
         #   raise I18n.t('trees.errors.missing_grade_in_tree')
@@ -335,13 +337,17 @@ class TreesController < ApplicationController
         @s_o_hash[tree.subject.code] << newHash
         #addNodeToArrHash(treeHash[tree.codeArrayAt(0)][:nodes][tree.codeArrayAt(1)][:nodes][tree.codeArrayAt(2)], tree.subCode, newHash)
 
-      # when 5
+      when 5
       #   # # to do - look into refactoring this
       #   # # check to make sure parent in hash exists.
       #   # Rails.logger.debug("*** tree index_listing: #{tree.inspect}")
       #   # Rails.logger.debug("*** tree.name_key: #{tree.name_key}")
       #   # Rails.logger.debug("*** Translation for tree.name_key: #{Translation.where(locale: 'en', key: tree.name_key).first.inspect}")
-      #   newHash = {text: "#{I18n.translate('app.labels.indicator')} #{tree.subCode}: #{translation}", id: "#{tree.id}", nodes: {}}
+        newHash = {label: "#{I18n.translate('app.labels.indicator')} #{tree.subCode}:", text: "#{translation}", id: "#{tree.id}"}
+        parent_code = tree.code.split('.')
+        parent_code.pop()
+        parent_code = parent_code.join('')
+        @indicator_hash["#{tree.subject.code}#{parent_code}"] << newHash
       #   # Rails.logger.debug("indicator newhash: #{newHash.inspect}")
       #   if treeHash[tree.codeArrayAt(0)].blank?
       #     raise I18n.t('trees.errors.missing_grade_in_tree')

--- a/app/models/tree_tree.rb
+++ b/app/models/tree_tree.rb
@@ -6,12 +6,14 @@ class TreeTree < BaseRec
   APPLIES_KEY = 'applies'
   DEPENDS_KEY = 'depends'
 
-  def reciprocal_relationship(relation)
+  scope :active, -> { where(:active => true) }
+
+  def self.reciprocal_relationship(relation)
   	lookup = {
-      :akin => 'akin',
-      :applies => 'depends',
-      :depends => 'applies'
+      :"#{AKIN_KEY}" => AKIN_KEY,
+      :"#{APPLIES_KEY}" => DEPENDS_KEY,
+      :"#{DEPENDS_KEY}" => APPLIES_KEY
     }
-    lookup[relation]
+    lookup[relation] || lookup[:"#{relation}"]
   end
 end

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -48,7 +48,7 @@
       </li>
     <%
     end
-    if controller.controller_name == 'trees' %>
+    if controller.controller_name == 'trees' && action_name != 'sequence' %>
       <li class="nav-item active" aria-selected='true'>
         <a class="nav-link btn btn-primary" href=<%= trees_path %>><%= translate('nav_bar.curriculum.name') %></a>
       </li>
@@ -67,8 +67,30 @@
         <a class="nav-link btn btn-primary" href=<%= sectors_path %>><%= translate('nav_bar.sectors.name') %></a>
       </li>
     <%
+    end    
+    if action_name == 'big_ideas' %>
+      <li class="nav-item active" aria-selected='true'>
+        <a class="nav-link btn btn-primary" href="#">
+          <%= translate('nav_bar.big_ideas.name') %></a>
+      </li>
+    <% else %>
+      <li class="nav-item" role='menuitem'>
+        <a class="nav-link btn btn-primary" href="#"><%= translate('nav_bar.big_ideas.name') %></a>
+      </li>
+    <%
     end
-    if controller.controller_name == 'trees' %>
+    if action_name == 'misconceptions' %>
+      <li class="nav-item active" aria-selected='true'>
+        <a class="nav-link btn btn-primary" href="#">
+          <%= translate('nav_bar.misconceptions.name') %></a>
+      </li>
+    <% else %>
+      <li class="nav-item" role='menuitem'>
+        <a class="nav-link btn btn-primary" href="#"><%= translate('nav_bar.misconceptions.name') %></a>
+      </li>
+    <%
+    end
+    if controller.controller_name == 'trees' && action_name == 'sequence' %>
       <li class="nav-item active" aria-selected='true'>
         <a class="nav-link btn btn-primary" href=<%= sequence_trees_path %>><%= translate('trees.sequencing.title') %></a>
       </li>

--- a/app/views/tree_trees/_edit.html.erb
+++ b/app/views/tree_trees/_edit.html.erb
@@ -1,0 +1,56 @@
+<div class="modal-header">
+   <h3 id="myModalLabel">LO Connection</h3>
+ </div>
+ <div class="modal-body">
+
+<%= form_for(@tree_tree) do |f| %>
+  <div>
+  	<input type="hidden" name="tree_tree[tree_referencer_id]" value='<%= @tree_tree.tree_referencer_id %>'>
+  	<input type="hidden" name="tree_tree[tree_referencee_id]" value='<%= @tree_tree.tree_referencee_id %>'>
+  </div>
+
+  <fieldset>
+    <label for='relationship'><%= translate('trees.labels.relation') %></label>
+    <div>
+    <%= @referencer_subject_translation + " " + @referencer.code %>
+    <select id="relationship" name="tree_tree[relationship]">
+      <option value="<%= TreeTree::APPLIES_KEY %>"
+        <% if @tree_tree.relationship == TreeTree::APPLIES_KEY
+          ' selected'
+        end %>>
+      	<%= I18n.translate('trees.labels.relation_types.applies') %>
+      </option>
+      <option value="<%= TreeTree::DEPENDS_KEY %>"
+        <% if @tree_tree.relationship == TreeTree::DEPENDS_KEY
+          ' selected'
+        end %>>
+      	<%= I18n.translate('trees.labels.relation_types.depends') %>
+      </option>
+      <option value="<%= TreeTree::AKIN_KEY %>"
+        <% if @tree_tree.relationship == TreeTree::AKIN_KEY
+          ' selected'
+        end %>>
+      	<%= I18n.translate('trees.labels.relation_types.akin') %>
+      </option>
+    </select>
+    <%= @referencee_subject_translation + " " + @referencee.code %>
+    </div>
+  </fieldset>
+
+  <fieldset>
+    <label for='explanation'><%= translate('app.labels.explanation') %></label>
+    <div>
+    <%= f.text_area :explanation, name: 'tree_tree[explanation]', id: 'explanation', value: @explanation %>
+    </div>
+  </fieldset>
+  <fieldset>
+    <label for="tree_tree[active]">Active?</label>
+      <input name="tree_tree[active]" type="checkbox"
+        <% @tree_tree.active ? ' checked' : '' %>></input>
+  </fieldset>
+ <div class="modal-footer">
+   <button class="btn" data-dismiss="modal" aria-hidden="true">Close</button>
+   <button class="btn btn-primary">Save changes</button>
+ </div>
+
+<% end %>

--- a/app/views/tree_trees/edit.js.erb
+++ b/app/views/tree_trees/edit.js.erb
@@ -1,0 +1,2 @@
+$("#modal-container").html("<%= escape_javascript(render('tree_trees/edit')) %>");
+$("#modal_popup").modal();

--- a/app/views/trees/sequence.html.erb
+++ b/app/views/trees/sequence.html.erb
@@ -28,13 +28,15 @@
               </div>
                 <% k[:connections].each do |c| %>
                   <% if c.active %>
-                    <div class="hide-unless-condition negative-margin-left">
-                      <a class="icon-link lo-handle" title="<%= translate('app.labels.deactivate') %>" onclick="patch_tree_tree_activation(<%= c.id %>, 'false')">
+                    <div class="hide-unless-condition">
+                      <% if current_user.present? && current_user.is_admin? %>
+                      <a class="icon-link lo-handle negative-margin-left" title="<%= translate('app.labels.deactivate') %>" onclick="patch_tree_tree_activation(<%= c.id %>, 'false')">
                         <i class="fa fa-close"></i>
                       </a>
                       <a class="icon-link lo-handle" title="<%= translate('app.labels.edit') %>" onclick="edit_tree_tree(<%= c.id %>, 'false')">
                         <i class="fa fa-pencil"></i>
                       </a>
+                      <% end %>
                       <strong><%= translate('trees.labels.relation_types.' + c.relationship) %></strong> 
                       <% ref = c.tree_referencee.subject.code + '.' + c.tree_referencee[:code] %>
                       <a href="<%= tree_path(c.tree_referencee_id)%>" 

--- a/app/views/trees/sequence.html.erb
+++ b/app/views/trees/sequence.html.erb
@@ -4,6 +4,10 @@
 <br>
 <div class='text-center sequence-page'>
   <h2 id="sequencing-header"><%= translate('trees.sequencing.title') %></h2>
+  <div> 
+    <button id="show-indicators" class="btn-info" onclick="showIndicators(true);">Show Indicators</button>
+    <button id="hide-indicators" class="btn-info" onclick="showIndicators(false);" aria-hidden="true" hidden>Show Indicators</button>
+  </div> 
   <% @s_o_hash.keys.each do |i| %>
     <div class='subj-checkbox'>
       <label for="check-<%= i %>">      
@@ -46,7 +50,7 @@
                 <% end %>
               </div>
               <div class="pull-right">
-               <a class="icon-link hide-if-collapsed lo-handle" onclick="related_LO_display(<%= k[:connections].pluck(:tree_referencee_id) << k[:id] %> );"><i class="fa fa-plug connections-icon pull-right" title="highlight connected LOs"></i></a>
+               <a class="icon-link hide-if-collapsed lo-handle" onclick="related_LO_display(<%= k[:connections].map { | lo | [ lo[:relationship], lo[:tree_referencee_id]] } %>, <%= k[:id] %> );"><i class="fa fa-plug connections-icon pull-right" title="highlight connected LOs"></i></a>
             <% else %>
             <div class="pull-right">
             <% end %>

--- a/app/views/trees/sequence.html.erb
+++ b/app/views/trees/sequence.html.erb
@@ -6,7 +6,7 @@
   <h2 id="sequencing-header"><%= translate('trees.sequencing.title') %></h2>
   <div> 
     <button id="show-indicators" class="btn-info" onclick="showIndicators(true);">Show Indicators</button>
-    <button id="hide-indicators" class="btn-info" onclick="showIndicators(false);" aria-hidden="true" hidden>Show Indicators</button>
+    <button id="hide-indicators" class="btn-info" onclick="showIndicators(false);" aria-hidden="true" hidden>Hide Indicators</button>
   </div> 
   <% @s_o_hash.keys.each do |i| %>
     <div class='subj-checkbox'>
@@ -26,6 +26,18 @@
         <% j.each do |k| %>
           <li id="lo_<%= k[:id] %>" class="sequence-item sequence-item--collapsable list-group-item" data-lo-id="<%= k[:id] %>"> 
             <a class="truncate-if-collapsed" href="<%= tree_path(k[:id])%>" title="<%= k[:text] %>"><%= k[:text] %></a>
+            <% if @indicator_hash[k[:code]].length > 0 %>
+              <div class="indicators-container hidden hide-if-collapsed"><strong>
+                <%= translate('app.labels.indicator') %>
+              </strong>
+              <% @indicator_hash[k[:code]].each do |indicator| %>
+              <div>
+                <strong><%= indicator[:label] %></strong>
+                <%= indicator[:text] %>
+              </div>
+              <% end %>
+              </div>
+            <% end %>
             <% if k[:connections].length > 0 %>
               <div class="connections-div hide-if-collapsed" data-connections="<%= k[:connections].pluck(:tree_referencee_id) %>">
               <div><strong class='hide-unless-condition'><%= translate('trees.labels.outcome_connections') %></strong>

--- a/app/views/trees/sequence.html.erb
+++ b/app/views/trees/sequence.html.erb
@@ -44,7 +44,7 @@
               </div>
                 <% k[:connections].each do |c| %>
                   <% if c.active %>
-                    <div class="hide-unless-condition">
+                    <div class="hide-unless-condition block">
                       <% if current_user.present? && current_user.is_admin? %>
                       <a class="icon-link lo-handle negative-margin-left" title="<%= translate('app.labels.deactivate') %>" onclick="patch_tree_tree_activation(<%= c.id %>, 'false')">
                         <i class="fa fa-close"></i>
@@ -53,6 +53,7 @@
                         <i class="fa fa-pencil"></i>
                       </a>
                       <% end %>
+                      <div class="relationship-color-key spotlight-<%= c.relationship %>"></div>
                       <strong><%= translate('trees.labels.relation_types.' + c.relationship) %></strong> 
                       <% ref = c.tree_referencee.subject.code + '.' + c.tree_referencee[:code] %>
                       <a href="<%= tree_path(c.tree_referencee_id)%>" 

--- a/app/views/trees/sequence.html.erb
+++ b/app/views/trees/sequence.html.erb
@@ -27,12 +27,20 @@
               <div><strong class='hide-unless-condition'><%= translate('trees.labels.outcome_connections') %></strong>
               </div>
                 <% k[:connections].each do |c| %>
-                  <div class="hide-unless-condition"><strong><%= translate('trees.labels.relation_types.' + c.relationship) %></strong> <% 
-                  ref = c.tree_referencee.subject.code + '.' + c.tree_referencee[:code]
-                  %>
-                  <a href="<%= tree_path(c.tree_referencee_id)%>" 
-                    title= "<%= @translations[c.explanation_key] %>"><%= ref %></a>
-                  </div>
+                  <% if c.active %>
+                    <div class="hide-unless-condition">
+                      <a class="icon-link lo-handle" onclick="patch_tree_tree_activation(<%= c.id %>, 'false')">
+                        <i class="fa fa-close"></i>
+                      </a>
+                      <a class="icon-link lo-handle" onclick="edit_tree_tree(<%= c.id %>, 'false')">
+                        <i class="fa fa-pencil"></i>
+                      </a>
+                      <strong><%= translate('trees.labels.relation_types.' + c.relationship) %></strong> 
+                      <% ref = c.tree_referencee.subject.code + '.' + c.tree_referencee[:code] %>
+                      <a href="<%= tree_path(c.tree_referencee_id)%>" 
+                      title= "<%= @translations[c.explanation_key] %>"><%= ref %></a>
+                    </div>
+                  <% end %>
                 <% end %>
               </div>
               <div class="pull-right">

--- a/app/views/trees/sequence.html.erb
+++ b/app/views/trees/sequence.html.erb
@@ -28,11 +28,11 @@
               </div>
                 <% k[:connections].each do |c| %>
                   <% if c.active %>
-                    <div class="hide-unless-condition">
-                      <a class="icon-link lo-handle" onclick="patch_tree_tree_activation(<%= c.id %>, 'false')">
+                    <div class="hide-unless-condition negative-margin-left">
+                      <a class="icon-link lo-handle" title="<%= translate('app.labels.deactivate') %>" onclick="patch_tree_tree_activation(<%= c.id %>, 'false')">
                         <i class="fa fa-close"></i>
                       </a>
-                      <a class="icon-link lo-handle" onclick="edit_tree_tree(<%= c.id %>, 'false')">
+                      <a class="icon-link lo-handle" title="<%= translate('app.labels.edit') %>" onclick="edit_tree_tree(<%= c.id %>, 'false')">
                         <i class="fa fa-pencil"></i>
                       </a>
                       <strong><%= translate('trees.labels.relation_types.' + c.relationship) %></strong> 

--- a/config/locales/pages.en.yml
+++ b/config/locales/pages.en.yml
@@ -13,6 +13,7 @@ en:
       cancel: "Cancel"
       submit: "Submit"
       edit: "Edit"
+      deactivate: "Deactivate"
       create: "Create"
       subject: "Subject"
       grade_band: "Grade"

--- a/config/locales/pages.en.yml
+++ b/config/locales/pages.en.yml
@@ -81,6 +81,12 @@ en:
     sectors:
       name: "Future Sectors"
       hover: "Displays the Curriculum by Future Sectors"
+    big_ideas:
+      name: "Big Ideas"
+      hover: ""
+    misconceptions:
+      name: "Misconceptions"
+      hover: "Displays Misconceptions"
     documents:
       name: "Documents"
       hover: "Documents Management for Administrators"

--- a/config/locales/pages.tr.yml
+++ b/config/locales/pages.tr.yml
@@ -8,6 +8,7 @@ tr:
       cancel: "Cancel"
       submit: "Submit"
       edit: "Edit"
+      deactivate: "devre dışı bırakmak"
       create: "Create"
       subject: "Konusu"
       grade_band: "seviyesi"

--- a/config/locales/pages.tr.yml
+++ b/config/locales/pages.tr.yml
@@ -38,6 +38,12 @@ tr:
     sectors:
       name: "Gelecek Sektörler"
       hover: "Gelecekteki Sektörlere Göre Müfredatı görüntüler"
+    big_ideas:
+      name: "Büyük Fikirler"
+      hover: ""
+    misconceptions:
+      name: "Yanılgılar"
+      hover: ""
     documents:
       name: "Belge"
       hover: "Yöneticiler İçin Belge Yönetimi"

--- a/db/migrate/20191105155404_add_active_to_trees.rb
+++ b/db/migrate/20191105155404_add_active_to_trees.rb
@@ -1,0 +1,5 @@
+class AddActiveToTrees < ActiveRecord::Migration[5.1]
+  def change
+    add_column :trees, :active, :boolean, default: true
+  end
+end

--- a/db/migrate/20191105155659_add_active_to_tree_trees.rb
+++ b/db/migrate/20191105155659_add_active_to_tree_trees.rb
@@ -1,0 +1,5 @@
+class AddActiveToTreeTrees < ActiveRecord::Migration[5.1]
+  def change
+    add_column :tree_trees, :active, :boolean, default: true
+  end
+end

--- a/db/migrate/20191105155833_add_active_to_sector_trees.rb
+++ b/db/migrate/20191105155833_add_active_to_sector_trees.rb
@@ -1,0 +1,5 @@
+class AddActiveToSectorTrees < ActiveRecord::Migration[5.1]
+  def change
+    add_column :sector_trees, :active, :boolean, default: true
+  end
+end

--- a/db/migrate/20191105155906_add_active_to_tree_types.rb
+++ b/db/migrate/20191105155906_add_active_to_tree_types.rb
@@ -1,0 +1,5 @@
+class AddActiveToTreeTypes < ActiveRecord::Migration[5.1]
+  def change
+    add_column :tree_types, :active, :boolean, default: true
+  end
+end

--- a/db/migrate/20191105155931_add_active_to_versions.rb
+++ b/db/migrate/20191105155931_add_active_to_versions.rb
@@ -1,0 +1,5 @@
+class AddActiveToVersions < ActiveRecord::Migration[5.1]
+  def change
+    add_column :versions, :active, :boolean, default: true
+  end
+end

--- a/db/migrate/20191105160015_add_active_to_subjects.rb
+++ b/db/migrate/20191105160015_add_active_to_subjects.rb
@@ -1,0 +1,5 @@
+class AddActiveToSubjects < ActiveRecord::Migration[5.1]
+  def change
+    add_column :subjects, :active, :boolean, default: true
+  end
+end

--- a/db/migrate/20191105160059_add_active_to_grade_bands.rb
+++ b/db/migrate/20191105160059_add_active_to_grade_bands.rb
@@ -1,0 +1,5 @@
+class AddActiveToGradeBands < ActiveRecord::Migration[5.1]
+  def change
+    add_column :grade_bands, :active, :boolean, default: true
+  end
+end

--- a/db/migrate/20191105160129_add_active_to_sectors.rb
+++ b/db/migrate/20191105160129_add_active_to_sectors.rb
@@ -1,0 +1,5 @@
+class AddActiveToSectors < ActiveRecord::Migration[5.1]
+  def change
+    add_column :sectors, :active, :boolean, default: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20191030192923) do
+ActiveRecord::Schema.define(version: 20191105160129) do
 
   create_table "grade_bands", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.integer "tree_type_id", null: false
@@ -18,6 +18,7 @@ ActiveRecord::Schema.define(version: 20191030192923) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "sort_order", default: 0
+    t.boolean "active", default: true
     t.index ["tree_type_id"], name: "index_grade_bands_on_tree_type_id"
   end
 
@@ -34,6 +35,7 @@ ActiveRecord::Schema.define(version: 20191030192923) do
     t.string "explanation_key"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.boolean "active", default: true
     t.index ["sector_id"], name: "index_sector_trees_on_sector_id"
     t.index ["tree_id"], name: "index_sector_trees_on_tree_id"
   end
@@ -44,6 +46,7 @@ ActiveRecord::Schema.define(version: 20191030192923) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "base_key"
+    t.boolean "active", default: true
     t.index ["code"], name: "index_sectors_on_code"
   end
 
@@ -53,6 +56,7 @@ ActiveRecord::Schema.define(version: 20191030192923) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "base_key"
+    t.boolean "active", default: true
     t.index ["tree_type_id"], name: "index_subjects_on_tree_type_id"
   end
 
@@ -75,6 +79,7 @@ ActiveRecord::Schema.define(version: 20191030192923) do
     t.string "explanation_key"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.boolean "active", default: true
     t.index ["tree_referencee_id"], name: "index_tree_trees_on_tree_referencee_id"
     t.index ["tree_referencer_id"], name: "index_tree_trees_on_tree_referencer_id"
   end
@@ -83,6 +88,7 @@ ActiveRecord::Schema.define(version: 20191030192923) do
     t.string "code"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.boolean "active", default: true
   end
 
   create_table "trees", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
@@ -99,6 +105,7 @@ ActiveRecord::Schema.define(version: 20191030192923) do
     t.integer "depth", default: 0
     t.integer "sort_order", default: 0
     t.integer "sequence_order", default: 0
+    t.boolean "active", default: true
     t.index ["grade_band_id"], name: "index_trees_on_grade_band_id"
     t.index ["name_key"], name: "index_trees_on_name_key"
     t.index ["subject_id"], name: "index_trees_on_subject_id"
@@ -167,6 +174,7 @@ ActiveRecord::Schema.define(version: 20191030192923) do
     t.string "code"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.boolean "active", default: true
   end
 
 end


### PR DESCRIPTION
Migrations to add an "active" field to the Tree, TreeTree, SectorTree, TreeType, Version, Subject, GradeBand, and Sector tables.

Does everything in issue #47 save for enabling editing/deactivation of LO connections from the detail page:
- Sequence page should allow for deactivating connections.
- Connecting LO that exist already or have been deactivated should bring up an edit connection dialog (reuse create dialog).
- Listing of connections for an LO will each have an edit and deactivate icon.
- These actions should only be available to admin.

Color-code expanded LO connections on the Sequence page (by relationship type), and adds relationship-color-key  divs next to each relationship listed.

Add indicators to the display of LOs on the sequence page, and a button to hide or show indicators.

Also adds non-functional "Big Ideas" and "Misconceptions" buttons to the nav header.