### PR TITLE
Fix gradebands on maint page

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -30,7 +30,7 @@ class ApplicationController < ActionController::Base
     # set the current Subject ID
     def setSubjectCode(code)
       Rails.logger.debug("app setSubjectCode code: #{code.inspect}")
-      if Subject.all.map{ |s| s.code}.include?(code)
+      if Subject.where(:tree_type_id => @treeTypeRec.id).map{ |s| s.code}.include?(code)
         # next default Subject to cookie:
         Rails.logger.debug("app Subject code matched! #{code.inspect}")
         @subject_code = code
@@ -44,11 +44,12 @@ class ApplicationController < ActionController::Base
     # set the current gradeBand ID
     def setGradeBandCode(code)
       Rails.logger.debug("app setGradeBand code: #{code.inspect}")
-      if GradeBand.all.map{ |gb| gb.code}.include?(code)
+      if GradeBand.where(:tree_type_id => @treeTypeRec.id).map{ |gb| gb.code}.include?(code)
         # next default gradeBand to cookie:
         Rails.logger.debug("app gradeBand code matched! #{code.inspect}")
         cookies['gradeBand'] = code
       else
+        cookies['gradeBand'] = 0
         Rails.logger.debug("app gradeBand code not matched! #{code}")
       end
     end

--- a/app/controllers/trees_controller.rb
+++ b/app/controllers/trees_controller.rb
@@ -940,13 +940,13 @@ class TreesController < ApplicationController
     if (params[:tree].present? && tree_params[:grade_band_id] == '0') || (!params[:tree].present? && @grade_band_code == 0)
       Rails.logger.debug("*** defaults: #{@grade_band_code}")
       @gb = nil
-      @grade_band_code = GradeBand.all.first
+      @grade_band_code = GradeBand.where(:tree_type_id => @treeTypeRec.id).first
     elsif params[:tree].present? && tree_params[:grade_band_id].present?
       @gb = GradeBand.find(tree_params[:grade_band_id])
       @grade_band_code = @gb.code
       Rails.logger.debug("*** index_listing gb params ID: #{tree_params[:grade_band_id]}, code: #{@gb.code}")
     elsif @grade_band_code.present?
-      @gb = GradeBand.where(code: @grade_band_code).first
+      @gb = GradeBand.where(code: @grade_band_code, tree_type_id: @treeTypeRec.id).first
       Rails.logger.debug("*** index_listing @grade_band_code: #{@grade_band_code.inspect}")
       @grade_band_code = @gb.code
     elsif @gbs.first
@@ -958,7 +958,7 @@ class TreesController < ApplicationController
       @gb = nil
       @grade_band_code = ''
     end
-    setGradeBandCode(@grade_band_code) if @gb
+    setGradeBandCode(@grade_band_code) #if @gb
     Rails.logger.debug("*** @grade_band_code: #{@grade_band_code.inspect}")
     Rails.logger.debug("*** @gb: #{@gb.inspect}")
 


### PR DESCRIPTION
- Look at tree_type_id in addition to code when retrieving a specific GradeBand record by code in TreesController#treePrep
- If gradeband "All" is selected (and @grade_band_code of 0 passed in to treePrep), set cookie for gradeband to 0 (interpreted by the app as "All").