### PR TITLE
fix LO detail page

### DIFF
--- a/app/controllers/trees_controller.rb
+++ b/app/controllers/trees_controller.rb
@@ -387,7 +387,7 @@ class TreesController < ApplicationController
     transl_keys = @trees.map { |t| "#{t.base_key}.name" }
 
     @relations = Hash.new { |h, k| h[k] = [] }
-    relations = DimensionTree.active
+    relations = DimTree.active
     relations.each do |rel|
       @relations["tree_id #{rel.tree_id}"] << rel
       @relations["dim_id #{rel.dimension_id}"] << rel
@@ -477,12 +477,12 @@ class TreesController < ApplicationController
     errors = []
 
     #Check whether a tree_tree for this relationship already exists.
-    dim_tree_matches = DimensionTree.where(
+    dim_tree_matches = DimTree.where(
       :tree_id => tree_params[:tree_id],
       :dimension_id => tree_params[:dimension_id])
 
     if errors.length == 0
-      @dim_tree = DimensionTree.new(tree_params)
+      @dim_tree = DimTree.new(tree_params)
       @tree = Tree.find(tree_params[:tree_id])
       @dim = Dimension.find(tree_params[:dimension_id])
       @explanation = ''

--- a/app/models/dim_tree.rb
+++ b/app/models/dim_tree.rb
@@ -1,4 +1,4 @@
-class DimensionTree < BaseRec
+class DimTree < BaseRec
   # note cannot use DimensionTree as model class name, it always returned:
   # NameError: uninitialized constant DimensionTree
   self.table_name = 'dimension_trees'


### PR DESCRIPTION
-Rollback renaming DimTree class "DimensionTree" to match schema. 
-fixes the LO detail page, which was broken in the last commit.