### PR TITLE
Fixes to initial Eg STEM University Curriculum

### DIFF
--- a/app/assets/stylesheets/header.scss
+++ b/app/assets/stylesheets/header.scss
@@ -42,6 +42,11 @@ nav#topNav {
     background-color: #ddd;
   }
 }
+.flexContainer {
+  flex-wrap: wrap;
+  justify-content: center;
+}
+
 
 
 @media only screen and (max-width: 767px) {

--- a/app/assets/stylesheets/trees.scss
+++ b/app/assets/stylesheets/trees.scss
@@ -141,6 +141,34 @@
       text-align: left;
     }
 
+    ul.maint-column {
+      li {
+        border: 1px solid black;
+        border-collapse: collapse;
+        padding: 0 5px;
+      }
+      li.maint-header {
+        background: lightgrey;
+        text-align: left;
+      }
+      li.maint-sub-header {
+        background: #eeeeee;
+        text-align: left;
+      }
+      li.maint-item {
+        text-align: left;
+      }
+      .indent-0 { margin-left: 0px; }
+      .indent-1 { margin-left: 5px; }
+      .indent-2 { margin-left: 10px; }
+      .indent-3 { margin-left: 15px; }
+      .indent-4 { margin-left: 20px; }
+      .indent-5 { margin-left: 25px; }
+      .indent-6 { margin-left: 30px; }
+      .indent-7 { margin-left: 35px; }
+      .indent-8 { margin-left: 40px; }
+    }
+
     .sequence-item, .sequence-header, .dimension-item, .dimension-header {
       list-style-type: none;
       list-style-position: none;

--- a/app/controllers/trees_controller.rb
+++ b/app/controllers/trees_controller.rb
@@ -8,87 +8,7 @@ class TreesController < ApplicationController
   end
 
   def index_listing
-    # to do - refactor this
-    Rails.logger.debug("*** @treeTypeRec: #{@treeTypeRec.inspect}")
-    @subjects = {}
-    subjIds = {}
-    Subject.where(tree_type_id: @treeTypeRec.id).each do |s|
-      @subjects[s.code] = s
-      subjIds[s.id.to_s] = s
-    end
-    Rails.logger.debug("*** @subjects: #{@subjects.inspect}")
-    @gbs = GradeBand.where(tree_type_id: @treeTypeRec.id)
-    # @gbs_upper = GradeBand.where(code: ['9','13'])
-    Rails.logger.debug("*** @gbs: #{@gbs.inspect}")
-
-    # get subject from tree param or from cookie (app controller getSubjectCode)
-    if params[:tree].present? && tree_params[:subject_id].present?
-      @subj = subjIds[tree_params[:subject_id]]
-      Rails.logger.debug("*** index_listing params ID: #{tree_params[:subject_id]}")
-    elsif @subject_code.present? && @subjects[@subject_code].present?
-      @subj = @subjects[@subject_code]
-      Rails.logger.debug("*** index_listing @subject_code: #{@subject_code.inspect}")
-    else
-      subjCode, @subj = @subjects.first
-      Rails.logger.debug("*** index_listing no match: #{subjCode} #{@subj.inspect}")
-    end
-
-    Rails.logger.debug("*** @subject_code: #{@subject_code.inspect}")
-    Rails.logger.debug("*** @subj: #{@subj.inspect}")
-    Rails.logger.debug("*** @subj.abbr(@locale_code): #{@subj.abbr(@locale_code).inspect}")
-    setSubjectCode(@subj.code)
-
-    # get gradeBand from tree param or from cookie (app controller getSubjectCode)
-    if params[:tree].present? && tree_params[:grade_band_id] == '0'
-      Rails.logger.debug("*** defaults: #{@grade_band_code}")
-      @gb = nil
-      @grade_band_code = GradeBand.all.first
-    elsif params[:tree].present? && tree_params[:grade_band_id].present?
-      @gb = GradeBand.find(tree_params[:grade_band_id])
-      @grade_band_code = @gb.code
-      Rails.logger.debug("*** index_listing gb params ID: #{tree_params[:grade_band_id]}, code: #{@gb.code}")
-    elsif @grade_band_code.present?
-      @gb = GradeBand.where(code: @grade_band_code).first
-      Rails.logger.debug("*** index_listing @grade_band_code: #{@grade_band_code.inspect}")
-      @grade_band_code = @gb.code
-    else
-      # defaults to all
-      Rails.logger.debug("*** defaults: #{@grade_band_code}")
-      @gb = nil
-      @grade_band_code = GradeBand.all.first
-    end
-    setGradeBandCode(@grade_band_code) if @gb
-    Rails.logger.debug("*** @grade_band_code: #{@grade_band_code.inspect}")
-    Rails.logger.debug("*** @gb: #{@gb.inspect}")
-
-    listing = Tree.where(
-      tree_type_id: @treeTypeRec.id,
-      version_id: @versionRec.id
-    )
-    listing = listing.where(subject_id: @subj.id) if @subj.present?
-    listing = listing.where(grade_band_id: @gb.id) if @gb.present?
-    # Note: sort order does matter for sequence of siblings in tree.
-    @trees = listing.joins(:grade_band).order("grade_bands.sort_order, trees.sort_order, code").all
-
-    # @tree is used for filtering form
-    @tree = Tree.new(
-      tree_type_id: @treeTypeRec.id,
-      version_id: @versionRec.id
-    )
-    @tree.subject_id = @subj.id if @subj.present?
-    @tree.grade_band_id = @gb.id if @gb.present?
-
-    # Translations table no longer belonging to I18n Active record gem.
-    # note: Active Record had problems with placeholder conditions in join clause.
-    # Consider having Translations belong_to trees and sectors.
-    # Current solution: get translation from hash of pre-cached translations.
-    base_keys= @trees.map { |t| "#{t.base_key}.name" }
-    @translations = Hash.new
-    translations = Translation.where(locale: @locale_code, key: base_keys)
-    translations.each do |t|
-      # puts "t.key: #{t.key.inspect}, t.value: #{t.value.inspect}"
-      @translations[t.key] = t.value
-    end
+    treePrep
 
     treeHash = {}
     areaHash = {}
@@ -238,6 +158,67 @@ class TreesController < ApplicationController
   #     @group_indicators << [thisCode, all_translations[ix]] if all_translations.length > ix
   #   end
   # end
+
+  def maint
+    # to do: Issue 77. Relations (Sequencing) page is page where updates to the curriculum are done. Thus this is where adds and deletes should be.
+    # 1) The Relations page needs to display the hierarchy items within the listing, to clarify if a LO sequence change has moved it within the hierarchy. The hierarchy items will not be draggable (at least initially).
+    # 2) An added item should be entered through a popup, indicating its parent, then entered into the correct position in the Relations page. The Sequences should be updated at this point in time (unless we remove the sort_order field).  May want to put Add and Deactivate icons in hierarchy.  May want to add deactivate icon in LOs. May need to add LO indicator to hierarchy level.
+
+    # 3) I recommend that the LO code be reflective of the current position in the hierarchy, not what the old LO code was. Thus we should keep the old LO code when changing versions, but allow the number to change as appropriate in the hierarchy. May want to put LO Code formula (from tree_types record, with old code displayed (from prior version, or from first value when no prior version.)
+
+    # note also Issue 6.  Allow user to change version of Curriculum.
+    # - Have versions listing page, with ability to add new version, select current version, display current version and Curriculum Type in Header.
+
+    # New Issue? - Need ability to choose the columns to display in the relations page.
+    # - Always show current Curriculum Type and version, and either no subjects or last subject chosen to edit.  Maybe this should be on an Edit page?
+    # - Ability to choose other subjects in this or other curriculum.  Column should show Type, Version, subject and grades.
+    # - Should only be able to edit the current subject being edited.
+    # - should be able to drag hierarchy items (and LOs) to the editing column on the left.
+
+    treePrep
+
+    @treeByParents = Hash.new{ |h, k| h[k] = {} }
+
+    # create ruby hash from tree records, to easily build tree from record codes
+    @trees.each do |tree|
+      translation = @translations[tree.name_key]
+      # Parent keys types ( Tree Type, Version, Subject, & Grade Band)
+      tkey = tree.tree_type.code + "." + tree.version.code + "." + tree.subject.code + "." + tree.grade_band.code
+
+      # column header indicating the subject and grade, and if not current one, the curriculum and version
+      tkeyTrans = ''
+      if (false) # when current curriculum and version are known, check if current column is not the current one
+        tkeyTrans += Translation.find_translation_name(@locale_code, 'curriculum.'+tree.tree_type.code+'.title', 'Missing Curriculum Name') + ' - ' + tree.version.code + ' - '
+      end
+      tkeyTrans += Translation.find_translation_name(@locale_code, 'subject.'+tree.tree_type.code+'.'+ tree.subject.code+ '.name', 'Missing Subject Name') + ' - ' + Translation.find_translation_name(@locale_code, 'grades.'+tree.tree_type.code+'.'+ tree.grade_band.code+ '.name', 'Missing Subject Name')
+      @translations[tkey] = tkeyTrans
+      newHash = {
+        id: tree.id,
+        depth: tree.depth,
+        subj_code: tree.subject.code,
+        gb_code: tree.grade_band.code,
+        code: tree.code,
+        last_code: tree.codeArrayAt(tree.depth-1),
+        depth_name: @hierarchies[tree.depth-1],
+        text: "#{tree.code}: #{translation}"
+        #connections: @relations[tree.id]
+      }
+      @treeByParents[tkey][tree.code] = newHash
+      Rails.logger.debug("*** @treeByParent [#{tkey}] [#{tree.code}] = #{newHash.inspect}")
+    end
+
+    @treeByParents.each do |tkey, codeh|
+      Rails.logger.debug("*** LOOP @treeByParent tkey: #{tkey}")
+      codeh.each do |code, hash|
+        Rails.logger.debug("*** LOOP code: #{code} => #{hash.inspect}")
+      end
+    end
+
+    respond_to do |format|
+      format.html { render 'maint'}
+    end
+
+  end
 
   def sequence
     index_prep
@@ -895,6 +876,110 @@ class TreesController < ApplicationController
       version_id: @versionRec.id
     )
     @otcTree = ''
