### PR TITLE
More Edit Options on the Detail Page & Nav Options in the Nav Bar

### DIFF
--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -20,8 +20,20 @@ body {
     cursor: pointer;
     // list-style-position: none;
   }
-  #modal_popup label {
-    font-weight: bold;
+  .stack {
+    clear: both;
+    display: block;
+  }
+  #modal_popup{
+    textarea {
+      width: 100%;
+    }
+    fieldset {
+      margin-bottom: 10px;
+    }
+    label {
+      font-weight: bold;
+    }
   }
 
   .show-hide-gradeband {

--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -24,6 +24,9 @@ body {
     clear: both;
     display: block;
   }
+  .dropdown-menu {
+    left: inherit;
+  }
   #modal_popup{
     textarea {
       width: 100%;

--- a/app/assets/stylesheets/header.scss
+++ b/app/assets/stylesheets/header.scss
@@ -28,6 +28,7 @@
 }
 
 nav#topNav {
+  max-width: 100%;
   .nav-item a.nav-link {
     padding-top: 2px;
     padding-bottom: 2px;

--- a/app/controllers/sectors_controller.rb
+++ b/app/controllers/sectors_controller.rb
@@ -103,7 +103,7 @@ class SectorsController < ApplicationController
     rptRows << [sector.code, '', translations[sector.name_key], '-1', '']
     # filter out records when pulling from the join
     # To Do: put grade band and subject into sector_trees join record to efficiently filter out selected grade or subject
-    sector.sector_trees.each do |st|
+    sector.sector_trees.active.each do |st|
       if @grade_band_id.present? && st.tree.grade_band_id.to_s != @grade_band_id
       elsif @subject_id.present? && st.tree.subject_id.to_s != @subject_id
       else

--- a/app/controllers/trees_controller.rb
+++ b/app/controllers/trees_controller.rb
@@ -695,6 +695,7 @@ class TreesController < ApplicationController
         @translation = translation[name_key]
       elsif @edit_type == "indicator"
         @indicator = Tree.find(tree_params[:attr_id])
+        @attr_id = @indicator.id
         name_key = @indicator.buildNameKey
         translation = Translation.translationsByKeys(
           @locale_code,
@@ -703,6 +704,7 @@ class TreesController < ApplicationController
         @translation = translation[name_key]
       elsif @edit_type == "treetree"
         @rel = TreeTree.find(tree_params[:attr_id])
+        @attr_id = @rel.id
         expl_key = @rel.explanation_key
         @tree_referencee = @rel.tree_referencee
         @tree_referencee_code = I18n.t("trees.labels.#{@tree_referencee.subject.code}") + " #{@tree_referencee.code}"
@@ -711,59 +713,22 @@ class TreesController < ApplicationController
           expl_key
         )
         @explanation = translation[expl_key]
+      elsif @edit_type == "sectortree"
+        @rel = SectorTree.find(tree_params[:attr_id])
+        @attr_id = @rel.id
+        expl_key = @rel.explanation_key
+        name_matches = Translation.where(
+          :locale => @locale_code,
+          :key => @rel.sector.name_key
+          )
+        @sector_name = (name_matches.length > 0 ? ": #{name_matches.first.value}" : '')
+        @tree_referencee_code = "#{I18n.t('app.labels.sector_num', num: @rel.sector.code)}#{@sector_name}"
+        translation = Translation.translationsByKeys(
+          @locale_code,
+          expl_key
+        )
+        @explanation = translation[expl_key]
       end
-
-      #prepare to output the edit form
-      @tree_items_to_display = []
-      @subjects = Subject.all.order(:code)
-      subjById = @subjects.map{ |rec| [rec.id, rec.code]}
-      @subjById = Hash[subjById]
-      Rails.logger.debug("*** @subjById: #{@subjById.inspect}")
-      relatedBySubj = @subjects.map{ |rec| [rec.code, []]}
-      @relatedBySubj = Hash[relatedBySubj]
-      Rails.logger.debug("*** @relatedBySubj: #{@relatedBySubj.inspect}")
-      # get all translation keys for this learning outcome
-      treeKeys = @tree.getAllTransNameKeys
-      if @tree.depth == 4
-        # when outcome level, get children (indicators), to in outcome page
-        @tree.getAllChildren.each do |c|
-          treeKeys << c.name_key
-        end
-
-      end
-      Rails.logger.debug("*** treeKeys: #{treeKeys.inspect}")
-      @trees.each do |t|
-        # get translation key for this item
-        treeKeys << t.name_key
-        # get translation key for each sector, big idea and misconception for this item
-        if treeKeys
-          t.sector_trees.each do |st|
-            treeKeys << st.sector.name_key
-            treeKeys << st.explanation_key
-          end
-          t.dim_trees.each do |dt|
-            treeKeys << dt.dimension.dim_name_key
-            treeKeys << dt.dim_explanation_key
-          end
-        end
-        # get translation key for each related item for this item
-        t.tree_referencers.each do |r|
-          rTree = r.tree_referencee
-          treeKeys << rTree.name_key
-          treeKeys << r.explanation_key
-          subCode = @subjById[rTree.subject_id]
-          @relatedBySubj[subCode] << {
-            code: rTree.code,
-            relationship: ((r.relationship == 'depends') ? r.relationship+' on' : r.relationship+' to'),
-            tkey: rTree.name_key,
-            explanation: r.explanation_key,
-            tid: (rTree.depth < 2) ? 0 : rTree.id
-          } if !@relatedBySubj[subCode].include?(rTree.code)
-        end
-        treeKeys << "#{t.base_key}.explain"
-        @tree_items_to_display << t
-      end
-      @translations = Translation.translationsByKeys(@locale_code, treeKeys)
     end
     respond_to do |format|
       format.html
@@ -801,6 +766,11 @@ class TreesController < ApplicationController
         @tree_tree.active = tree_tree_params[:active]
         @reciprocal_tree_tree.active = tree_tree_params[:active]
         save_translation = false if (tree_tree_params[:active].to_s == 'false')
+      elsif update == 'sectortree'
+        @rel = SectorTree.find(tree_params[:attr_id])
+        name_key = @rel.explanation_key
+        @rel.active = sector_tree_params[:active]
+        save_translation = false if (sector_tree_params[:active].to_s == 'false')
       end #if update type is 'outcome', 'indicator', etc
 
       translation_matches = Translation.where(
@@ -822,6 +792,7 @@ class TreesController < ApplicationController
            @translation.save! if save_translation
            @tree_tree.save! if @tree_tree
            @reciprocal_tree_tree.save! if @reciprocal_tree_tree
+           @rel.save! if (@rel && !save_translation)
          rescue ActiveRecord::StatementInvalid => e
            errors << e
          end
@@ -888,6 +859,12 @@ class TreesController < ApplicationController
       :tree_referencer_id,
       :tree_referencee_id,
       :relationship,
+      :active
+    )
+  end
+
+  def sector_tree_params
+    params.require(:sector_tree).permit(
       :active
     )
   end

--- a/app/controllers/trees_controller.rb
+++ b/app/controllers/trees_controller.rb
@@ -608,7 +608,7 @@ class TreesController < ApplicationController
       editMe = params['editme']
       @editMe = false
       # turn off detail editing page for now
-      if editMe && editMe == @tree.id.to_s
+      if editMe && editMe == @tree.id.to_s && current_user.present?
         @editMe = true
       end
       # Rails.logger.debug("*** @editMe: #{@editMe.inspect}")
@@ -705,8 +705,7 @@ class TreesController < ApplicationController
         @rel = TreeTree.find(tree_params[:attr_id])
         expl_key = @rel.explanation_key
         @tree_referencee = @rel.tree_referencee
-        @tree_referencee_code = I18n.t("trees.labels.#{@tree_referencee.subject.code}")
-        + ".#{@tree_referencee.code}"
+        @tree_referencee_code = I18n.t("trees.labels.#{@tree_referencee.subject.code}") + " #{@tree_referencee.code}"
         translation = Translation.translationsByKeys(
           @locale_code,
           expl_key

--- a/app/controllers/trees_controller.rb
+++ b/app/controllers/trees_controller.rb
@@ -713,7 +713,7 @@ class TreesController < ApplicationController
           expl_key
         )
         @explanation = translation[expl_key]
-      elsif @edit_type == "sectortree"
+      elsif @edit_type == "sector"
         @rel = SectorTree.find(tree_params[:attr_id])
         @attr_id = @rel.id
         expl_key = @rel.explanation_key
@@ -763,14 +763,14 @@ class TreesController < ApplicationController
           ).first
         name_key = @tree_tree.explanation_key
         @tree_tree.relationship = tree_tree_params[:relationship] if tree_tree_params[:relationship]
-        @tree_tree.active = tree_tree_params[:active]
-        @reciprocal_tree_tree.active = tree_tree_params[:active]
+        @tree_tree.active = tree_params[:active]
+        @reciprocal_tree_tree.active = tree_params[:active]
         save_translation = false if (tree_tree_params[:active].to_s == 'false')
-      elsif update == 'sectortree'
+      elsif update == 'sector'
         @rel = SectorTree.find(tree_params[:attr_id])
         name_key = @rel.explanation_key
-        @rel.active = sector_tree_params[:active]
-        save_translation = false if (sector_tree_params[:active].to_s == 'false')
+        @rel.active = tree_params[:active]
+        save_translation = false if (tree_params[:active].to_s == 'false')
       end #if update type is 'outcome', 'indicator', etc
 
       translation_matches = Translation.where(
@@ -792,7 +792,7 @@ class TreesController < ApplicationController
            @translation.save! if save_translation
            @tree_tree.save! if @tree_tree
            @reciprocal_tree_tree.save! if @reciprocal_tree_tree
-           @rel.save! if (@rel && !save_translation)
+           @rel.save! if @rel
          rescue ActiveRecord::StatementInvalid => e
            errors << e
          end
@@ -837,7 +837,8 @@ class TreesController < ApplicationController
       :dimension_id,
       :edit_type,
       :attr_id,
-      :name_translation
+      :name_translation,
+      :active
     )
   end
 
@@ -859,12 +860,6 @@ class TreesController < ApplicationController
       :tree_referencer_id,
       :tree_referencee_id,
       :relationship,
-      :active
-    )
-  end
-
-  def sector_tree_params
-    params.require(:sector_tree).permit(
       :active
     )
   end

