### PR TITLE
Add More User-Friendly Gradeband Filters to the Sequence and Dimensions pages

### DIFF
--- a/app/assets/javascripts/dimensions.js
+++ b/app/assets/javascripts/dimensions.js
@@ -15,8 +15,7 @@ $(function() {
     	$('#'+subj_abbr+'-dim-column').removeClass('hidden')
       $('#'+subj_abbr+'-lo-column').removeClass('hidden')
       connections_display(true)
-      $('.show-hide-gradeband').addClass('text-selected');
-      $('.show-hide-gradeband').removeClass('down');
+      $('.show-hide-gradeband').addClass('option-selected');
       $('.dim-item').removeClass('hidden');
       document.cookie = page_title + "_subject_visible=" + subj_abbr;
     }

--- a/app/assets/javascripts/dimensions.js
+++ b/app/assets/javascripts/dimensions.js
@@ -16,6 +16,7 @@ $(function() {
       $('#'+subj_abbr+'-lo-column').removeClass('hidden')
       connections_display(true)
       $('.show-hide-gradeband').addClass('text-selected');
+      $('.show-hide-gradeband').removeClass('down');
       $('.dim-item').removeClass('hidden');
       document.cookie = page_title + "_subject_visible=" + subj_abbr;
     }

--- a/app/assets/javascripts/sequence.js
+++ b/app/assets/javascripts/sequence.js
@@ -73,16 +73,15 @@ $(function() {
    *                              and "text-selected".
    */
   toggle_visibility = function (selector, trigger, matchTrigger) {
-    $(trigger).toggleClass('down text-selected');
-    var down = $(trigger).hasClass("down");
-    var sel = $(trigger).hasClass("text-selected");
-    if (down && !sel)
-      $(selector).addClass('hidden');
-    else
+    $(trigger).toggleClass('option-selected');
+    var sel = $(trigger).hasClass("option-selected");
+    if (sel)
       $(selector).removeClass('hidden');
+    else
+      $(selector).addClass('hidden');
     if (matchTrigger != undefined && matchTrigger != '') {
-        $(matchTrigger).addClass((down ? "down " : "") + (sel ? "text-selected" : ""))
-        $(matchTrigger).removeClass((!down ? "down " : "") + (!sel ? "text-selected" : ""))
+        $(matchTrigger).addClass((sel ? "option-selected" : ""))
+        $(matchTrigger).removeClass((!sel ? "option-selected" : ""))
     }
   }
 

--- a/app/assets/javascripts/sequence.js
+++ b/app/assets/javascripts/sequence.js
@@ -26,30 +26,64 @@ $(function() {
    * @param {String} subj_arr Array of abbreviations for a subject.
    *                            E.g. 'bio', 'phy', etc.
    * @param {String} gb_code The code for the affected gradeband.
+   * @param {Boolean} multi True if multiple subjects are being
+   *                        affected. This is needed because the
+   *                        show/hide gradeband checkboxes for
+   *                        "all subjects" should update the
+   *                        single-subject checkboxes.
    */
-  gradeband_visibility = function (subj_arr, gb_code, all) {
+  gradeband_visibility = function (subj_arr, gb_arr, multi) {
     var subj_abbr = subj_arr.pop();
-    if (($('#' + subj_abbr + '-gb-check-' + gb_code).prop('checked') && !all) ||
-      ($('#all-gb-check-' + gb_code).prop('checked') && all)) {
-       $('#' + subj_abbr + '-gb-check-' + gb_code).prop('checked', true)
-       $('#'+subj_abbr+'-column .lo_gb_code_' + gb_code).removeClass('hidden')
+    for (var gb in gb_arr) {
+      var gb_code = gb_arr[gb]
+      if (gb_arr.length > 1) {
+        if ($('#all-gb-check-All').prop('checked')) {
+          $('#' + subj_abbr + '-gb-check-' + gb_code).prop('checked', true)
+          $('#all-gb-check-' + gb_code).prop('checked', true)
+          $('#'+subj_abbr+'-column .lo_gb_code_' + gb_code).removeClass('hidden')
+        }
+        else {
+           $('#' + subj_abbr + '-gb-check-' + gb_code).prop('checked', false)
+           $('#all-gb-check-' + gb_code).prop('checked', false)
+           $('#'+subj_abbr+'-column .lo_gb_code_' + gb_code).addClass('hidden')
+         }
+      }
+      else {
+        if (($('#' + subj_abbr + '-gb-check-' + gb_code).prop('checked') && !multi) ||
+          ($('#all-gb-check-' + gb_code).prop('checked') && multi)) {
+           $('#' + subj_abbr + '-gb-check-' + gb_code).prop('checked', true)
+           $('#'+subj_abbr+'-column .lo_gb_code_' + gb_code).removeClass('hidden')
+        }
+        else {
+           $('#' + subj_abbr + '-gb-check-' + gb_code).prop('checked', false)
+           $('#'+subj_abbr+'-column .lo_gb_code_' + gb_code).addClass('hidden')
+        }
+      }
     }
-    else {
-       $('#' + subj_abbr + '-gb-check-' + gb_code).prop('checked', false)
-       $('#'+subj_abbr+'-column .lo_gb_code_' + gb_code).addClass('hidden')
-    }
-    if (subj_arr.length > 0) gradeband_visibility(subj_arr, gb_code, all);
+    if (subj_arr.length > 0) gradeband_visibility(subj_arr, gb_arr, multi);
   }
 
   /**
    * Generic toggle visibility method
    * @param {String} selector CSS selector for the element or elements to hide
    * @param {String} trigger CSS selector for the element triggering this function
+   * @param {String} matchTrigger Selectors for elements or elements that should
+   *                              be updated to match the trigger element's
+   *                              settings with regard to the classes "down"
+   *                              and "text-selected".
    */
-  toggle_visibility = function (selector, trigger) {
-    console.log('toggle')
-    $(trigger).toggleClass('down text-selected')
-    $(selector).toggleClass('hidden')
+  toggle_visibility = function (selector, trigger, matchTrigger) {
+    $(trigger).toggleClass('down text-selected');
+    var down = $(trigger).hasClass("down");
+    var sel = $(trigger).hasClass("text-selected");
+    if (down && !sel)
+      $(selector).addClass('hidden');
+    else
+      $(selector).removeClass('hidden');
+    if (matchTrigger != undefined && matchTrigger != '') {
+        $(matchTrigger).addClass((down ? "down " : "") + (sel ? "text-selected" : ""))
+        $(matchTrigger).removeClass((!down ? "down " : "") + (!sel ? "text-selected" : ""))
+    }
   }
 
   /**

--- a/app/assets/javascripts/sequence.js
+++ b/app/assets/javascripts/sequence.js
@@ -23,7 +23,7 @@ $(function() {
 
   /**
    * Hide or show LOs by subject and gradeband.
-   * @param {String} subj_arr Array of abbreviations for a subject.
+   * @param {Array<String>} subj_arr Array of abbreviations for a subject.
    *                            E.g. 'bio', 'phy', etc.
    * @param {String} gb_code The code for the affected gradeband.
    * @param {Boolean} multi True if multiple subjects are being
@@ -69,8 +69,8 @@ $(function() {
    * @param {String} trigger CSS selector for the element triggering this function
    * @param {String} matchTrigger Selectors for elements or elements that should
    *                              be updated to match the trigger element's
-   *                              settings with regard to the classes "down"
-   *                              and "text-selected".
+   *                              settings with regard to the ".option-selected"
+   *                              class.
    */
   toggle_visibility = function (selector, trigger, matchTrigger) {
     $(trigger).toggleClass('option-selected');

--- a/app/assets/javascripts/sequence.js
+++ b/app/assets/javascripts/sequence.js
@@ -23,17 +23,22 @@ $(function() {
 
   /**
    * Hide or show LOs by subject and gradeband.
-   * @param {String} subj_abbr Abbreviation for a subject.
+   * @param {String} subj_arr Array of abbreviations for a subject.
    *                            E.g. 'bio', 'phy', etc.
    * @param {String} gb_code The code for the affected gradeband.
    */
-  gradeband_visibility = function (subj_abbr, gb_code) {
-    if ($('#' + subj_abbr + '-gb-check-' + gb_code).prop('checked')) {
+  gradeband_visibility = function (subj_arr, gb_code, all) {
+    var subj_abbr = subj_arr.pop();
+    if (($('#' + subj_abbr + '-gb-check-' + gb_code).prop('checked') && !all) ||
+      ($('#all-gb-check-' + gb_code).prop('checked') && all)) {
+       $('#' + subj_abbr + '-gb-check-' + gb_code).prop('checked', true)
        $('#'+subj_abbr+'-column .lo_gb_code_' + gb_code).removeClass('hidden')
     }
     else {
+       $('#' + subj_abbr + '-gb-check-' + gb_code).prop('checked', false)
        $('#'+subj_abbr+'-column .lo_gb_code_' + gb_code).addClass('hidden')
     }
+    if (subj_arr.length > 0) gradeband_visibility(subj_arr, gb_code, all);
   }
 
   /**

--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -28,7 +28,19 @@ body {
     color: grey;
   }
 
-  .text-selected {
+  .rotate {
+    -moz-transition: all .2s linear;
+    -webkit-transition: all .2s linear;
+    transition: all .2s linear;
+    cursor: pointer;
+  }
+  .rotate.option-selected {
+    -moz-transform:rotate(-90deg);
+    -webkit-transform:rotate(-90deg);
+    transform:rotate(-90deg);
+  }
+
+  span.option-selected {
     font-weight: bold;
     color: black;
   }

--- a/app/assets/stylesheets/trees.scss
+++ b/app/assets/stylesheets/trees.scss
@@ -108,18 +108,6 @@
 
     .hidden { display: none; }
 
-    .rotate {
-      -moz-transition: all .2s linear;
-      -webkit-transition: all .2s linear;
-      transition: all .2s linear;
-      cursor: pointer;
-    }
-    .rotate.down {
-        -moz-transform:rotate(-90deg);
-        -webkit-transform:rotate(-90deg);
-        transform:rotate(-90deg);
-    }
-
     .subj-checkbox {
       display: inline-block;
       vertical-align: top;

--- a/app/assets/stylesheets/trees.scss
+++ b/app/assets/stylesheets/trees.scss
@@ -74,6 +74,17 @@
       border-top: 1px solid black;
     }
 
+    .filter-grid {
+      display: grid;
+      border: 1px solid grey;
+      margin: 1vh auto;
+      max-width: 550px;
+      font-size: 90%;
+      ul {
+        border: none;
+      }
+    }
+
     .sequence-grid.cols-6, .dimension-grid.cols-6 {
        grid-template-columns: 16.5% 16.5% 16.5% 16.5% 16.5% 16.5%;
     }
@@ -82,7 +93,7 @@
        grid-template-columns: 20% 20% 20% 20% 20%;
     }
 
-    .sequence-grid.cols-4, .dimension-grid.cols-4 {
+    .sequence-grid.cols-4, .dimension-grid.cols-4, .filter-grid.cols-4 {
        grid-template-columns: 25% 25% 25% 25%;
     }
 

--- a/app/assets/stylesheets/trees.scss
+++ b/app/assets/stylesheets/trees.scss
@@ -80,6 +80,7 @@
       margin: 1vh auto;
       max-width: 550px;
       font-size: 90%;
+      text-align: left;
       ul {
         border: none;
       }

--- a/app/controllers/trees_controller.rb
+++ b/app/controllers/trees_controller.rb
@@ -256,7 +256,7 @@ class TreesController < ApplicationController
     componentHash = {}
     newHash = {}
     @subj_gradebands = Hash.new { |h, k| h[k] =  [] }
-
+    @gradebands = listing.joins(:grade_band).pluck('grade_bands.code').uniq
     @subjects = {}
     subjIds = {}
     subjects = Subject.all

--- a/app/controllers/trees_controller.rb
+++ b/app/controllers/trees_controller.rb
@@ -256,7 +256,7 @@ class TreesController < ApplicationController
     componentHash = {}
     newHash = {}
     @subj_gradebands = Hash.new { |h, k| h[k] =  [] }
-    @gradebands = listing.joins(:grade_band).pluck('grade_bands.code').uniq
+    @gradebands = ["All", *listing.joins(:grade_band).pluck('grade_bands.code').uniq]
     @subjects = {}
     subjIds = {}
     subjects = Subject.all
@@ -415,6 +415,7 @@ class TreesController < ApplicationController
         :los => []
       }
       @subj_gradebands[s.code] = listing.joins(:subject).where('subjects.code' => s.code).joins(:grade_band).pluck('grade_bands.code').uniq
+      @subj_gradebands[s.code] << "All" if @subj_gradebands[s.code].length > 1
       transl_keys << s.base_key+'.name'
       transl_keys << s.base_key+'.abbr'
     end

--- a/app/views/trees/dimensions.html.erb
+++ b/app/views/trees/dimensions.html.erb
@@ -56,7 +56,7 @@
           <% @subj_gradebands[i].each do |gb_code| %>
             <% selector = (gb_code == "All" ? ".dim-item" : ".gb_code_#{gb_code}") %>
             <% matchTrigger = (gb_code == "All" ? '.show-hide-gradeband' : nil) %>
-            <span id="show-hide-gradeband-<%= gb_code %>" class="show-hide-gradeband show-hide-gradeband-<%= gb_code %> text-selected" onclick="toggle_visibility('<%= selector %>', '.show-hide-gradeband-<%= gb_code %>', '<%= matchTrigger %>');"><%= gb_code == "All" ? I18n.t('app.labels.all') : "  #{gb_code} " %></span>
+            <span id="show-hide-gradeband-<%= gb_code %>" class="show-hide-gradeband show-hide-gradeband-<%= gb_code %> option-selected" onclick="toggle_visibility('<%= selector %>', '.show-hide-gradeband-<%= gb_code %>', '<%= matchTrigger %>');"><%= gb_code == "All" ? I18n.t('app.labels.all') : "  #{gb_code} " %></span>
           <% end #iterate through subject's grade bands %>
           <% end #if subject has gradebands %>
         </li>

--- a/app/views/trees/dimensions.html.erb
+++ b/app/views/trees/dimensions.html.erb
@@ -54,9 +54,11 @@
             <%= translate('app.labels.grade_band_show') if (@subj_gradebands[i].length == 1)
           %>:
           <% @subj_gradebands[i].each do |gb_code| %>
-            <span id="show-hide-gradeband-<%= gb_code %>" class="show-hide-gradeband show-hide-gradeband-<%= gb_code %> text-selected" onclick="toggle_visibility('.gb_code_<%= gb_code %>', '.show-hide-gradeband-<%= gb_code %>');"><%= "  #{gb_code} " %></span>
-          <% end %>
-          <% end %>
+            <% selector = (gb_code == "All" ? ".dim-item" : ".gb_code_#{gb_code}") %>
+            <% matchTrigger = (gb_code == "All" ? '.show-hide-gradeband' : nil) %>
+            <span id="show-hide-gradeband-<%= gb_code %>" class="show-hide-gradeband show-hide-gradeband-<%= gb_code %> text-selected" onclick="toggle_visibility('<%= selector %>', '.show-hide-gradeband-<%= gb_code %>', '<%= matchTrigger %>');"><%= gb_code == "All" ? I18n.t('app.labels.all') : "  #{gb_code} " %></span>
+          <% end #iterate through subject's grade bands %>
+          <% end #if subject has gradebands %>
         </li>
         <% j[:los].each do |k| %>
           <li id="<%= i %>_lo_<%= k[:id] %>" class="dim-item dim-item--collapsable list-group-item gb_code_<%= k[:gb_code] %>" data-loid="<%= k[:id] %>">

--- a/app/views/trees/sequence.html.erb
+++ b/app/views/trees/sequence.html.erb
@@ -16,13 +16,15 @@
     <div id='all-gradebands-list' class='filter-grid cols-4 hidden'>
       <% filter_rows = (@gradebands.length / 4.0).ceil %>
       <% @gradebands.each_with_index do |gb_code, i| %>
+        <% gb_arr = (gb_code == "All" ? @gradebands : [gb_code]) %>
         <% if i%filter_rows == 0 %>
           <ul>
         <% end %>
           <li>
-            <input id="all-gb-check-<%= gb_code %>" type="checkbox" onchange='gradeband_visibility(<%= @s_o_hash.keys %>, "<%= gb_code %>", true);' checked></input>
+            <input id="all-gb-check-<%= gb_code %>" type="checkbox" onchange='gradeband_visibility(<%= @s_o_hash.keys %>, <%= gb_arr %>, true);' checked></input>
             <label for="all-gb-check-<%= gb_code %>">
-              <%= I18n.t('app.labels.grade_band_num', num: gb_code) %>
+              <%= I18n.t('app.labels.grade_band_num', num: gb_code) if gb_code != "All" %>
+              <%= I18n.t('app.labels.all') if gb_code == "All" %>
             </label>
           </li>
 
@@ -42,7 +44,7 @@
           <ul id="<%= i %>-gradebands-list" class="gradebands-list hidden">
             <% @subj_gradebands[i].each do |gb_code|%>
               <li>
-              <input id="<%= i %>-gb-check-<%= gb_code %>" type="checkbox" onchange='gradeband_visibility(["<%= i %>"], "<%= gb_code %>");' checked></input>
+              <input id="<%= i %>-gb-check-<%= gb_code %>" type="checkbox" onchange='gradeband_visibility(["<%= i %>"], ["<%= gb_code %>"]);' checked></input>
               <label for="<%= i %>-gb-check-<%= gb_code %>">
                 <%= I18n.t('app.labels.grade_band_num', num: gb_code) %>
               </label>

--- a/app/views/trees/sequence.html.erb
+++ b/app/views/trees/sequence.html.erb
@@ -8,6 +8,28 @@
     <div>
       <button id="show-indicators" class="btn-info" onclick="showIndicators(true);">Show Indicators</button>
       <button id="hide-indicators" class="btn-info" onclick="showIndicators(false);" aria-hidden="true" hidden>Hide Indicators</button>
+       <button class="btn-info" onclick="toggle_visibility('#all-gradebands-list', '#show-gb-controls-all');">
+       <span>Filter by Grade </span>
+       <i id="show-gb-controls-all" class="rotate fa fa-angle-left down"></i>
+       </button>
+    </div>
+    <div id='all-gradebands-list' class='filter-grid cols-4 hidden'>
+      <% filter_rows = (@gradebands.length / 4.0).ceil %>
+      <% @gradebands.each_with_index do |gb_code, i| %>
+        <% if i%filter_rows == 0 %>
+          <ul>
+        <% end %>
+          <li>
+            <input id="all-gb-check-<%= gb_code %>" type="checkbox" onchange='gradeband_visibility(<%= @s_o_hash.keys %>, "<%= gb_code %>", true);' checked></input>
+            <label for="all-gb-check-<%= gb_code %>">
+              <%= I18n.t('app.labels.grade_band_num', num: gb_code) %>
+            </label>
+          </li>
+
+        <% if i%filter_rows == filter_rows - 1 %>
+          </ul>
+        <% end %>
+      <% end #iterate through @gradebands %>
     </div>
     <% @s_o_hash.keys.each do |i| %>
       <div class='subj-checkbox'>
@@ -20,7 +42,7 @@
           <ul id="<%= i %>-gradebands-list" class="gradebands-list hidden">
             <% @subj_gradebands[i].each do |gb_code|%>
               <li>
-              <input id="<%= i %>-gb-check-<%= gb_code %>" type="checkbox" onchange='gradeband_visibility("<%= i %>", "<%= gb_code %>");' checked></input>
+              <input id="<%= i %>-gb-check-<%= gb_code %>" type="checkbox" onchange='gradeband_visibility(["<%= i %>"], "<%= gb_code %>");' checked></input>
               <label for="<%= i %>-gb-check-<%= gb_code %>">
                 <%= I18n.t('app.labels.grade_band_num', num: gb_code) %>
               </label>

--- a/app/views/trees/sequence.html.erb
+++ b/app/views/trees/sequence.html.erb
@@ -8,7 +8,7 @@
     <div>
       <button id="show-indicators" class="btn-info" onclick="showIndicators(true);">Show Indicators</button>
       <button id="hide-indicators" class="btn-info" onclick="showIndicators(false);" aria-hidden="true" hidden>Hide Indicators</button>
-       <button class="btn-info" onclick="toggle_visibility('#all-gradebands-list', '#show-gb-controls-all');">
+       <button id="filter-gradebands-btn" class="btn-info" onclick="toggle_visibility('#all-gradebands-list', '#show-gb-controls-all');">
        <span>Filter by Grade </span>
        <i id="show-gb-controls-all" class="rotate fa fa-angle-left down"></i>
        </button>


### PR DESCRIPTION
Adds:
- Prominent button on the Sequence page to filter all subjects by grade.
- "Show/Hide all LOs"-options on the Sequence page and the Dimensions page.

**Note:** In the future, might want to consider ways to merge `subject_visibility()` and `gradeband_visibility()` into the generic `toggle_visibility()` function.