+  end
+
+  def treePrep
+    Rails.logger.debug("*** @treeTypeRec: #{@treeTypeRec.inspect}")
+    @subjects = {}
+    subjIds = {}
+    Subject.where(tree_type_id: @treeTypeRec.id).each do |s|
+      @subjects[s.code] = s
+      subjIds[s.id.to_s] = s
+    end
+    Rails.logger.debug("*** @subjects: #{@subjects.inspect}")
+    @gbs = GradeBand.where(tree_type_id: @treeTypeRec.id)
+    # @gbs_upper = GradeBand.where(code: ['9','13'])
+    Rails.logger.debug("*** @gbs: #{@gbs.inspect}")
+
+    # get subject from tree param or from cookie (app controller getSubjectCode)
+    if params[:tree].present? && tree_params[:subject_id].present?
+      @subj = subjIds[tree_params[:subject_id]]
+      Rails.logger.debug("*** index_listing params ID: #{tree_params[:subject_id]}")
+    elsif @subject_code.present? && @subjects[@subject_code].present?
+      @subj = @subjects[@subject_code]
+      Rails.logger.debug("*** index_listing @subject_code: #{@subject_code.inspect}")
+    elsif @subjects.first
+      subjCode, @subj = @subjects.first
+      Rails.logger.debug("*** index_listing no match: #{subjCode} #{@subj.inspect}")
+    else
+      @subj = Subject.new
+    end
+
+    Rails.logger.debug("*** @subject_code: #{@subject_code.inspect}")
+    Rails.logger.debug("*** @subj: #{@subj.inspect}")
+    Rails.logger.debug("*** @subj.abbr(@locale_code): #{@subj.abbr(@locale_code).inspect}")
+    setSubjectCode(@subj.code)
+
+    # get gradeBand from tree param or from cookie (app controller getSubjectCode)
+    if params[:tree].present? && tree_params[:grade_band_id] == '0'
+      Rails.logger.debug("*** defaults: #{@grade_band_code}")
+      @gb = nil
+      @grade_band_code = GradeBand.all.first
+    elsif params[:tree].present? && tree_params[:grade_band_id].present?
+      @gb = GradeBand.find(tree_params[:grade_band_id])
+      @grade_band_code = @gb.code
+      Rails.logger.debug("*** index_listing gb params ID: #{tree_params[:grade_band_id]}, code: #{@gb.code}")
+    elsif @grade_band_code.present?
+      @gb = GradeBand.where(code: @grade_band_code).first
+      Rails.logger.debug("*** index_listing @grade_band_code: #{@grade_band_code.inspect}")
+      @grade_band_code = @gb.code
+    elsif @gbs.first
+      @gb = @gbs.first
+      @grade_band_code = @gb.code
+      Rails.logger.debug("*** index_listing no match: #{@gb.inspect}")
+    else
+      Rails.logger.debug("*** defaults: #{@grade_band_code}")
+      @gb = nil
+      @grade_band_code = ''
+    end
+    setGradeBandCode(@grade_band_code) if @gb
+    Rails.logger.debug("*** @grade_band_code: #{@grade_band_code.inspect}")
+    Rails.logger.debug("*** @gb: #{@gb.inspect}")
+
+    listing = Tree.where(
+      tree_type_id: @treeTypeRec.id,
+      version_id: @versionRec.id
+    )
+    Rails.logger.debug("*** listing.count: #{listing.count}")
+    listing = listing.where(subject_id: @subj.id) if @subj.present?
+    Rails.logger.debug("*** listing.count: #{listing.count}")
+    listing = listing.where(grade_band_id: @gb.id) if @gb.present?
+    Rails.logger.debug("*** listing.count: #{listing.count}")
+    # Note: sort order does matter for sequence of siblings in tree.
+    @trees = listing.joins(:grade_band).order("grade_bands.sort_order, trees.sort_order, code").all
+    Rails.logger.debug("*** @trees.count: #{@trees.count}")
+
+    # @tree is used for filtering form
+    @tree = Tree.new(
+      tree_type_id: @treeTypeRec.id,
+      version_id: @versionRec.id
+    )
+    @tree.subject_id = @subj.id if @subj.present?
+    @tree.grade_band_id = @gb.id if @gb.present?
+
+    @relations = Hash.new { |h, k| h[k] = [] }
+    relations = TreeTree.active
+    relations.each do |rel|
+      @relations[rel.tree_referencer_id] << rel
+    end
+
+    # Translations table no longer belonging to I18n Active record gem.
+    # note: Active Record had problems with placeholder conditions in join clause.
+    # Consider having Translations belong_to trees and sectors.
+    # Current solution: get translation from hash of pre-cached translations.
+    base_keys= @trees.map { |t| "#{t.base_key}.name" }
+    tempArray = []
+    @subjects.each { |k, v| tempArray << "#{v.base_key}.name" }
+    @subjects.each { |s, v| tempArray << "#{v.base_key}.abbr" }
+    relations.each { |r| tempArray << r.explanation_key }
+    base_keys.concat(tempArray)
+
+    @translations = Hash.new
+    translations = Translation.where(locale: @locale_code, key: base_keys)
+    translations.each do |t|
+      # puts "t.key: #{t.key.inspect}, t.value: #{t.value.inspect}"
+      @translations[t.key] = t.value
+    end
   end
 
 end