--- a/app/models/dimension.rb
+++ b/app/models/dimension.rb
@@ -3,6 +3,10 @@ class Dimension < BaseRec
   # dim_type field valid options
   BIG_IDEA = 'bigidea'
   MISCONCEPTION = 'miscon'
+  QUESTION = 'question'
+  CONCEPT = 'concept'
+  COMPETENCY = 'comp'
+  STANDARD = 'standard'
   VAL_DIM_TYPES = [BIG_IDEA, MISCONCEPTION]
   DIM_TYPE_KEYS = {BIG_IDEA => 'trees.bigidea.title', MISCONCEPTION => 'trees.miscon.title'}
 

--- a/app/models/sector_tree.rb
+++ b/app/models/sector_tree.rb
@@ -1,4 +1,6 @@
 class SectorTree < BaseRec
   belongs_to :sector
   belongs_to :tree
+
+  scope :active, -> { where(:active => true) }
 end

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -68,28 +68,6 @@
       </li>
     <%
     end
-    if action_name == 'big_ideas' %>
-      <li class="nav-item active" aria-selected='true'>
-        <a class="nav-link btn btn-primary" href=<%= dimensions_trees_path(dim_type: Dimension::BIG_IDEA) %>>
-          <%= translate('nav_bar.big_ideas.name') %></a>
-      </li>
-    <% else %>
-      <li class="nav-item" role='menuitem'>
-        <a class="nav-link btn btn-primary" href=<%= dimensions_trees_path(dim_type: Dimension::BIG_IDEA) %>><%= translate('nav_bar.big_ideas.name') %></a>
-      </li>
-    <%
-    end
-    if action_name == 'misconceptions' %>
-      <li class="nav-item active" aria-selected='true'>
-        <a class="nav-link btn btn-primary" href=<%= dimensions_trees_path(dim_type: Dimension::MISCONCEPTION) %>>
-          <%= translate('nav_bar.misconceptions.name') %></a>
-      </li>
-    <% else %>
-      <li class="nav-item" role='menuitem'>
-        <a class="nav-link btn btn-primary" href=<%= dimensions_trees_path(dim_type: Dimension::MISCONCEPTION) %>><%= translate('nav_bar.misconceptions.name') %></a>
-      </li>
-    <%
-    end
     if controller.controller_name == 'trees' && action_name == 'sequence' %>
       <li class="nav-item active" aria-selected='true'>
         <a class="nav-link btn btn-primary" href=<%= sequence_trees_path %>><%= translate('trees.sequencing.title') %></a>
