### PR TITLE
Exclude subject headers on the Sequence page from being sortable. 

### DIFF
--- a/app/assets/javascripts/sequence.js
+++ b/app/assets/javascripts/sequence.js
@@ -208,8 +208,20 @@ edit_tree_tree = function (tree_tree_id) {
         .catch(function (err) { console.log("ERROR:", err) })
 }
 
+/**
+ *
+ * 1) Initializes jqueryui sort behavior for LOs
+ *    within a given subject, and across gradebands.
+ * 2) Initializes jqueryui drag (and snap back into place)
+ *    behavior for LOs within and across subjects and
+ *    gradebands.
+ */
 initializeSortAndDrag = function () {
    $('.sequence-page .list-group').sortable({
+    //specify only .list-group-items
+    //should be sortable (to
+    //exclude subject headers)
+    items: '.list-group-item',
     placeholder: 'drop-placeholder',
     handle: '.sort-handle',
     stop: function (e, ui) {

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -93,7 +93,8 @@ ActiveRecord::Schema.define(version: 20191108181256) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["key"], name: "index_translations_on_key"
-    t.index ["value"], name: "index_translations_on_value", length: { value: 255 }
+    t.index ["locale", "key"], name: "index_translations_on_keys"
+    t.index ["value"], name: "index_translations_on_value", length: { value: 256 }
   end
 
   create_table "tree_trees", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -93,8 +93,7 @@ ActiveRecord::Schema.define(version: 20191108181256) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["key"], name: "index_translations_on_key"
-    t.index ["locale", "key"], name: "index_translations_on_keys"
-    t.index ["value"], name: "index_translations_on_value", length: { value: 256 }
+    t.index ["value"], name: "index_translations_on_value", length: { value: 255 }
   end
 
   create_table "tree_trees", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|


### PR DESCRIPTION
Exclude subject headers on the Sequence page from being sortable. Executed a rake db:migrate (the last merge added a migration with a new 'dimensions' table) which changed schema.rb.