--- a/app/controllers/uploads_controller.rb
+++ b/app/controllers/uploads_controller.rb
@@ -148,7 +148,7 @@ class UploadsController < ApplicationController
           if line_num == 0
             infoLine = line.split(',')
             begin
-              grade_band = @treeTypeRec.code == "EGSTEMUNIV" ? infoLine[2].strip : Integer(infoLine[2])
+              grade_band = @treeTypeRec.code == "egstemuniv" ? infoLine[2].strip : Integer(infoLine[2])
             rescue ArgumentError, TypeError
               grade_band = 0
             end
@@ -434,7 +434,7 @@ class UploadsController < ApplicationController
     errors = []
     codes.each_with_index do |code, ix|
       begin
-        numCode = @treeTypeRec.code == "EGSTEMUNIV" ? code : Integer(code)
+        numCode = @treeTypeRec.code == "egstemuniv" ? code : Integer(code)
         numCodes << numCode
       rescue
         numCodes << -1

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -42,7 +42,7 @@
   </div>
 </header>
 <nav id='topNav' class="navbar navbar-expand-sm bg-light text-center">
-  <ul class="navbar-nav mx-auto">
+  <ul class="flexContainer navbar-nav mx-auto">
     <%
     if controller.controller_name == 'users' && action_name == 'home' %>
       <li class="nav-item active" aria-selected='true'>