@@ -98,8 +76,35 @@
       <li class="nav-item" role='menuitem'>
         <a class="nav-link btn btn-primary" href=<%= sequence_trees_path %>><%= translate('trees.sequencing.title') %></a>
       </li>
+    <% end %>
+    <li class="nav-item" role='menuitem'>
+      <button class="btn btn-primary dropdown-toggle" type="button" data-toggle="dropdown" title=<%= translate('nav_bar.connections.hover') %>>
+        <%= translate('nav_bar.connections.name') %>
+        <span class="caret"></span>
+      </button>
+      <ul class="dropdown-menu">
+        <li class="nav-item" role='menuitem'>
+        <a class="nav-link btn btn-primary" href=<%= dimensions_trees_path(dim_type: Dimension::BIG_IDEA) %>><%= translate('nav_bar.big_ideas.name') %></a>
+        </li>
+        <li class="nav-item" role='menuitem'>
+          <a class="nav-link btn btn-primary" href=<%= dimensions_trees_path(dim_type: Dimension::MISCONCEPTION) %>><%= translate('nav_bar.misconceptions.name') %></a>
+        </li>
+        <li class="nav-item" role='menuitem'>
+        <a class="nav-link btn btn-primary" href="#"><%= translate('nav_bar.questions.name') %></a>
+        </li>
+        <li class="nav-item active" role='menuitem'>
+        <a class="nav-link btn btn-primary" href="#">
+          <%= translate('nav_bar.concepts.name') %></a>
+        </li>
+        <li class="nav-item" role='menuitem'>
+        <a class="nav-link btn btn-primary" href="#"><%= translate('nav_bar.competencies.name') %></a>
+        </li>
+        <li class="nav-item" role='menuitem'>
+        <a class="nav-link btn btn-primary" href="#"><%= translate('nav_bar.standards.name') %></a>
+        </li>
+      </ul>
+    </li>
     <%
