### PR TITLE
Allow Big Idea and Misconception connections to be edited on the LO detail page

### DIFF
--- a/app/controllers/trees_controller.rb
+++ b/app/controllers/trees_controller.rb
@@ -713,16 +713,19 @@ class TreesController < ApplicationController
           expl_key
         )
         @explanation = translation[expl_key]
-      elsif @edit_type == "sector"
-        @rel = SectorTree.find(tree_params[:attr_id])
+      elsif @edit_type == "sector" || @edit_type == "dimtree"
+        @rel = SectorTree.find(tree_params[:attr_id]) if (@edit_type == "sector")
+        @rel = DimTree.find(tree_params[:attr_id]) if (@edit_type == "dimtree")
         @attr_id = @rel.id
-        expl_key = @rel.explanation_key
+        expl_key = @edit_type == "sector" ? @rel.explanation_key : @rel.dim_explanation_key
+        name_key = @edit_type == "sector" ? @rel.sector.name_key : @rel.dimension.dim_name_key
         name_matches = Translation.where(
           :locale => @locale_code,
-          :key => @rel.sector.name_key
+          :key => name_key
           )
-        @sector_name = (name_matches.length > 0 ? ": #{name_matches.first.value}" : '')
-        @tree_referencee_code = "#{I18n.t('app.labels.sector_num', num: @rel.sector.code)}#{@sector_name}"
+        @rel_name = (name_matches.length > 0 ? ": #{name_matches.first.value}" : '')
+        @tree_referencee_code = "#{I18n.t('app.labels.sector_num', num: @rel.sector.code)}#{@rel_name}" if @edit_type == "sector"
+        @tree_referencee_code = "#{I18n.t("trees.#{@rel.dimension.dim_type}.singular")} #{@rel_name}" if @edit_type == "dimtree"
         translation = Translation.translationsByKeys(
           @locale_code,
           expl_key
@@ -766,10 +769,10 @@ class TreesController < ApplicationController
         @tree_tree.active = tree_params[:active]
         @reciprocal_tree_tree.active = tree_params[:active]
         save_translation = false if (tree_tree_params[:active].to_s == 'false')
-      elsif update == 'sector'
-        @rel = SectorTree.find(tree_params[:attr_id])
-        name_key = @rel.explanation_key
-        @rel.active = tree_params[:active]
+      elsif update == 'sector' || update == 'dimtree'
+        @rel = update == 'sector' ? SectorTree.find(tree_params[:attr_id]) : DimTree.find(tree_params[:attr_id])
+        name_key = update == 'sector' ? @rel.explanation_key : @rel.dim_explanation_key
+        @rel.active = tree_params[:active] if (update == 'sector')
         save_translation = false if (tree_params[:active].to_s == 'false')
       end #if update type is 'outcome', 'indicator', etc
 

--- a/app/views/trees/_edit.html.erb
+++ b/app/views/trees/_edit.html.erb
@@ -15,7 +15,7 @@
   	<%= f.text_area :name_translation, name: 'tree[name_translation]', id: 'name_translation', style: {className: "pull-left"}, value: @translation  %>
   </fieldset>
   <!--build fields for editing treetree and sector relationships-->
-  <% elsif @edit_type == 'treetree' || @edit_type == 'sector' %>
+  <% elsif @edit_type == 'treetree' || @edit_type == 'sector' || @edit_type == 'dimtree' %>
   <fieldset>
     <label for='relationship'><%= translate('trees.labels.relation') %></label>
     <div>
@@ -35,7 +35,7 @@
 	      	<%= I18n.translate('trees.labels.relation_types.akin') %>
 	      </option>
 	    </select>
-    <% elsif @edit_type == 'sector' %>
+    <% elsif @edit_type == 'sector' || @edit_type == 'dimtree' %>
       <label class="stack"> - <%= I18n.t('trees.bigidea.relates_to') %> - </label>
     <% end %>
     <span class="stack"><%= @tree_referencee_code %></span>
@@ -47,11 +47,13 @@
     <%= f.text_area :explanation, name: 'tree[name_translation]', id: 'explanation', value: @explanation %>
     </div>
   </fieldset>
+  <% if @edit_type != "dimtree" %>
   <fieldset>
     <label for="<%= @edit_type == 'treetree' ? 'tree' : 'sector' %>_tree[active]">Active?</label>
       <input name="tree[active]" type="checkbox"
         <%= @rel.active ? ' checked' : '' %>></input>
   </fieldset>
+  <% end %>
 
 	<% end #build fieldsets by @edit_type %>
 

--- a/app/views/trees/show.html.erb
+++ b/app/views/trees/show.html.erb
@@ -82,6 +82,10 @@
             </div>
             <div class='col col-lg-6 ind-col last-col'>
               <%= @translations[dt.dim_explanation_key] %>
+              <% if @editMe %>
+                <%= link_to(fa_icon("times"), tree_path(@tree.id, tree: { edit_type: 'dimtree', attr_id: dt[:id], active: false}, sector_tree: {active: false}), {:class => "fa-lg pull-right", method: :patch}) if @editMe %>
+                <%= link_to(fa_icon("edit"), edit_tree_path(@tree.id, tree: { edit_type: 'dimtree', attr_id: dt[:id]}), {:remote => true, :class => "fa-lg pull-right", 'data-toggle' =>  "modal", 'data-target' => '#modal_popup'}) if @editMe %>
+              <% end %>
             </div>
           </div>
         <%
@@ -115,6 +119,10 @@
             </div>
             <div class='col col-lg-6 ind-col last-col'>
               <%= @translations[dt.dim_explanation_key] %>
+              <% if @editMe %>
+                <%= link_to(fa_icon("times"), tree_path(@tree.id, tree: { edit_type: 'dimtree', attr_id: dt[:id], active: false}, sector_tree: {active: false}), {:class => "fa-lg pull-right", method: :patch}) if @editMe %>
+                <%= link_to(fa_icon("edit"), edit_tree_path(@tree.id, tree: { edit_type: 'dimtree', attr_id: dt[:id]}), {:remote => true, :class => "fa-lg pull-right", 'data-toggle' =>  "modal", 'data-target' => '#modal_popup'}) if @editMe %>
+              <% end %>
             </div>
           </div>
         <%
@@ -164,7 +172,7 @@
               <%= @translations["#{st.explanation_key}"] %>
               <% if @editMe %>
                 <%= link_to(fa_icon("times"), tree_path(@tree.id, tree: { edit_type: 'sector', attr_id: st[:id], active: false}, sector_tree: {active: false}), {:class => "fa-lg pull-right", method: :patch}) if @editMe %>
-                  <%= link_to(fa_icon("edit"), edit_tree_path(@tree.id, tree: { edit_type: 'sector', attr_id: st[:id]}), {:remote => true, :class => "fa-lg pull-right", 'data-toggle' =>  "modal", 'data-target' => '#modal_popup'}) if @editMe %>
+                <%= link_to(fa_icon("edit"), edit_tree_path(@tree.id, tree: { edit_type: 'sector', attr_id: st[:id]}), {:remote => true, :class => "fa-lg pull-right", 'data-toggle' =>  "modal", 'data-target' => '#modal_popup'}) if @editMe %>
               <% end %>
             </div>
           </div>


### PR DESCRIPTION
Allow Big Idea and Misconception connections to be edited on the LO detail page. Allows editing explanations of the connection-- "active" is not currently included in the dimtree schema.