@@ -75,12 +75,12 @@
     <% end
     if controller.controller_name == 'trees' && action_name == 'sequence' %>
       <li class="nav-item active" aria-selected='true'>
-        <a class="nav-link btn btn-primary" href=<%= sequence_trees_path %>><%= translate('trees.sequencing.title') %></a>
+        <a class="nav-link btn btn-primary" href=<%= sequence_trees_path %>><%= translate('nav_bar.relations.name') %></a>
       </li>
     <%
     else %>
       <li class="nav-item" role='menuitem'>
-        <a class="nav-link btn btn-primary" href=<%= sequence_trees_path %>><%= translate('trees.sequencing.title') %></a>
+        <a class="nav-link btn btn-primary" href=<%= sequence_trees_path %>><%= translate('nav_bar.relations.name') %></a>
       </li>
     <%
     end
@@ -126,6 +126,17 @@
     </li>
     <%
     if current_user.present? && current_user.is_admin?
+      if controller.controller_name == 'trees' && action_name == 'maint' %>
+        <li class="nav-item active" aria-selected='true'>
+          <a class="nav-link btn btn-primary" href=<%= maint_trees_path() %>><%= translate('nav_bar.maint.name') %></a>
+        </li>
+  <%
+      else %>
+        <li class="nav-item" role='menuitem'>
+          <a class="nav-link btn btn-primary" href=<%= maint_trees_path() %>><%= translate('nav_bar.maint.name') %></a>
+        </li>
+  <%
+      end
       if controller.controller_name == 'uploads'
     %>
       <li class="nav-item active" aria-selected='true'>
@@ -138,8 +149,8 @@
         <a class="nav-link btn btn-primary" href=<%= uploads_path %>><%= translate('nav_bar.uploads.name') %></a>
       </li>
     <%
-        end
-        if controller.controller_name == 'users' && action_name == 'index'
+      end
+      if controller.controller_name == 'users' && action_name == 'index'
     %>
       <li class="nav-item active" aria-selected='true'>
         <a class="nav-link btn btn-primary" href=<%= users_path %>><%= translate('nav_bar.users.name') %></a>
@@ -151,30 +162,32 @@
         <a class="nav-link btn btn-primary" href=<%= users_path %>><%= translate('nav_bar.users.name') %></a>
       </li>
     <%
-        end
       end
+    end
 
-      if current_user.present?
-        if controller.controller_name == 'users' && action_name == 'edit' %>
-          <li class="nav-item active" aria-selected='true'>
-            <a class="nav-link btn btn-primary" href=<%= edit_user_path(current_user.id) %>><%= translate('nav_bar.my_account.name') %></a>
-          </li>
+    if current_user.present?
+      if controller.controller_name == 'users' && action_name == 'edit' %>
+        <li class="nav-item active" aria-selected='true'>
+          <a class="nav-link btn btn-primary" href=<%= edit_user_path(current_user.id) %>><%= translate('nav_bar.my_account.name') %></a>
+        </li>
     <%