-    end
     if current_user.present? && current_user.is_admin?
       if controller.controller_name == 'uploads'
     %>

--- a/app/views/trees/_edit.html.erb
+++ b/app/views/trees/_edit.html.erb
@@ -6,33 +6,38 @@
 <%= form_for(@tree) do |f| %>
   <div class="hidden_fields">
     <%= f.hidden_field :code, name: 'tree[edit_type]', value: @edit_type %>
-    <%= f.hidden_field :code, name: 'tree[attr_id]', value: @indicator.id if (@edit_type == 'indicator') %>
-    <%= f.hidden_field :code, name: 'tree[attr_id]', value: @rel.id if (@edit_type == 'treetree') %>
+    <%= f.hidden_field :code, name: 'tree[attr_id]', value: @attr_id  if (@edit_type != 'outcome') %>
   </div>
+  <!--feilds for editing the Outcome and Indicator text-->
 	<% if @edit_type == 'outcome' || @edit_type == 'indicator' %>
 	<fieldset>
 	  <label for='name_translation' class="pull-left"><%= @edit_type == "outcome"  ? "#{I18n.translate('app.labels.outcome')}:" : "#{I18n.translate('app.labels.indicator')}:" %></label>
   	<%= f.text_area :name_translation, name: 'tree[name_translation]', id: 'name_translation', style: {className: "pull-left"}, value: @translation  %>
   </fieldset>
-  <% elsif @edit_type == 'treetree' %>
+  <!--build fields for editing treetree and sectortree relationships-->
+  <% elsif @edit_type == 'treetree' || @edit_type == 'sectortree' %>
   <fieldset>
     <label for='relationship'><%= translate('trees.labels.relation') %></label>
     <div>
     <span class="stack"><%= I18n.t("trees.labels.#{@tree.subject.code}") + " " + @tree.code %></span>
