### PR TITLE
Limit number of subjects displayed on the relations page.

### DIFF
--- a/app/assets/javascripts/sequence.js
+++ b/app/assets/javascripts/sequence.js
@@ -10,9 +10,18 @@ $(function() {
    * @param  {String} subj_abbr Abbreviation for a subject.
    *                            E.g. 'bio', 'phy', etc.
    */
-  subject_visibility = function (subj_abbr) {
+  subject_visibility = function (subj_abbr, max_subjs, err_translation) {
+    err_translation = err_translation || "Maximum number of subjects that can be displayed: " + max_subjs
+    var num_checked = $('.subj-checkbox>input:checked').length
   	if ($('#check-' + subj_abbr).prop('checked')) {
-  	   $('#'+subj_abbr+'-column').removeClass('hidden')
+      if (num_checked <= max_subjs) {
+        $('#'+subj_abbr+'-column').removeClass('hidden')
+      }
+      else {
+        $('#check-' + subj_abbr).prop("checked", false)
+        if (err_translation) alert(err_translation);
+        return
+      }
   	}
   	else {
   	   $('#'+subj_abbr+'-column').addClass('hidden')

--- a/app/controllers/trees_controller.rb
+++ b/app/controllers/trees_controller.rb
@@ -241,7 +241,7 @@ class TreesController < ApplicationController
 
   def sequence
     index_prep
-
+    @max_subjects = 6
     @s_o_hash = Hash.new  { |h, k| h[k] = [] }
     @indicator_hash = Hash.new { |h, k| h[k] = [] }
     listing = Tree.where(

--- a/app/controllers/trees_controller.rb
+++ b/app/controllers/trees_controller.rb
@@ -103,12 +103,12 @@ class TreesController < ApplicationController
       case depth
 
       when 1
-        newHash = {text: "#{I18n.translate('app.labels.grade_band')} #{tree.subCode}: #{translation}", id: "#{tree.id}", nodes: {}}
+        newHash = {text: "#{@hierarchies[0] if @hierarchies.length > 0} #{tree.subCode}: #{translation}", id: "#{tree.id}", nodes: {}}
         # add grade (band) if not there already
         treeHash[tree.codeArrayAt(0)] = newHash if !treeHash[tree.codeArrayAt(0)].present?
 
       when 2
-        newHash = {text: "#{I18n.translate('app.labels.area')} #{tree.codeArrayAt(1)}: #{translation}", id: "#{tree.id}", nodes: {}}
+        newHash = {text: "#{@hierarchies[1] if @hierarchies.length > 1} #{tree.codeArrayAt(1)}: #{translation}", id: "#{tree.id}", nodes: {}}
         puts ("+++ codeArray: #{tree.codeArray.inspect}")
         if treeHash[tree.codeArrayAt(0)].blank?
           raise I18n.t('trees.errors.missing_grade_in_tree')
@@ -117,7 +117,7 @@ class TreesController < ApplicationController
         addNodeToArrHash(treeHash[tree.codeArrayAt(0)], tree.subCode, newHash)
 
       when 3
-        newHash = {text: "#{I18n.translate('app.labels.component')} #{tree.codeArrayAt(2)}: #{translation}", id: "#{tree.id}", nodes: {}}
+        newHash = {text: "#{@hierarchies[2] if @hierarchies.length > 2} #{tree.codeArrayAt(2)}: #{translation}", id: "#{tree.id}", nodes: {}}
         puts ("+++ codeArray: #{tree.codeArray.inspect}")
         if treeHash[tree.codeArrayAt(0)].blank?
           raise I18n.t('trees.errors.missing_grade_in_tree')
@@ -128,7 +128,7 @@ class TreesController < ApplicationController
         addNodeToArrHash(treeHash[tree.codeArrayAt(0)][:nodes][tree.codeArrayAt(1)], tree.subCode, newHash)
 
       when 4
-        newHash = {text: "#{I18n.translate('app.labels.outcome')} #{tree.subCode}: #{translation}", id: "#{tree.id}", nodes: {}}
+        newHash = {text: "#{@hierarchies[3] if @hierarchies.length > 3} #{tree.subCode}: #{translation}", id: "#{tree.id}", nodes: {}}
         if treeHash[tree.codeArrayAt(0)].blank?
           raise I18n.t('trees.errors.missing_grade_in_tree')
         elsif treeHash[tree.codeArrayAt(0)][:nodes][tree.codeArrayAt(1)].blank?

--- a/app/controllers/uploads_controller.rb
+++ b/app/controllers/uploads_controller.rb
@@ -148,14 +148,14 @@ class UploadsController < ApplicationController
           if line_num == 0
             infoLine = line.split(',')
             begin
-              grade_band = Integer(infoLine[2])
+              grade_band = @treeTypeRec.code == "EGSTEMUNIV" ? infoLine[2].strip : Integer(infoLine[2])
             rescue ArgumentError, TypeError
               grade_band = 0
             end
             puts "grade_band: #{grade_band.inspect}"
             puts "@gradeBandRec.code: #{@gradeBandRec.code.inspect}"
             if grade_band.to_s != @gradeBandRec.code
-              puts "Abort"
+              puts "Abort (line 158)"
               flash[:alert] = "ERROR: Invalid grade_band: #{grade_band}"
               abortRun = true
               @abortRow = true
@@ -434,7 +434,7 @@ class UploadsController < ApplicationController
     errors = []
     codes.each_with_index do |code, ix|
       begin
-        numCode = Integer(code)
+        numCode = @treeTypeRec.code == "EGSTEMUNIV" ? code : Integer(code)
         numCodes << numCode
       rescue
         numCodes << -1

--- a/app/views/trees/sequence.html.erb
+++ b/app/views/trees/sequence.html.erb
@@ -86,7 +86,7 @@
             <% end %>
             <% if k[:connections].length > 0 %>
               <div class="connections-div hide-if-collapsed" data-connections="<%= k[:connections].pluck(:tree_referencee_id) %>">
-              <div><strong class='hide-unless-condition'><%= translate('trees.labels.outcome_connections') %></strong>
+              <div><strong class='hide-unless-condition'><%= I18n.t('trees.labels.outcome_connections', outcome: (@hierarchies[3].pluralize if @hierarchies.length > 3)) %></strong>
               </div>
                 <% k[:connections].each do |c| %>
                   <% if c.active %>

--- a/app/views/trees/sequence.html.erb
+++ b/app/views/trees/sequence.html.erb
@@ -33,9 +33,12 @@
         <% end %>
       <% end #iterate through @gradebands %>
     </div>
+    <% subj_counter = 0 %>
+    <% subj_default_count = 3 %>
     <% @s_o_hash.keys.each do |i| %>
+      <% subj_counter += 1 %>
       <div class='subj-checkbox'>
-        <input id="check-<%= i %>" type="checkbox" onchange='subject_visibility("<%= i %>");' checked></input>
+        <input id="check-<%= i %>" type="checkbox" onchange='subject_visibility("<%= i %>", <%= @max_subjects %>, "<%= I18n.t('app.errors.max_subj_display_count', num: @max_subjects) %>");' <%= subj_counter <= subj_default_count ? "checked" : "" %>></input>
         <label for="check-<%= i %>">
           <%= @subjectByCode[i][:abbr] %>
         </label>
@@ -58,10 +61,12 @@
     <% end %>
   </div>
 </div>
+<% subj_counter = 0 %>
 <div id="trees" class="sequence-page">
-  <div class="sequence-grid cols-<%= @s_o_hash.keys.count %>">
+  <div class="sequence-grid cols-<%= subj_default_count %>">
 	<% @s_o_hash.each do |i, j| %>
-    <div id="<%=i%>-column" class="sequence-item subject-column">
+    <% subj_counter += 1 %>
+    <div id="<%=i%>-column" class="sequence-item subject-column<%= subj_counter > subj_default_count ? " hidden" : "" %>">
       <ul class="list-group">
         <li class="sequence-header"><%= Translation.where(locale: @locale_code, key: @subjects[i].base_key + ".name").first.value %></li>
         <% j.each do |k| %>

--- a/app/views/trees/show.html.erb
+++ b/app/views/trees/show.html.erb
@@ -13,18 +13,18 @@
     <div class='detail-page'>
 
       <!-- Display the translated descriptions of all parents for this item (Grade, Unit, Chapter, Outcome)  -->
-      <div class='row subject-grade-row'><div class='col col-lg-12 text-left'><%= I18n.translate('app.labels.grade_band') %>: <%= tree.grade_band.code %></div></div>
-      <div class='row area-row'><div class='col col-lg-12 text-left'><%= "#{I18n.translate('app.labels.area')} #{tree.codeArrayAt(1)}: #{@translations[area.buildNameKey]}" %></div></div>
-      <div class='row component-row'><div class='col col-lg-12 text-left'><%= "#{I18n.translate('app.labels.component')} #{tree.codeArrayAt(2)}: #{@translations[component.buildNameKey]}" %></div></div>
+      <div class='row subject-grade-row'><div class='col col-lg-12 text-left'><%= @hierarchies[0] if @hierarchies.length > 0 %>: <%= tree.grade_band.code %></div></div>
+      <div class='row area-row'><div class='col col-lg-12 text-left'><%= "#{@hierarchies[1] if @hierarchies.length > 1} #{tree.codeArrayAt(1)}: #{@translations[area.buildNameKey]}" %></div></div>
+      <div class='row component-row'><div class='col col-lg-12 text-left'><%= "#{@hierarchies[2] if @hierarchies.length > 2} #{tree.codeArrayAt(2)}: #{@translations[component.buildNameKey]}" %></div></div>
       <div class='row outcome-row'>
-        <div class='col col-lg-6 text-left'><%= "#{I18n.translate('app.labels.outcome')} #{tree.codeArrayAt(3)}: #{@translations[outcome.buildNameKey]}" %>
+        <div class='col col-lg-6 text-left'><%= "#{@hierarchies[3] if @hierarchies.length > 3} #{tree.codeArrayAt(3)}: #{@translations[outcome.buildNameKey]}" %>
           <%= link_to(fa_icon("edit"), edit_tree_path(@tree.id, tree: { edit_type: 'outcome'}), {:remote => true, 'data-toggle' =>  "modal", 'data-target' => '#modal_popup'}) if @editMe %>
         </div>
         <div class='col col-lg-6 text-right'>
           <% if @editMe %>
             <span class='font-weight-bold'>Editing</span>
           <% else %>
-            <%= link_to("Edit #{I18n.t('app.labels.outcome')}", tree_path(@tree.id, editme: @tree.id) ) if current_user.present? %>
+            <%= link_to("Edit #{@hierarchies[3] if @hierarchies.length > 3}", tree_path(@tree.id, editme: @tree.id) ) if current_user.present? %>
             <!-- # %= link_to("Edit LO", edit_tree_path(@tree.id), {:remote => true, 'data-toggle' =>  "modal", 'data-target' => '#modal_popup'}) % -->
           <% end %>
         </div>
@@ -183,7 +183,7 @@
       <div class='related-items-table'>
         <div class='row subject-relations center-label-bold top-label'>
           <div class='col col-lg-12'>
-            <%= I18n.t('trees.labels.outcome_connections') %>
+            <%= I18n.t('trees.labels.outcome_connections', outcome: (@hierarchies[3].pluralize if @hierarchies.length > 3)) %>
               <% if @editMe && false %>
                 <a href="#"><span class="pull-right">
                   <i class="fa fa-plus-square fa-lg"></i>

--- a/config/locales/pages.en.yml
+++ b/config/locales/pages.en.yml
@@ -180,7 +180,7 @@ en:
       related_sectors: 'Related Sectors'
       how_sectors_related: 'How Sector is Related'
       indicator_connections: 'Connections to Other Explanations:'
-      outcome_connections: 'Connections to Other Attainments:'
+      outcome_connections: 'Connections to Other %{outcome}:'
       relation: 'Relation'
       how_outcome_related: 'How Attainment is Related'
       relation_types:

--- a/config/locales/pages.en.yml
+++ b/config/locales/pages.en.yml
@@ -74,6 +74,7 @@ en:
       missing_tree_type_code: "error - invalid Tree Type Code"
       missing_version_record: "error - missing Version Record"
       missing_version_code: "error - invalid Version Code"
+      max_subj_display_count: "A maximum of %{num} subjects can be displayed at once."
   home:
     name: "Curriculum Home Page"
     title: "Curriculum Home Page"

--- a/config/locales/pages.tr.yml
+++ b/config/locales/pages.tr.yml
@@ -34,6 +34,8 @@ tr:
       sector: "Gelecek Vizyonu"
       explanation: "Açıklama"
       sector_num: "Sektör %{num}"
+      errors:
+        max_subj_display_count: "Bir defada en fazla %{num} konu görüntülenebilir."
   nav_bar:
     home:
       name: "Ev"

--- a/config/upload_files/EGSTEMUNIVBioFreshEng.txt
+++ b/config/upload_files/EGSTEMUNIVBioFreshEng.txt
@@ -1,0 +1,17 @@
+en,bio,fresh
+fresh Freshman
+fresh.1 Majors Biological Principals
+fresh.1.1 Unit 1
+fresh.1.1.1 STEM Teacher should be able to overview the prior knowledge of STEM students about biological pollution hazards via quizzes, observation cards, reviews, posters, and oral presentations
+fresh.1.1.2 STEM Teacher should be able to detect, identify and document biological pollutants via figures, photos, videos and maps
+fresh.1.1.3 STEM Teacher should be able to analyze the impact of pollutants on forms, cellular and genetic structure of living organisms as microorganisms, plants, animals and human via field trips to compare in reports between polluted and non-polluted ecosystems
+fresh.1.1.4 STEM Teacher should be able to create, supervise and evaluate projects participating in solving pollution challenges via research article
+fresh.2 Majors Organismal Biology
+fresh.2.1 Unit 1
+fresh.2.1.1 Explain the main definitions and concept of evolution
+fresh.2.1.2 Analyze the main forms of evolution referring to some examples in animal life and plants
+fresh.2.1.3 Apply the newly gained knowledge of different evolution activities
+fresh.2.1.4 Observe some examples from morphological, anatomical and genetic structures relating them to their functions
+fresh.2.1.5 Synthesize and evaluate the concept of evolution as reflecting change over time and how to show the relationship between the climte and environmnetal changes
+fresh.2.1.6 Explain and clarify that evolution is not against religious beliefs
+fresh.2.1.7 Analyze the main genetic changes that occur because of evolution

--- a/config/upload_files/EGSTEMUNIVCheFreshEng.txt
+++ b/config/upload_files/EGSTEMUNIVCheFreshEng.txt
@@ -1,0 +1,18 @@
+en,che,fresh
+fresh Freshman
+fresh.1 Chemistry Semester 1
+fresh.1.1 Unit 1
+fresh.1.1.1 Use the periodic table to predict the properties of elements
+fresh.1.1.2 Represent data on data tables and graphs correctly
+fresh.1.1.3 Conduct, analyze a series of measurements and evaluate the scientific reports with values of significant figures
+fresh.1.1.4 Conduct spectral analysis
+fresh.1.1.5 Use the appropriate laboratory procedures to determine the concentration of analyte
+fresh.1.2 Unit 2
+fresh.1.2.1 Students can compare between organic and inorganic compounds
+fresh.1.2.2 Distinguish between molecular, structural, and empirical formula
+fresh.2 Chemistry Semester 2
+fresh.2.1 Unit 1
+fresh.2.1.1 Determine the formulas, including the charges for common polyatomic ions
+fresh.2.1.2 Construct several electrochemical cells to study redox reactions
+fresh.2.1.3 Explain how the structure and bonding of carbon to the diversity and number of organic compounds
+fresh.2.1.4 Explain the relationships between the properties and structures of organic compounds with various functional groups

--- a/lib/tasks/seed_eg_stem.rake
+++ b/lib/tasks/seed_eg_stem.rake
@@ -10,7 +10,7 @@ namespace :seed_eg_stem do
     myTreeType = TreeType.where(code: 'EGSTEMUNIV')
     myTreeTypeValues = {
       code: 'EGSTEMUNIV',
-      hierarchy_codes: 'sem,unit,lo',
+      hierarchy_codes: 'grade,sem,unit,lo',
       valid_locales: BaseRec::LOCALE_EN,
       sector_set_code: 'gr.chall',
       sector_set_name_key: 'sector.set.gr.chal.name',
@@ -25,6 +25,8 @@ namespace :seed_eg_stem do
     @egstem = TreeType.where(code: 'EGSTEMUNIV').first
 
     # Create translation(s) for hierarchy codes
+    rec, status, message = Translation.find_or_update_translation(BaseRec::LOCALE_EN, 'curriculum.egstemuniv.hierarchy.grade', 'Grade')
+    throw "ERROR updating sector translation: #{message}" if status == BaseRec::REC_ERROR
     rec, status, message = Translation.find_or_update_translation(BaseRec::LOCALE_EN, 'curriculum.egstemuniv.hierarchy.sem', 'Semester')
     throw "ERROR updating sector translation: #{message}" if status == BaseRec::REC_ERROR
     rec, status, message = Translation.find_or_update_translation(BaseRec::LOCALE_EN, 'curriculum.egstemuniv.hierarchy.unit', 'Unit')
@@ -94,25 +96,28 @@ namespace :seed_eg_stem do
   ###################################################################################
   desc "create the grade bands for this tree type (curriculum)"
   task create_grade_bands: :environment do
-    %w(10 11 12).each do |g|
+    sort_counter = 0
+    %w(fresh soph junior senior).each do |g|
       begin
-        gf = (g == 'k') ? 0 : g
+        gf = (g == 'k') ? 0 : sort_counter
         if GradeBand.where(tree_type_id: @egstem.id, code: g).count < 1
           GradeBand.create(
             tree_type_id: @egstem.id,
             code: g,
-            sort_order: "%02d" % [gf]
+            sort_order: gf
           )
         end
+        sort_counter += 1
       rescue => ex
         puts("exception creating gradeband #{g}, error: #{ex}")
       end
     end
 
-    @gb_10 = GradeBand.where(tree_type_id: @egstem.id, code: '10').first
-    @gb_11 = GradeBand.where(tree_type_id: @egstem.id, code: '11').first
-    @gb_12 = GradeBand.where(tree_type_id: @egstem.id, code: '12').first
-    @gb_hs = [@gb_10, @gb_11, @gb_12]
+    @gb_fresh = GradeBand.where(tree_type_id: @egstem.id, code: 'fresh').first
+    @gb_soph = GradeBand.where(tree_type_id: @egstem.id, code: 'soph').first
+    @gb_junior = GradeBand.where(tree_type_id: @egstem.id, code: 'junior').first
+    @gb_senior = GradeBand.where(tree_type_id: @egstem.id, code: 'senior').first
+    @gb_univ = [@gb_fresh, @gb_soph, @gb_junior, @gb_senior]
     puts "grade bands are created for EGSTEM"
   end #create_grade_bands
 
@@ -120,64 +125,65 @@ namespace :seed_eg_stem do
   ###################################################################################
   desc "create the subjects for this tree type (curriculum)"
   task create_subjects: :environment do
-    if Subject.where(tree_type_id: @egstem.id, code: 'bio')
-      Subject.create(
+    @subjects = []
+    if Subject.where(tree_type_id: @egstem.id, code: 'bio').count < 1
+      @subjects << Subject.create(
         tree_type_id: @egstem.id,
         code: 'bio',
         base_key: 'subject.egstemuniv.bio'
       )
     end
-    if Subject.where(tree_type_id: @egstem.id, code: 'cap')
-      Subject.create(
+    if Subject.where(tree_type_id: @egstem.id, code: 'cap').count < 1
+      @subjects << Subject.create(
         tree_type_id: @egstem.id,
         code: 'cap',
         base_key: 'subject.egstemuniv.cap'
       )
     end
-    if Subject.where(tree_type_id: @egstem.id, code: 'che')
-      Subject.create(
+    if Subject.where(tree_type_id: @egstem.id, code: 'che').count < 1
+      @subjects << Subject.create(
         tree_type_id: @egstem.id,
         code: 'che',
         base_key: 'subject.egstemuniv.che'
       )
     end
-    if Subject.where(tree_type_id: @egstem.id, code: 'engl')
-      Subject.create(
+    if Subject.where(tree_type_id: @egstem.id, code: 'engl').count < 1
+      @subjects << Subject.create(
         tree_type_id: @egstem.id,
         code: 'engl',
         base_key: 'subject.egstemuniv.engl'
       )
     end
-    if Subject.where(tree_type_id: @egstem.id, code: 'edu')
-      Subject.create(
+    if Subject.where(tree_type_id: @egstem.id, code: 'edu').count < 1
+      @subjects << Subject.create(
         tree_type_id: @egstem.id,
         code: 'edu',
         base_key: 'subject.egstemuniv.edu'
       )
     end
-    if Subject.where(tree_type_id: @egstem.id, code: 'geo')
-      Subject.create(
+    if Subject.where(tree_type_id: @egstem.id, code: 'geo').count < 1
+      @subjects << Subject.create(
         tree_type_id: @egstem.id,
         code: 'geo',
         base_key: 'subject.egstemuniv.geo'
       )
     end
-    if Subject.where(tree_type_id: @egstem.id, code: 'mat')
-      Subject.create(
+    if Subject.where(tree_type_id: @egstem.id, code: 'mat').count < 1
+      @subjects << Subject.create(
         tree_type_id: @egstem.id,
         code: 'mat',
         base_key: 'subject.egstemuniv.mat'
       )
     end
-    if Subject.where(tree_type_id: @egstem.id, code: 'mec')
-      Subject.create(
+    if Subject.where(tree_type_id: @egstem.id, code: 'mec').count < 1
+      @subjects << Subject.create(
         tree_type_id: @egstem.id,
         code: 'mec',
         base_key: 'subject.egstemuniv.mec'
       )
     end
-    if Subject.where(tree_type_id: @egstem.id, code: 'phy')
-      Subject.create(
+    if Subject.where(tree_type_id: @egstem.id, code: 'phy').count < 1
+      @subjects << Subject.create(
         tree_type_id: @egstem.id,
         code: 'phy',
         base_key: 'subject.egstemuniv.phy'
@@ -247,7 +253,27 @@ namespace :seed_eg_stem do
   desc "create the upload control files"
   task create_uploads: :environment do
     # code here
-    puts "No uploads for EGSTEM"
+    puts "Try to create uploads."
+    @gb_univ.each do |g|
+      @subjects.each do |s|
+        if Upload.where(
+          tree_type_code: @egstem.code,
+          subject_id: s.id,
+          grade_band_id: g.id,
+          locale_id: @loc_en.id
+        ).count < 1
+          puts "Try to create uploads for grade #{g} subject #{s}"
+          Upload.create(
+            tree_type_code: @egstem.code,
+            subject_id: s.id,
+            grade_band_id: g.id,
+            locale_id: @loc_en.id,
+            status: 0,
+            filename: "#{@egstem.code}#{s.code.capitalize}#{g.code.capitalize}Eng.txt"
+          )
+        end
+      end
+    end
   end #create_uploads
 
 


### PR DESCRIPTION
On the sequence/relations page, display a maximum of 6 subjects at once, and only display 3 by default. 

If the user attempts to check more than 6 subjects, an alert pops up explaining that a max of 6 subjects can be displayed at once.