-        else %>
-          <li class="nav-item" role='menuitem'>
-            <a class="nav-link btn btn-primary" href=<%= edit_user_path(current_user.id) %>><%= translate('nav_bar.my_account.name') %></a>
-          </li>
+      else %>
+        <li class="nav-item" role='menuitem'>
+          <a class="nav-link btn btn-primary" href=<%= edit_user_path(current_user.id) %>><%= translate('nav_bar.my_account.name') %></a>
+        </li>
     <%
-        end
+      end
     %>
       <li class="nav-item" role='menuitem'>
         <a class="nav-link btn btn-primary" href=<%= sign_out_path %>><%= translate('nav_bar.signout.name') %></a>
       </li>
-    <% else %>
+    <%
+    else %>
       <li class="nav-item" role='menuitem'>
         <a class="nav-link btn btn-primary" href=<%= new_user_session_path %>><%= translate('nav_bar.signin.name') %></a>
       </li>
-    <% end %>
+    <%
+    end %>
   </ul>
 </nav>
 <div id='pageSubHeaderTitle' class=''>

--- a/app/views/trees/index.html.erb
+++ b/app/views/trees/index.html.erb
@@ -6,9 +6,9 @@
 <% if @otcJson %>
 <br>
 <div class='text-center'>
-  <button id='showAreas' class='btn-info' onclick="$('#tree').treeview({data: otcTree, levels: 2, enableLinks: true/* , showCheckbox: true*/})"><%= @hierarchies[0] if @hierarchies.length > 0 %></button>
-  <button id='showComponents' class='btn-info' onclick="$('#tree').treeview({data: otcTree, levels: 3, enableLinks: true/* , showCheckbox: true*/})"><%= @hierarchies[1] if @hierarchies.length > 1 %></button>
-  <button id='showOutcomes' class='btn-info' onclick="$('#tree').treeview({data: otcTree, levels: 4, enableLinks: true/* , showCheckbox: true*/})"><%= @hierarchies[2] if @hierarchies.length > 2 %></button>
+  <button id='showAreas' class='btn-info' onclick="$('#tree').treeview({data: otcTree, levels: 2, enableLinks: true/* , showCheckbox: true*/})"><%= @hierarchies[1] if @hierarchies.length > 1 %></button>
+  <button id='showComponents' class='btn-info' onclick="$('#tree').treeview({data: otcTree, levels: 3, enableLinks: true/* , showCheckbox: true*/})"><%= @hierarchies[2] if @hierarchies.length > 2 %></button>
+  <button id='showOutcomes' class='btn-info' onclick="$('#tree').treeview({data: otcTree, levels: 4, enableLinks: true/* , showCheckbox: true*/})"><%= @hierarchies[3] if @hierarchies.length > 3 %></button>
   <!-- button id='showIndicators' class='btn-info' onclick="$('#tree').treeview({data: otcTree, levels: 5, enableLinks: true/* , showCheckbox: true*/})"><%= translate('trees.labels.show_indicators') %></button -->
 </div>
 <div id="tree"></div>

--- a/app/views/trees/maint.html.erb
+++ b/app/views/trees/maint.html.erb
@@ -1,0 +1,44 @@
+<% content_for(:title_code, 'trees.maint.name') %>
+<% content_for(:page_class, 'trees') %>
+
+<br>
+<div class='text-center sequence-page'>
+  <h2><%= translate('trees.maint.title') %></h2>
+</div>
+<% subj_counter = 0 %>
+<div id="trees" class="sequence-page">
+  <div class="sequence-grid cols-<%= 2 %>">
+    <ul class="list-group maint-column">
+      <% @treeByParents.each do |tkey, codeh| %>
+        <li class="maint-header indent-0"><%= @translations[tkey] %></li>
+        <% codeh.each do |code, h| %>
+          <% if h[:depth] == 4 %>
+          <li class="maint-item indent-3">
+            <a href="<%= tree_path(h[:id])%>" title="<%= h[:text] %>"><%= h[:depth_name] %>: <%= h[:last_code] %></a>
+            <%= h[:text] %>
+            <div class="pull-right">
+              <a class="" data-confirm="Are you sure?"  href="/<%= @locale_code %>/trees/<%= h[:id] %>?%5Bactive%5D=false">
+                <i class="fa fa-times pull-right" title="deactivate this LO"></i>
+              </a>
+              <a class="sort-handle lo-handle ui-sortable-handle" onclick="" href="#">
+                <i class="fa fa-thumb-tack pull-right" title="resequence this LO"></i>
+              </a>
+              <a class="" href="/<%= @locale_code %>/trees/<%= h[:id] %>?editme=<%= h[:id] %>">
+                <i class="fa fa-edit pull-right" title="edit this LO"></i>
+              </a>
+            </div>
+          </li>
+          <% else %>
+            <li class="maint-sub-header indent-<%= h[:depth]-1 %> ">
+              <a class="" href="#">
+                <i class="fa fa-compress pull-left" title="collapse"></i>
+              </a>
+              <%= h[:depth_name] %>: <%= h[:text] %>
+            </li>
+          <% end %>
+        <% end %>
+      <% end %>
+      </ul>
+    </div>
+  </div>
+</div>