-    <select id="relationship" name="tree_tree[relationship]" class="stack">
-      <option value="<%= TreeTree::APPLIES_KEY %>"
-        <%= ' selected' if @rel.relationship == TreeTree::APPLIES_KEY %>>
-      	<%= I18n.translate('trees.labels.relation_types.applies') %>
-      </option>
-      <option value="<%= TreeTree::DEPENDS_KEY %>"
-        <%= ' selected' if @rel.relationship == TreeTree::DEPENDS_KEY %>>
-      	<%= I18n.translate('trees.labels.relation_types.depends') %>
-      </option>
-      <option value="<%= TreeTree::AKIN_KEY %>"
-        <%= ' selected' if @rel.relationship == TreeTree::AKIN_KEY %>>
-      	<%= I18n.translate('trees.labels.relation_types.akin') %>
-      </option>
-    </select>
+    <% if @edit_type == 'treetree' %>
+	    <select id="relationship" name="tree_tree[relationship]" class="stack">
+	      <option value="<%= TreeTree::APPLIES_KEY %>"
+	        <%= ' selected' if @rel.relationship == TreeTree::APPLIES_KEY %>>
+	      	<%= I18n.translate('trees.labels.relation_types.applies') %>
+	      </option>
+	      <option value="<%= TreeTree::DEPENDS_KEY %>"
+	        <%= ' selected' if @rel.relationship == TreeTree::DEPENDS_KEY %>>
+	      	<%= I18n.translate('trees.labels.relation_types.depends') %>
+	      </option>
+	      <option value="<%= TreeTree::AKIN_KEY %>"
+	        <%= ' selected' if @rel.relationship == TreeTree::AKIN_KEY %>>
+	      	<%= I18n.translate('trees.labels.relation_types.akin') %>
+	      </option>
+	    </select>
+    <% elsif @edit_type == 'sectortree' %>
+      <label class="stack"> - <%= I18n.t('trees.bigidea.relates_to') %> - </label>
+    <% end %>
     <span class="stack"><%= @tree_referencee_code %></span>
     </div>
   </fieldset>
@@ -43,8 +48,8 @@
     </div>
   </fieldset>
   <fieldset>
-    <label for="tree_tree[active]">Active?</label>
-      <input name="tree_tree[active]" type="checkbox"
+    <label for="<%= @edit_type == 'treetree' ? 'tree' : 'sector' %>_tree[active]">Active?</label>
+      <input name="<%= @edit_type == 'treetree' ? 'tree' : 'sector' %>_tree[active]" type="checkbox"
         <%= @rel.active ? ' checked' : '' %>></input>
   </fieldset>
 

--- a/app/views/trees/_edit.html.erb
+++ b/app/views/trees/_edit.html.erb
@@ -14,8 +14,8 @@
 	  <label for='name_translation' class="pull-left"><%= @edit_type == "outcome"  ? "#{I18n.translate('app.labels.outcome')}:" : "#{I18n.translate('app.labels.indicator')}:" %></label>
   	<%= f.text_area :name_translation, name: 'tree[name_translation]', id: 'name_translation', style: {className: "pull-left"}, value: @translation  %>
   </fieldset>
-  <!--build fields for editing treetree and sectortree relationships-->
-  <% elsif @edit_type == 'treetree' || @edit_type == 'sectortree' %>
+  <!--build fields for editing treetree and sector relationships-->
+  <% elsif @edit_type == 'treetree' || @edit_type == 'sector' %>
   <fieldset>
     <label for='relationship'><%= translate('trees.labels.relation') %></label>
     <div>
@@ -35,7 +35,7 @@
 	      	<%= I18n.translate('trees.labels.relation_types.akin') %>
 	      </option>
 	    </select>
-    <% elsif @edit_type == 'sectortree' %>
+    <% elsif @edit_type == 'sector' %>
       <label class="stack"> - <%= I18n.t('trees.bigidea.relates_to') %> - </label>
     <% end %>
     <span class="stack"><%= @tree_referencee_code %></span>
@@ -49,7 +49,7 @@
   </fieldset>
   <fieldset>
     <label for="<%= @edit_type == 'treetree' ? 'tree' : 'sector' %>_tree[active]">Active?</label>
-      <input name="<%= @edit_type == 'treetree' ? 'tree' : 'sector' %>_tree[active]" type="checkbox"
+      <input name="tree[active]" type="checkbox"
         <%= @rel.active ? ' checked' : '' %>></input>
   </fieldset>
 

--- a/app/views/trees/_edit.html.erb
+++ b/app/views/trees/_edit.html.erb
@@ -18,8 +18,8 @@
   <fieldset>
     <label for='relationship'><%= translate('trees.labels.relation') %></label>
     <div>
-    <%= I18n.t("trees.labels.#{@tree.subject.code}") + " " + @tree.code %>
-    <select id="relationship" name="tree_tree[relationship]">
+    <span class="stack"><%= I18n.t("trees.labels.#{@tree.subject.code}") + " " + @tree.code %></span>
+    <select id="relationship" name="tree_tree[relationship]" class="stack">
       <option value="<%= TreeTree::APPLIES_KEY %>"
         <%= ' selected' if @rel.relationship == TreeTree::APPLIES_KEY %>>
       	<%= I18n.translate('trees.labels.relation_types.applies') %>
