### PR TITLE
Fix Math Uploads

### DIFF
--- a/app/views/trees/sequence.html.erb
+++ b/app/views/trees/sequence.html.erb
@@ -28,7 +28,7 @@
             <a class="truncate-if-collapsed" href="<%= tree_path(k[:id])%>" title="<%= k[:text] %>"><%= k[:text] %></a>
             <% if @indicator_hash[k[:code]].length > 0 %>
               <div class="indicators-container hidden hide-if-collapsed"><strong>
-                <%= translate('app.labels.indicator') %>
+                <%= translate('app.labels.indicators') %>:
               </strong>
               <% @indicator_hash[k[:code]].each do |indicator| %>
               <div>

--- a/config/upload_files/Mat09Eng.txt
+++ b/config/upload_files/Mat09Eng.txt
@@ -84,6 +84,7 @@ ç) In deep-rooted expressions, transactions with nested roots leading to infin
 9.3.5. Applications of Equations and Inequalities
 Terms and Concepts: ratio, proportion, direct proportion, inverse proportion, percentage
 Symbols and representations: %, a/b, a:b, a/b = c/d, a:b = c:d
+9.3.5.1 Applications of Equations and Inequalities
 a) Ratio, proportionality, direct proportion, inverse proportional concepts and the properties of proportion and proportion are reminded.
 b) Golden ratio is introduced and real life examples are given but calculation methods are not included.
 9.3.5.2. Solves problems related to equations and inequalities.
@@ -165,6 +166,7 @@ d) With the help of information and communication technologies, it is observed h
 9.5. (DATA, COUNTING AND PROBABILITY) Data
 9.5.1. Measures of Central Tendency and Propagation
 Terms and Concepts: data, discrete data, continuous data, arithmetic mean, median (median), peak value (mode), aperture, maximum value, minimum value, standard deviation
+9.5.1.1. Measures of Central Tendency and Propagation
 a) Data concept, discrete and continuous data types are given.
 b) Arithmetic mean, median, peak value, maximum value, minimum value and openness are given.
 c) The lower quarter, upper quarters and quarters are not included.

--- a/config/upload_files/Mat10Eng.txt
+++ b/config/upload_files/Mat10Eng.txt
@@ -31,6 +31,7 @@ c) Real life problems are included.
 10.2. (NUMBERS AND ALGEBRA) Functions
 10.2.1. Concept of Functions and Representation
 Terms and Concepts: function, definition set, value set, image set, function chart, fixed function, function inside, overlay function, one to one function, equal function, unit function, linear function, single function, double function, vertical (vertical) correct test
+10.2.1.1. Concept of Functions and Representation
 a) The concept of function is explained.
 b) Only functions defined on real numbers are considered.
 c) Into function, covering function, one-to-one function, equal function, unit (identity) function, fixed function, linear function, single function, dual function and segmented function is described.

--- a/config/upload_files/Mat12Eng.txt
+++ b/config/upload_files/Mat12Eng.txt
@@ -69,6 +69,7 @@ b) The historical development of the limit and the contributions of Salih Zeki t
 c) Continuity applications are made with the help of information and communication technologies.
 12.5.2. Instantaneous Change Rate and Derivative
 Terms and Concepts: instantaneous change rate, slope of the tangent, derivative, derivative from right, derivative from left
+12.5.2.1 Instantaneous Change Rate and Derivative
 a) The instantaneous change rate is explained by using physics and geometry models.
 b) The relation between the derivative value of a given function at a point and the inclination of the tangent at that point is emphasized.
 c) The relationship between the left-hand derivative and the right-hand derivative of a function at a point and the derivative.


### PR DESCRIPTION
Edited the upload files to prevent a handful of math indicators from being processed as LOs.

Also using the plural "indicators" locale translation as appropriate on the Sequence page.