--- a/config/application.rb
+++ b/config/application.rb
@@ -15,11 +15,11 @@ module Curriculum
     # Application configuration should go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded.
 
-    config.i18n.available_locales = [:en, :tr]
-    config.i18n.default_locale = :tr
+    config.i18n.available_locales = [:en, :tr, :ar_EG]
+    config.i18n.default_locale = :en
 
     # missing translations fallback to en (English))
-    config.i18n.fallbacks = {'tr_TR' => 'tr', 'tr' => 'en'}
+    config.i18n.fallbacks = {'ar_EG' => 'en', 'tr' => 'en'}
 
   end
 end

--- a/config/locales/pages.en.yml
+++ b/config/locales/pages.en.yml
@@ -88,6 +88,12 @@ en:
     sectors:
       name: "Sectors"
       hover: "Displays the Curriculum by Sectors"
+    relations:
+      name: "Relations"
+      hover: "Display the Relations between Curriculum Items"
+    maint:
+      name: "Maintenance"
+      hover: "Page for Maintenance of Curriculum Items"
     connections:
       name: "Other"
       hover: "Other Connections"
@@ -160,6 +166,8 @@ en:
       title: "Turkey STEM Curriculum"
     sequencing:
       title: "Relations"
+    maint:
+      title: "Maintenance"
     miscon:
       title: "Misconceptions"
       singular: "Misconception"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -38,6 +38,7 @@ scope "(:locale)", locale: /tr|en/ do
       post 'reorder'
       post 'create_dim_tree'
       patch 'update_dim_tree'
+      get 'maint'
     end
   end
   match '/dim_tree', :to => "trees#dim_tree_add_edit", :as => :dim_tree_path, :via => [:post, :patch, :put]

--- a/lib/tasks/seed_eg_stem.rake
+++ b/lib/tasks/seed_eg_stem.rake
@@ -7,9 +7,9 @@ namespace :seed_eg_stem do
   ###################################################################################
   desc "create the tree type(s)"
   task create_tree_type: :environment do
-    myTreeType = TreeType.where(code: 'EGSTEMUNIV')
+    myTreeType = TreeType.where(code: 'egstemuniv')
     myTreeTypeValues = {
-      code: 'EGSTEMUNIV',
+      code: 'egstemuniv',
       hierarchy_codes: 'grade,sem,unit,lo',
       valid_locales: BaseRec::LOCALE_EN,
       sector_set_code: 'gr.chall',
@@ -21,8 +21,8 @@ namespace :seed_eg_stem do
     else
       TreeType.update(myTreeType.first.id, myTreeTypeValues)
     end
-    throw "Invalid Tree Type Count" if TreeType.where(code: 'EGSTEMUNIV').count != 1
-    @egstem = TreeType.where(code: 'EGSTEMUNIV').first
+    throw "Invalid Tree Type Count" if TreeType.where(code: 'egstemuniv').count != 1
+    @egstem = TreeType.where(code: 'egstemuniv').first
 
     # Create translation(s) for hierarchy codes
     rec, status, message = Translation.find_or_update_translation(BaseRec::LOCALE_EN, 'curriculum.egstemuniv.hierarchy.grade', 'Grade')
@@ -42,7 +42,7 @@ namespace :seed_eg_stem do
     rec, status, message = Translation.find_or_update_translation(BaseRec::LOCALE_EN, 'curriculum.egstemuniv.title', 'Egypt STEM Teacher Prep Curriculum')
     throw "ERROR updating curriculum.egstemuniv.title translation: #{message}" if status == BaseRec::REC_ERROR
 
-    puts "Curriculum (Tree Type) is created for EGSTEMUNIV "
+    puts "Curriculum (Tree Type) is created for egstemuniv "
     puts "  Created Curriculum: #{@egstem.code} with Hierarchy: #{@egstem.hierarchy_codes}"
   end #create_tree_type
 
@@ -89,7 +89,7 @@ namespace :seed_eg_stem do
       )
     end
     @user = User.where(email: 'egstemuniv@sample.com').first
-    puts "admin user is created for EGSTEMUNIV"
+    puts "admin user is created for egstemuniv"
   end #create_admin_user
 
 
@@ -119,6 +119,17 @@ namespace :seed_eg_stem do
     @gb_senior = GradeBand.where(tree_type_id: @egstem.id, code: 'senior').first
     @gb_univ = [@gb_fresh, @gb_soph, @gb_junior, @gb_senior]
     puts "grade bands are created for EGSTEM"