@@ -33,7 +33,7 @@
       	<%= I18n.translate('trees.labels.relation_types.akin') %>
       </option>
     </select>
-    <%= @tree_referencee_code %>
+    <span class="stack"><%= @tree_referencee_code %></span>
     </div>
   </fieldset>
   <fieldset>

--- a/app/views/trees/show.html.erb
+++ b/app/views/trees/show.html.erb
@@ -24,7 +24,7 @@
           <% if @editMe %>
             <span class='font-weight-bold'>Editing</span>
           <% else %>
-            <%= link_to("Edit LO", tree_path(@tree.id, editme: @tree.id) ) %>
+            <%= link_to("Edit LO", tree_path(@tree.id, editme: @tree.id) ) if current_user.present? %>
             <!-- # %= link_to("Edit LO", edit_tree_path(@tree.id), {:remote => true, 'data-toggle' =>  "modal", 'data-target' => '#modal_popup'}) % -->
           <% end %>
         </div>
@@ -162,7 +162,7 @@
             </div>
             <div class='col col-lg-6 rel-reason-col val'>
               <%= @translations["#{st.explanation_key}"] %>
-              <% if @editMe %>
+              <% if @editMe && false %>
                 <a href="#"><span class="pull-right">
                   <i class="fa fa-times fa-lg"></i>
                 </span></a>

--- a/app/views/trees/show.html.erb
+++ b/app/views/trees/show.html.erb
@@ -162,14 +162,9 @@
             </div>
             <div class='col col-lg-6 rel-reason-col val'>
               <%= @translations["#{st.explanation_key}"] %>
-              <% if @editMe && false %>
-                <a href="#"><span class="pull-right">
-                  <i class="fa fa-times fa-lg"></i>
-                </span></a>
-                <%= link_to 'Edit LO', edit_tree_path(st.id),  {:remote => true, 'data-toggle' =>  "modal", 'data-target' => '#modal_popup'}  %>
-                <a href="#"><span class="pull-right">
-                  <i class="fa fa-edit fa-lg"></i>
-                </span></a>
+              <% if @editMe %>
+                <%= link_to(fa_icon("times"), tree_path(@tree.id, tree: { edit_type: 'sectortree', attr_id: st[:id]}, sector_tree: {active: false}), {:class => "fa-lg pull-right", method: :patch}) if @editMe %>
+                  <%= link_to(fa_icon("edit"), edit_tree_path(@tree.id, tree: { edit_type: 'sectortree', attr_id: st[:id]}), {:remote => true, :class => "fa-lg pull-right", 'data-toggle' =>  "modal", 'data-target' => '#modal_popup'}) if @editMe %>
               <% end %>
             </div>
           </div>

--- a/app/views/trees/show.html.erb
+++ b/app/views/trees/show.html.erb
@@ -143,7 +143,7 @@
             <%= I18n.t('trees.labels.how_sectors_related') %>
           </div>
         </div>
-        <% tree.sector_trees.each do |st| %>
+        <% tree.sector_trees.active.each do |st| %>
           <div class='row'>
             <div class='col col-lg-6 rel-sectors'>
               <%= link_to(
@@ -163,8 +163,8 @@
             <div class='col col-lg-6 rel-reason-col val'>
               <%= @translations["#{st.explanation_key}"] %>
               <% if @editMe %>
-                <%= link_to(fa_icon("times"), tree_path(@tree.id, tree: { edit_type: 'sectortree', attr_id: st[:id]}, sector_tree: {active: false}), {:class => "fa-lg pull-right", method: :patch}) if @editMe %>
-                  <%= link_to(fa_icon("edit"), edit_tree_path(@tree.id, tree: { edit_type: 'sectortree', attr_id: st[:id]}), {:remote => true, :class => "fa-lg pull-right", 'data-toggle' =>  "modal", 'data-target' => '#modal_popup'}) if @editMe %>
+                <%= link_to(fa_icon("times"), tree_path(@tree.id, tree: { edit_type: 'sector', attr_id: st[:id], active: false}, sector_tree: {active: false}), {:class => "fa-lg pull-right", method: :patch}) if @editMe %>
+                  <%= link_to(fa_icon("edit"), edit_tree_path(@tree.id, tree: { edit_type: 'sector', attr_id: st[:id]}), {:remote => true, :class => "fa-lg pull-right", 'data-toggle' =>  "modal", 'data-target' => '#modal_popup'}) if @editMe %>
               <% end %>
             </div>
           </div>
@@ -233,7 +233,7 @@
               <div class='connections-item'>
                 <%= @translations[r[:explanation]] %>
                 <% if @editMe %>
-                  <%= link_to(fa_icon("times"), tree_path(@tree.id, tree: { edit_type: 'treetree', attr_id: r[:ttid]}, tree_tree: {active: false}), {:class => "fa-lg pull-right", method: :patch}) if @editMe %>
+                  <%= link_to(fa_icon("times"), tree_path(@tree.id, tree: { edit_type: 'treetree', attr_id: r[:ttid], active: false}, tree_tree: {active: false}), {:class => "fa-lg pull-right", method: :patch}) if @editMe %>
                   <%= link_to(fa_icon("edit"), edit_tree_path(@tree.id, tree: { edit_type: 'treetree', attr_id: r[:ttid]}), {:remote => true, :class => "fa-lg pull-right", 'data-toggle' =>  "modal", 'data-target' => '#modal_popup'}) if @editMe %>
                 <% end %>
               </div>

--- a/config/locales/pages.en.yml
+++ b/config/locales/pages.en.yml
@@ -43,6 +43,7 @@ en:
       sector_related_explain: "Sectors Related Explanation"
       subject_related_explain: "Subjects Related Explanation"
       explanation: "Explanation"
+      sector_num: "Sector %{num}"
     roles:
       name: 'Roles'
       admin:
@@ -83,12 +84,27 @@ en:
     sectors:
       name: "Future Sectors"
       hover: "Displays the Curriculum by Future Sectors"
+    connections:
+      name: "Connections"
+      hover: "dropdown"
     big_ideas:
       name: "Big Ideas"
       hover: ""
     misconceptions:
       name: "Misconceptions"
       hover: "Displays Misconceptions"
+    questions:
+      name: "Essential Questions"
+      hover: "Displays Essential Questions"
+    concepts:
+      name: "Concepts"
+      hover: "Displays Concepts"
+    competencies:
+      name: "Competencies"
+      hover: "Displays Competencies"
+    standards:
+      name: "Standards"
+      hover: "Displays Standards"
     documents:
       name: "Documents"
       hover: "Documents Management for Administrators"

--- a/config/locales/pages.tr.yml
+++ b/config/locales/pages.tr.yml
@@ -30,6 +30,7 @@ tr:
       gen_list: "Liste Oluştur"
       sector: "Gelecek Vizyonu"
       explanation: "Açıklama"
+      sector_num: "Sektör %{num}"
   nav_bar:
     home:
       name: "Ev"
@@ -40,12 +41,27 @@ tr:
     sectors:
       name: "Gelecek Sektörler"
       hover: "Gelecekteki Sektörlere Göre Müfredatı görüntüler"
+    connections:
+      name: "Bağlantılar"
+      hover: "açılır"
     big_ideas:
       name: "Büyük Fikirler"
       hover: ""
     misconceptions:
       name: "Yanılgılar"
       hover: ""
+    questions:
+      name: "Temel sorular"
+      hover: "Temel Soruları görüntüler"
+    concepts:
+      name: "Kavramlar"
+      hover: "Kavramları görüntüler"
+    competencies:
+      name: "Yeterlilikleri"
+      hover: "Yetkinlikleri görüntüler"
+    standards:
+      name: "Standartlar"
+      hover: "Standartları görüntüler"
     documents:
       name: "Belge"
       hover: "Yöneticiler İçin Belge Yönetimi"


### PR DESCRIPTION
On the LO Detail page:
- adds functional edit/deactivate SectorTree buttons
- does not give edit options unless user is logged in

On the Future Sectors page:
- does not show inactive SectorTree connections

In the Nav Bar
- Adds nonfunctional "Essential Questions", "Concepts", "Competencies", and "Standards" options (these were requested by Joe)
- Bundles the new options (along with Big Ideas and Misconceptions) into a dropdown menu in the nav, called "Connections"

This update makes the assumption that the new Nav Bar options will be Dimension types, and added dimension type constants to the Dimensions.rb model.