+
+    # put in translations for Grade Names
+    rec, status, message = Translation.find_or_update_translation(BaseRec::LOCALE_EN, 'grades.egstemuniv.fresh.name', 'Freshman')
+    throw "ERROR updating sector translation: #{message}" if status == BaseRec::REC_ERROR
+    rec, status, message = Translation.find_or_update_translation(BaseRec::LOCALE_EN, 'grades.egstemuniv.soph.name', 'Sophmore')
+    throw "ERROR updating sector translation: #{message}" if status == BaseRec::REC_ERROR
+    rec, status, message = Translation.find_or_update_translation(BaseRec::LOCALE_EN, 'grades.egstemuniv.junior.name', 'Junior')
+    throw "ERROR updating sector translation: #{message}" if status == BaseRec::REC_ERROR
+    rec, status, message = Translation.find_or_update_translation(BaseRec::LOCALE_EN, 'grades.egstemuniv.senior.name', 'Senior')
+    throw "ERROR updating sector translation: #{message}" if status == BaseRec::REC_ERROR
+
   end #create_grade_bands
 
 

--- a/lib/tasks/seed_eg_stem.rake
+++ b/lib/tasks/seed_eg_stem.rake
@@ -253,7 +253,7 @@ namespace :seed_eg_stem do
   desc "create the upload control files"
   task create_uploads: :environment do
     # code here
-    puts "Try to create uploads."
+    # puts "Try to create uploads."
     @gb_univ.each do |g|
       @subjects.each do |s|
         if Upload.where(
@@ -262,7 +262,7 @@ namespace :seed_eg_stem do
           grade_band_id: g.id,
           locale_id: @loc_en.id
         ).count < 1
-          puts "Try to create uploads for grade #{g} subject #{s}"
+          # puts "Try to create uploads for grade #{g} subject #{s}"
           Upload.create(
             tree_type_code: @egstem.code,
             subject_id: s.id,

--- a/test/integration/db_seed_test.rb
+++ b/test/integration/db_seed_test.rb
@@ -10,11 +10,7 @@ class DbSeedTest < ActionDispatch::IntegrationTest
 
   test "confirm db_seed properly loads all tables" do
     assert_equal(1, Version.count)
-    assert_equal(1, TreeType.count)
-    assert_equal(4, Locale.count)
-    assert_equal(4, GradeBand.count)
-    assert_equal(6, Subject.count)
-    assert_equal(62, Upload.count)
+    assert_equal(3, Locale.count)
   end
 
 end

--- a/test/integration/tree_type_seed_test.rb
+++ b/test/integration/tree_type_seed_test.rb
@@ -1,0 +1,77 @@
+require 'helpers/test_components_helper'
+# require 'test_helper_debugging'
+require 'rake'
+
+class DbSeedTest < ActionDispatch::IntegrationTest
+  # include Devise::Test::IntegrationHelpers
+
+  setup do
+    # load rake tasks for application
+    # note: get application name from Rails.application.class.parent_name
+    # load "#{Rails.root}/db/seeds.rb"
+    Rails.application.load_seed
+    Curriculum::Application.load_tasks
+    Rake::Task['seed_eg_stem:populate'].invoke
+    Rake::Task.clear
+  end
+
+  test "confirm seed_eg_stem properly loads all tables" do
+    assert_equal(1, Version.count)
+    assert_equal(1, TreeType.count)
+    assert_equal(3, Locale.count)
+    assert_equal(4, GradeBand.count)
+    assert_equal(9, Subject.count)
+    assert_equal(36, Upload.count)
+    assert_equal(11, Sector.count)
+  end
+
+  test "confirm translations are loaded from seeds" do
+    assert_equal('Egypt STEM Teacher Prep Curriculum', Translation.find_translation_name(BaseRec::LOCALE_EN, 'curriculum.egstemuniv.title', 'xxx'))
+
+    assert_equal('Grade', Translation.find_translation_name(BaseRec::LOCALE_EN, 'curriculum.egstemuniv.hierarchy.grade', 'xxx'))
+    assert_equal('Unit', Translation.find_translation_name(BaseRec::LOCALE_EN, 'curriculum.egstemuniv.hierarchy.unit', 'xxx'))
+    assert_equal('Learning Outcome', Translation.find_translation_name(BaseRec::LOCALE_EN, 'curriculum.egstemuniv.hierarchy.lo', 'xxx'))
+
+    assert_equal('Grand Challenges', Translation.find_translation_name(BaseRec::LOCALE_EN, 'sector.set.gr.chal.name', 'xxx'))
+
+    assert_equal('Biology', Translation.find_translation_name(BaseRec::LOCALE_EN, 'subject.egstemuniv.bio.name', 'xxx'))
+    assert_equal('Bio', Translation.find_translation_name(BaseRec::LOCALE_EN, 'subject.egstemuniv.bio.abbr', 'xxx'))
+    assert_equal('Capstones', Translation.find_translation_name(BaseRec::LOCALE_EN, 'subject.egstemuniv.cap.name', 'xxx'))
+    assert_equal('Cap', Translation.find_translation_name(BaseRec::LOCALE_EN, 'subject.egstemuniv.cap.abbr', 'xxx'))
+
+    assert_equal('Chemistry', Translation.find_translation_name(BaseRec::LOCALE_EN, 'subject.egstemuniv.che.name', 'xxx'))
+    assert_equal('Chem', Translation.find_translation_name(BaseRec::LOCALE_EN, 'subject.egstemuniv.che.abbr', 'xxx'))
+
+    assert_equal('English', Translation.find_translation_name(BaseRec::LOCALE_EN, 'subject.egstemuniv.engl.name', 'xxx'))
+    assert_equal('Engl', Translation.find_translation_name(BaseRec::LOCALE_EN, 'subject.egstemuniv.engl.abbr', 'xxx'))
+
+    assert_equal('Education', Translation.find_translation_name(BaseRec::LOCALE_EN, 'subject.egstemuniv.edu.name', 'xxx'))
+    assert_equal('Edu', Translation.find_translation_name(BaseRec::LOCALE_EN, 'subject.egstemuniv.edu.abbr', 'xxx'))
+
+    assert_equal('Geology', Translation.find_translation_name(BaseRec::LOCALE_EN, 'subject.egstemuniv.geo.name', 'xxx'))
+    assert_equal('Geo', Translation.find_translation_name(BaseRec::LOCALE_EN, 'subject.egstemuniv.geo.abbr', 'xxx'))
+
+    assert_equal('Mathematics', Translation.find_translation_name(BaseRec::LOCALE_EN, 'subject.egstemuniv.mat.name', 'xxx'))
+    assert_equal('Math', Translation.find_translation_name(BaseRec::LOCALE_EN, 'subject.egstemuniv.mat.abbr', 'xxx'))
+
+    assert_equal('Mechanics', Translation.find_translation_name(BaseRec::LOCALE_EN, 'subject.egstemuniv.mec.name', 'xxx'))
+    assert_equal('Mec', Translation.find_translation_name(BaseRec::LOCALE_EN, 'subject.egstemuniv.mec.abbr', 'xxx'))
+
+    assert_equal('Physics', Translation.find_translation_name(BaseRec::LOCALE_EN, 'subject.egstemuniv.phy.name', 'xxx'))
+    assert_equal('Phy', Translation.find_translation_name(BaseRec::LOCALE_EN, 'subject.egstemuniv.phy.abbr', 'xxx'))
+
+    assert_equal('Deal with population growth and its consequences.', Translation.find_translation_name(BaseRec::LOCALE_EN, 'sector.egstemuniv.1.name', 'xxx'))
+    assert_equal('Improve the use of alternative energies.', Translation.find_translation_name(BaseRec::LOCALE_EN, 'sector.egstemuniv.2.name', 'xxx'))
+    assert_equal('Deal with urban congestion and its consequences.', Translation.find_translation_name(BaseRec::LOCALE_EN, 'sector.egstemuniv.3.name', 'xxx'))
+    assert_equal('Improve the scientific and technological environment for all.', Translation.find_translation_name(BaseRec::LOCALE_EN, 'sector.egstemuniv.4.name', 'xxx'))
+    assert_equal('Work to eradicate public health issues/disease.', Translation.find_translation_name(BaseRec::LOCALE_EN, 'sector.egstemuniv.5.name', 'xxx'))
+    assert_equal('Improve uses of arid areas.', Translation.find_translation_name(BaseRec::LOCALE_EN, 'sector.egstemuniv.6.name', 'xxx'))
+    assert_equal('Manage and increase the sources of clean water.', Translation.find_translation_name(BaseRec::LOCALE_EN, 'sector.egstemuniv.7.name', 'xxx'))
+    assert_equal('Increase the industrial and agricultural bases of Egypt.', Translation.find_translation_name(BaseRec::LOCALE_EN, 'sector.egstemuniv.8.name', 'xxx'))
+    assert_equal('Address and reduce pollution fouling our air, water and soil.', Translation.find_translation_name(BaseRec::LOCALE_EN, 'sector.egstemuniv.9.name', 'xxx'))
+    assert_equal('Recycle garbage and waste for economic and environmental purposes.', Translation.find_translation_name(BaseRec::LOCALE_EN, 'sector.egstemuniv.10.name', 'xxx'))
+    assert_equal('Reduce and adapt to the effect of climate change.', Translation.find_translation_name(BaseRec::LOCALE_EN, 'sector.egstemuniv.11.name', 'xxx'))
+
+  end
+
+end


### PR DESCRIPTION
resolves #75 , working on  issue 77.
- set english as the default locale when not preset
- Curriculum Tree to display 'Semester', 'Unit', and 'Learning Outcome'
- Added Maint page with top nav item when admin user
- Top nav now wraps and is centered using flexbox
- Maint page will display one Curriculum, Version, Subject, & Grade per column.
- Columns may be mixed and matched Curriculum, Versions, Subjects, & Grades.
- Columns contains all levels, so when re-ordering them, the new items will know their new hierarchy position
- higher levels have a non-functional collapse icon, for accordion functionality
- Edit, Move, and Deactivate Icons are partially functional
- Changed TreeType.code for EGSTEMUNIV to egstemuniv, so it can be used to build translation keys
- To Do:
  - load Turkey curriculum with this new version (new seed and upload fixes)
  - icon functionality
  - Ability to select left and right columns
  - show relations between left and right columns
  - Possibly a quick copy and paste outcome text
  - show item history, possibly by having a foreign key to old tree record