### PR TITLE
"Maint" Page (i.e., "Competencies", "Editing", etc)

### DIFF
--- a/app/assets/javascripts/common.js
+++ b/app/assets/javascripts/common.js
@@ -132,6 +132,10 @@ $(function() {
 
   $(document).on("turbolinks:load", function(event, state) {
     console.log("turbolinks:load");
+    $('[data-toggle="tooltip"]').tooltip({
+      html: true,
+      track: true
+    });
     readyFontSizes();
   });
   readyFontSizes();
@@ -142,5 +146,9 @@ $(function() {
 
   $(".subject-with-gb").on("change", function(event, state) {
     showCorrectGradeBand(this, event);
+  });
+  $('[data-toggle="tooltip"]').tooltip({
+    html: true,
+    track: true
   });
 });

--- a/app/assets/javascripts/common.js
+++ b/app/assets/javascripts/common.js
@@ -1,7 +1,4 @@
-
-
 $(function() {
-
   var saveUpperGbs;
   var saveAllGbs;
 
@@ -10,34 +7,32 @@ $(function() {
 
   //# Toggle display of the Top Nav bar
   toggleTopNav = function(that, ev) {
-    $('#topNav').toggle();
-  }
-
+    $("#topNav").toggle();
+  };
 
   //# Show the correct Grade Band selector
   showCorrectGradeBand = function(that, ev) {
-    sel = $('.subject-with-gb option:selected');
+    sel = $(".subject-with-gb option:selected");
     text = sel.text();
-    var upperGBs = ['Fiz', 'Hem'];
-    if($('#all-gbs-select').length > 0) {
-      $('#all-gbs-select').hide();
-      saveAllGbs = $('#all-gbs-select').detach();
+    var upperGBs = ["Fiz", "Hem"];
+    if ($("#all-gbs-select").length > 0) {
+      $("#all-gbs-select").hide();
+      saveAllGbs = $("#all-gbs-select").detach();
     }
-    if($('#upper-gbs-select').length > 0) {
-      $('#upper-gbs-select').hide();
-      saveUpperGbs = $('#upper-gbs-select').detach();
+    if ($("#upper-gbs-select").length > 0) {
+      $("#upper-gbs-select").hide();
+      saveUpperGbs = $("#upper-gbs-select").detach();
     }
     if (upperGBs.indexOf(text) < 0) {
       // not in upper grade bands only subjects
-      saveAllGbs.appendTo('#gb-container');
-      $('#all-gbs-select').show();
+      saveAllGbs.appendTo("#gb-container");
+      $("#all-gbs-select").show();
     } else {
       // in upper grade bands only subjects
-      saveUpperGbs.appendTo('#gb-container');
-      $('#upper-gbs-select').show();
+      saveUpperGbs.appendTo("#gb-container");
+      $("#upper-gbs-select").show();
     }
-  }
-
+  };
 
   //###################################
   //# ADD EVENT BINDINGS AND HANDLERS TOGETHER
@@ -45,21 +40,20 @@ $(function() {
   readyFontSizes = function() {
     $("#pageHeaderFontSize .smallest-text").on("click", function(event, state) {
       setSmallestText(this, event);
-    })
+    });
     $("#pageHeaderFontSize .smaller-text").on("click", function(event, state) {
       setSmallerText(this, event);
-    })
+    });
     $("#pageHeaderFontSize .medium-text").on("click", function(event, state) {
       setMediumText(this, event);
-    })
+    });
     $("#pageHeaderFontSize .larger-text").on("click", function(event, state) {
       setLargerText(this, event);
-    })
+    });
     $("#pageHeaderFontSize .largest-text").on("click", function(event, state) {
       setLargestText(this, event);
-    })
-  }
-
+    });
+  };
 
   setSmallestText = function(that, ev) {
     $("#outer-container").addClass("smallest-text");
@@ -67,7 +61,7 @@ $(function() {
     $("#outer-container").removeClass("medium-text");
     $("#outer-container").removeClass("larger-text");
     $("#outer-container").removeClass("largest-text");
-  }
+  };
 
   setSmallerText = function(that, ev) {
     $("#outer-container").removeClass("smallest-text");
@@ -75,7 +69,7 @@ $(function() {
     $("#outer-container").removeClass("medium-text");
     $("#outer-container").removeClass("larger-text");
     $("#outer-container").removeClass("largest-text");
-  }
+  };
 
   setMediumText = function(that, ev) {
     $("#outer-container").removeClass("smallest-text");
@@ -83,7 +77,7 @@ $(function() {
     $("#outer-container").addClass("medium-text");
     $("#outer-container").removeClass("larger-text");
     $("#outer-container").removeClass("largest-text");
-  }
+  };
 
   setLargerText = function(that, ev) {
     $("#outer-container").removeClass("smallest-text");
@@ -91,7 +85,7 @@ $(function() {
     $("#outer-container").removeClass("medium-text");
     $("#outer-container").addClass("larger-text");
     $("#outer-container").removeClass("largest-text");
-  }
+  };
 
   setLargestText = function(that, ev) {
     $("#outer-container").removeClass("smallest-text");
@@ -99,53 +93,85 @@ $(function() {
     $("#outer-container").removeClass("medium-text");
     $("#outer-container").removeClass("larger-text");
     $("#outer-container").addClass("largest-text");
-  }
-
+  };
 
   selectCurriculum = function(refresh_path, user_id) {
-    var selected = JSON.parse(document.getElementById("selectCurriculumDropdown").value);
+    var selected = JSON.parse(
+      document.getElementById("selectCurriculumDropdown").value
+    );
     console.log("selected curriculum: " + selected);
     //[cur[:tree_type_id], cur[:version_id]
     var data = {
-          "source_controller": "users",
-          "source_action": "set_curriculum",
-          "user[last_tree_type_id]" : selected[0],
-          "user[last_version_id]" : selected[1],
-          "user[user_id]" : user_id,
-          "user[refresh_path]" : refresh_path,
-        };
-    var token = $("meta[name='csrf-token']").attr('content');
+      source_controller: "users",
+      source_action: "set_curriculum",
+      "user[last_tree_type_id]": selected[0],
+      "user[last_version_id]": selected[1],
+      "user[user_id]": user_id,
+      "user[refresh_path]": refresh_path
+    };
+    var token = $("meta[name='csrf-token']").attr("content");
     $.ajax({
-      "type": 'patch',
-      "url": '/users/set_curriculum',
-      "headers": { 'X-CSRF-Token': token },
-      "data": data,
-      "dataType": "json",
-      "async": false
+      type: "patch",
+      url: "/users/set_curriculum",
+      headers: { "X-CSRF-Token": token },
+      data: data,
+      dataType: "json",
+      async: false
     })
-    .then(function (res) {
-      if (res.refresh) location.reload()
-      else document.location.href="/";
-    })
-    .catch(function (err) { console.log("ERROR:", err) })
-  }
+      .then(function(res) {
+        if (res.refresh) location.reload();
+        else document.location.href = "/";
+      })
+      .catch(function(err) {
+        console.log("ERROR:", err);
+      });
+  };
+
+  /**
+   * Generic toggle visibility method
+   * @param {String} selector CSS selector for the element or elements to hide
+   * @param {String} trigger CSS selector for the element triggering this function
+   * @param {String} matchTrigger Selectors for elements or elements that should
+   *                              be updated to match the trigger element's
+   *                              settings with regard to the ".option-selected"
+   *                              class.
+   */
+  toggle_visibility = function(selector, trigger, matchTrigger) {
+    $(trigger).toggleClass("option-selected");
+    var sel = $(trigger).hasClass("option-selected");
+    if (sel) {
+      $(selector).removeClass("hidden");
+      if ($(trigger).hasClass("accordion")) {
+        $(trigger).removeClass("fa-expand");
+        $(trigger).addClass("fa-compress");
+      }
+    } else {
+      $(selector).addClass("hidden");
+      if ($(trigger).hasClass("accordion")) {
+        $(trigger).removeClass("fa-compress");
+        $(trigger).addClass("fa-expand");
+      }
+    }
+    if (matchTrigger != undefined && matchTrigger != "") {
+      $(matchTrigger).addClass(sel ? "option-selected" : "");
+      $(matchTrigger).removeClass(!sel ? "option-selected" : "");
+    }
+  };
 
   //###################################
   //# ADD EVENT BINDINGS
 
-  $(document).on('turbolinks:load', function(event, state) {
-    console.log('turbolinks:load');
+  $(document).on("turbolinks:load", function(event, state) {
+    console.log("turbolinks:load");
     readyFontSizes();
   });
   readyFontSizes();
 
-  $(".fa-bars").on('click', function(event, state) {
+  $(".fa-bars").on("click", function(event, state) {
     toggleTopNav(this, event);
-  })
+  });
 
-
-  $(".subject-with-gb").on('change', function(event, state) {
+  $(".subject-with-gb").on("change", function(event, state) {
     showCorrectGradeBand(this, event);
-  })
-
+  });
 });

--- a/app/assets/javascripts/common.js
+++ b/app/assets/javascripts/common.js
@@ -127,37 +127,6 @@ $(function() {
       });
   };
 
-  /**
-   * Generic toggle visibility method
-   * @param {String} selector CSS selector for the element or elements to hide
-   * @param {String} trigger CSS selector for the element triggering this function
-   * @param {String} matchTrigger Selectors for elements or elements that should
-   *                              be updated to match the trigger element's
-   *                              settings with regard to the ".option-selected"
-   *                              class.
-   */
-  toggle_visibility = function(selector, trigger, matchTrigger) {
-    $(trigger).toggleClass("option-selected");
-    var sel = $(trigger).hasClass("option-selected");
-    if (sel) {
-      $(selector).removeClass("hidden");
-      if ($(trigger).hasClass("accordion")) {
-        $(trigger).removeClass("fa-expand");
-        $(trigger).addClass("fa-compress");
-      }
-    } else {
-      $(selector).addClass("hidden");
-      if ($(trigger).hasClass("accordion")) {
-        $(trigger).removeClass("fa-compress");
-        $(trigger).addClass("fa-expand");
-      }
-    }
-    if (matchTrigger != undefined && matchTrigger != "") {
-      $(matchTrigger).addClass(sel ? "option-selected" : "");
-      $(matchTrigger).removeClass(!sel ? "option-selected" : "");
-    }
-  };
-
   //###################################
   //# ADD EVENT BINDINGS
 

--- a/app/assets/javascripts/dimensions.js
+++ b/app/assets/javascripts/dimensions.js
@@ -2,55 +2,70 @@
 //# Dimensions Page Javascript #
 //############################
 
-
 $(function() {
+  show_maint_col = function(dimtype, show) {
+    var num_cols = $(".list-group:not('.hidden')").length;
+    if (show) {
+      $("#hide_" + dimtype + "_btn").removeClass("hidden");
+      $("#show_" + dimtype + "_btn").addClass("hidden");
+      $("." + dimtype + "-col").removeClass("hidden");
+    } else {
+      $("#show_" + dimtype + "_btn").removeClass("hidden");
+      $("#hide_" + dimtype + "_btn").addClass("hidden");
+      $("." + dimtype + "-col").addClass("hidden");
+    }
+    $(".sequence-grid").removeClass("cols-" + num_cols);
+    num_cols = $(".list-group:not('.hidden')").length;
+    num_cols = num_cols < 2 ? 2 : num_cols;
+    $(".sequence-grid").addClass("cols-" + num_cols);
+  };
   /**
    * Show a subject's dimension and lo column when the corresponding
    * radio button is checked.
    * @param  {String} subj_abbr Abbreviation for a subject.
    *                            E.g. 'bio', 'phy', etc.
    */
-    show_subject_dimensions = function (subj_abbr, page_title) {
-      $('.subject-column').addClass('hidden')
-    	$('#'+subj_abbr+'-dim-column').removeClass('hidden')
-      $('#'+subj_abbr+'-lo-column').removeClass('hidden')
-      connections_display(true)
-      $('.show-hide-gradeband').addClass('option-selected');
-      $('.dim-item').removeClass('hidden');
-      document.cookie = page_title + "_subject_visible=" + subj_abbr;
-    }
+  show_subject_dimensions = function(subj_abbr, page_title) {
+    $(".subject-column").addClass("hidden");
+    $("#" + subj_abbr + "-dim-column").removeClass("hidden");
+    $("#" + subj_abbr + "-lo-column").removeClass("hidden");
+    connections_display(true);
+    $(".show-hide-gradeband").addClass("option-selected");
+    $(".dim-item").removeClass("hidden");
+    document.cookie = page_title + "_subject_visible=" + subj_abbr;
+  };
 
   /**
    * Expand and highlight LO and dimension connections.
    */
-  connections_display = function (showall, rel, selected) {
-    console.log(rel, selected)
-    if ($(selected).hasClass('spotlight') || showall) {
-	  	$('.dim-item--collapsable')
-	  	  .removeClass('collapsed spotlight spotlight-akin show-connections-condition');
-	    $('.dim-item--collapsable')
-	  		.find('.connections-icon')
-	  		.attr('title', 'show connections');
-    }
-    else {
-      $('.dim-item--collapsable')
-  	   .addClass('collapsed')
-  	   .removeClass('spotlight spotlight-akin show-connections-condition')
-       .find('.connections-icon')
-       .attr('title', 'show connections');
-	  	  for (var r in rel) {
-	  	    $(rel[r]).removeClass('collapsed')
-	  		   .addClass('spotlight-akin show-connections-condition');
-	  	  }
+  connections_display = function(showall, rel, selected) {
+    console.log(rel, selected);
+    if ($(selected).hasClass("spotlight") || showall) {
+      $(".dim-item--collapsable").removeClass(
+        "collapsed spotlight spotlight-akin show-connections-condition"
+      );
+      $(".dim-item--collapsable")
+        .find(".connections-icon")
+        .attr("title", "show connections");
+    } else {
+      $(".dim-item--collapsable")
+        .addClass("collapsed")
+        .removeClass("spotlight spotlight-akin show-connections-condition")
+        .find(".connections-icon")
+        .attr("title", "show connections");
+      for (var r in rel) {
+        $(rel[r])
+          .removeClass("collapsed")
+          .addClass("spotlight-akin show-connections-condition");
+      }
       $(selected)
-        .removeClass('collapsed')
-        .addClass('spotlight show-connections-condition');
+        .removeClass("collapsed")
+        .addClass("spotlight show-connections-condition");
       $(selected)
-         .find('.connections-icon')
-         .attr('title', 'exit spotlight mode');
+        .find(".connections-icon")
+        .attr("title", "exit spotlight mode");
     }
-
-  }
+  };
 
   // showIndicators = function (show) {
   //   if (show) {
@@ -64,77 +79,76 @@ $(function() {
   //     $("#hide-indicators").attr("hidden", true)
   //   }
   // }
-
 });
 
-
-initializeDrag = function () {
-   $('.dimension-page .list-group-item').draggable({
-     revert: true,
-     zIndex: 101,
-     cursorAt: {
-            top: 60,
-            left: 60
-          },
-     helper: 'clone',
-     handle: '.connect-handle',
-     start: function (e, ui) {
-        console.log(ui)
-        $(ui.helper).addClass("ui-draggable-helper");
-     },
-     drag: function (e, ui) {
+initializeDrag = function() {
+  $(".dimension-page .list-group-item").draggable({
+    revert: true,
+    zIndex: 101,
+    cursorAt: {
+      top: 60,
+      left: 60
+    },
+    helper: "clone",
+    handle: ".connect-handle",
+    start: function(e, ui) {
+      console.log(ui);
+      $(ui.helper).addClass("ui-draggable-helper");
+    },
+    drag: function(e, ui) {
       //  var el_under_mouse = document.elementFromPoint(e.clientX, e.clientY);
       // //closest() returns null if no parent found with selector
       // el_under_mouse.closest('.list-group-item').className += 'highlight';
-     },
-     stop: function (e,ui) {
-      console.log(ui)
+    },
+    stop: function(e, ui) {
+      console.log(ui);
       var el_under_mouse = document.elementFromPoint(e.clientX, e.clientY);
       //closest() returns null if no parent found with selector
-      var item_to_connect = el_under_mouse.closest('.list-group-item')
+      var item_to_connect = el_under_mouse.closest(".list-group-item");
 
       //find out if the item being dragged is of the same type as the
       //item it was dropped on.
-      var types = [item_to_connect.dataset['loid'] == undefined, ui.helper[0].dataset['loid'] == undefined]
+      var types = [
+        item_to_connect.dataset["loid"] == undefined,
+        ui.helper[0].dataset["loid"] == undefined
+      ];
       //if an item is dropped on an item that is not of the same type
       if (item_to_connect != null && types[0] != types[1]) {
-        var tree_id, dimension_id
-        if (ui.helper[0].dataset['loid']) {
-        	tree_id = ui.helper[0].dataset['loid']
-          dimension_id = item_to_connect.id.split('_')[2]
+        var tree_id, dimension_id;
+        if (ui.helper[0].dataset["loid"]) {
+          tree_id = ui.helper[0].dataset["loid"];
+          dimension_id = item_to_connect.id.split("_")[2];
+        } else {
+          tree_id = item_to_connect.id.split("_")[2];
+          dimension_id = ui.helper[0].dataset["dimid"];
         }
-        else {
-          tree_id = item_to_connect.id.split('_')[2]
-          dimension_id = ui.helper[0].dataset['dimid']
-        }
-        console.log('treeeID', tree_id, "dimension_id", dimension_id)
-       // $("#modal_popup").modal('show');
+        console.log("treeeID", tree_id, "dimension_id", dimension_id);
+        // $("#modal_popup").modal('show');
         $.ajax({
-          "type": 'get',
-          "url": '/trees/edit_dimensions',
-          "data": {
-            "source_controller": 'trees',
-            "source_action": 'edit_dimensions',
+          type: "get",
+          url: "/trees/edit_dimensions",
+          data: {
+            source_controller: "trees",
+            source_action: "edit_dimensions",
             "tree[tree_id]": tree_id,
             "tree[dimension_id]": dimension_id
           },
-          "dataType": 'script',
-          "async": false
+          dataType: "script",
+          async: false
         })
-        .then(function (res) {
-          console.log("RESPONSE:", res)
-          //$("#modal-container").html(add_edit_dimtree_form(res))
-        })
-        .catch(function (err) { console.log("ERROR:", err) })
-
+          .then(function(res) {
+            console.log("RESPONSE:", res);
+            //$("#modal-container").html(add_edit_dimtree_form(res))
+          })
+          .catch(function(err) {
+            console.log("ERROR:", err);
+          });
       }
-     }
-   })
-}
+    }
+  });
+};
 
-
-
-$(document).on('turbolinks:load', function(event, state) {
- initializeDrag();
-})
+$(document).on("turbolinks:load", function(event, state) {
+  initializeDrag();
+});
 initializeDrag();

--- a/app/assets/javascripts/dimensions.js
+++ b/app/assets/javascripts/dimensions.js
@@ -124,15 +124,21 @@ initializeDrag = function() {
         }
         console.log("treeeID", tree_id, "dimension_id", dimension_id);
         // $("#modal_popup").modal('show');
+        var data = {
+          source_controller: "trees",
+          source_action: "edit_dimensions",
+          "tree[tree_id]": tree_id,
+          "tree[dimension_id]": dimension_id
+        };
+        if ($(".bigidea-col:not('.hidden')").length > 0)
+          data["show_bigidea"] = true;
+        if ($(".miscon-col:not('.hidden')").length > 0)
+          data["show_miscon"] = true;
+        console.log("data");
         $.ajax({
           type: "get",
           url: "/trees/edit_dimensions",
-          data: {
-            source_controller: "trees",
-            source_action: "edit_dimensions",
-            "tree[tree_id]": tree_id,
-            "tree[dimension_id]": dimension_id
-          },
+          data: data,
           dataType: "script",
           async: false
         })

--- a/app/assets/javascripts/dimensions.js
+++ b/app/assets/javascripts/dimensions.js
@@ -6,14 +6,26 @@ $(function() {
   show_maint_col = function(dimtype, show) {
     var num_cols = $(".list-group:not('.hidden')").length;
     if (show) {
-      $("#hide_" + dimtype + "_btn").removeClass("hidden");
-      $("#show_" + dimtype + "_btn").addClass("hidden");
-      $("." + dimtype + "-col").removeClass("hidden");
+      $("#hide_" + dimtype + "_btn")
+        .attr("aria-hidden", "false")
+        .removeClass("hidden");
+      $("#show_" + dimtype + "_btn")
+        .attr("aria-hidden", "true")
+        .addClass("hidden");
+      $("." + dimtype + "-col")
+        .attr("aria-hidden", "false")
+        .removeClass("hidden");
       document.cookie = dimtype + "_visible=true";
     } else {
-      $("#show_" + dimtype + "_btn").removeClass("hidden");
-      $("#hide_" + dimtype + "_btn").addClass("hidden");
-      $("." + dimtype + "-col").addClass("hidden");
+      $("#show_" + dimtype + "_btn")
+        .attr("aria-hidden", "false")
+        .removeClass("hidden");
+      $("#hide_" + dimtype + "_btn")
+        .attr("aria-hidden", "true")
+        .addClass("hidden");
+      $("." + dimtype + "-col")
+        .attr("aria-hidden", "true")
+        .addClass("hidden");
       document.cookie = dimtype + "_visible=false";
     }
     $(".sequence-grid").removeClass("cols-" + num_cols);

--- a/app/assets/javascripts/dimensions.js
+++ b/app/assets/javascripts/dimensions.js
@@ -9,10 +9,12 @@ $(function() {
       $("#hide_" + dimtype + "_btn").removeClass("hidden");
       $("#show_" + dimtype + "_btn").addClass("hidden");
       $("." + dimtype + "-col").removeClass("hidden");
+      document.cookie = dimtype + "_visible=true";
     } else {
       $("#show_" + dimtype + "_btn").removeClass("hidden");
       $("#hide_" + dimtype + "_btn").addClass("hidden");
       $("." + dimtype + "-col").addClass("hidden");
+      document.cookie = dimtype + "_visible=false";
     }
     $(".sequence-grid").removeClass("cols-" + num_cols);
     num_cols = $(".list-group:not('.hidden')").length;

--- a/app/assets/javascripts/sequence.js
+++ b/app/assets/javascripts/sequence.js
@@ -2,7 +2,6 @@
 //# Sequence Page Javascript #
 //############################
 
-
 $(function() {
   /**
    * Hide or show a subject column when the corresponding
@@ -10,25 +9,29 @@ $(function() {
    * @param  {String} subj_abbr Abbreviation for a subject.
    *                            E.g. 'bio', 'phy', etc.
    */
-  subject_visibility = function (subj_abbr, max_subjs, err_translation) {
-    err_translation = err_translation || "Maximum number of subjects that can be displayed: " + max_subjs
-    var num_checked = $('.subj-checkbox>input:checked').length
-  	if ($('#check-' + subj_abbr).prop('checked')) {
+  subject_visibility = function(subj_abbr, max_subjs, err_translation) {
+    err_translation =
+      err_translation ||
+      "Maximum number of subjects that can be displayed: " + max_subjs;
+    var num_checked = $(".subj-checkbox>input:checked").length;
+    if ($("#check-" + subj_abbr).prop("checked")) {
       if (num_checked <= max_subjs) {
-        $('#'+subj_abbr+'-column').removeClass('hidden')
-      }
-      else {
-        $('#check-' + subj_abbr).prop("checked", false)
+        $("#" + subj_abbr + "-column").removeClass("hidden");
+      } else {
+        $("#check-" + subj_abbr).prop("checked", false);
         if (err_translation) alert(err_translation);
-        return
+        return;
       }
-  	}
-  	else {
-  	   $('#'+subj_abbr+'-column').addClass('hidden')
-  	}
-  	$('.sequence-grid').removeClass('cols-0 cols-1 cols-2 cols-3 cols-4 cols-5 cols-6')
-  	$('.sequence-page .sequence-grid').addClass('cols-' + $('.subj-checkbox>input:checked').length )
-  }
+    } else {
+      $("#" + subj_abbr + "-column").addClass("hidden");
+    }
+    $(".sequence-grid").removeClass(
+      "cols-0 cols-1 cols-2 cols-3 cols-4 cols-5 cols-6"
+    );
+    $(".sequence-page .sequence-grid").addClass(
+      "cols-" + $(".subj-checkbox>input:checked").length
+    );
+  };
 
   /**
    * Hide or show LOs by subject and gradeband.
@@ -41,36 +44,44 @@ $(function() {
    *                        "all subjects" should update the
    *                        single-subject checkboxes.
    */
-  gradeband_visibility = function (subj_arr, gb_arr, multi) {
+  gradeband_visibility = function(subj_arr, gb_arr, multi) {
     var subj_abbr = subj_arr.pop();
     for (var gb in gb_arr) {
-      var gb_code = gb_arr[gb]
+      var gb_code = gb_arr[gb];
       if (gb_arr.length > 1) {
-        if ($('#all-gb-check-All').prop('checked')) {
-          $('#' + subj_abbr + '-gb-check-' + gb_code).prop('checked', true)
-          $('#all-gb-check-' + gb_code).prop('checked', true)
-          $('#'+subj_abbr+'-column .lo_gb_code_' + gb_code).removeClass('hidden')
+        if ($("#all-gb-check-All").prop("checked")) {
+          $("#" + subj_abbr + "-gb-check-" + gb_code).prop("checked", true);
+          $("#all-gb-check-" + gb_code).prop("checked", true);
+          $("#" + subj_abbr + "-column .lo_gb_code_" + gb_code).removeClass(
+            "hidden"
+          );
+        } else {
+          $("#" + subj_abbr + "-gb-check-" + gb_code).prop("checked", false);
+          $("#all-gb-check-" + gb_code).prop("checked", false);
+          $("#" + subj_abbr + "-column .lo_gb_code_" + gb_code).addClass(
+            "hidden"
+          );
         }
-        else {
-           $('#' + subj_abbr + '-gb-check-' + gb_code).prop('checked', false)
-           $('#all-gb-check-' + gb_code).prop('checked', false)
-           $('#'+subj_abbr+'-column .lo_gb_code_' + gb_code).addClass('hidden')
-         }
-      }
-      else {
-        if (($('#' + subj_abbr + '-gb-check-' + gb_code).prop('checked') && !multi) ||
-          ($('#all-gb-check-' + gb_code).prop('checked') && multi)) {
-           $('#' + subj_abbr + '-gb-check-' + gb_code).prop('checked', true)
-           $('#'+subj_abbr+'-column .lo_gb_code_' + gb_code).removeClass('hidden')
-        }
-        else {
-           $('#' + subj_abbr + '-gb-check-' + gb_code).prop('checked', false)
-           $('#'+subj_abbr+'-column .lo_gb_code_' + gb_code).addClass('hidden')
+      } else {
+        if (
+          ($("#" + subj_abbr + "-gb-check-" + gb_code).prop("checked") &&
+            !multi) ||
+          ($("#all-gb-check-" + gb_code).prop("checked") && multi)
+        ) {
+          $("#" + subj_abbr + "-gb-check-" + gb_code).prop("checked", true);
+          $("#" + subj_abbr + "-column .lo_gb_code_" + gb_code).removeClass(
+            "hidden"
+          );
+        } else {
+          $("#" + subj_abbr + "-gb-check-" + gb_code).prop("checked", false);
+          $("#" + subj_abbr + "-column .lo_gb_code_" + gb_code).addClass(
+            "hidden"
+          );
         }
       }
     }
     if (subj_arr.length > 0) gradeband_visibility(subj_arr, gb_arr, multi);
-  }
+  };
 
   /**
    * Generic toggle visibility method
@@ -81,75 +92,76 @@ $(function() {
    *                              settings with regard to the ".option-selected"
    *                              class.
    */
-  toggle_visibility = function (selector, trigger, matchTrigger) {
-    $(trigger).toggleClass('option-selected');
+  toggle_visibility = function(selector, trigger, matchTrigger) {
+    console.log(selector, trigger, matchTrigger);
+    $(trigger).toggleClass("option-selected");
     var sel = $(trigger).hasClass("option-selected");
     if (sel) {
-      $(selector).removeClass('hidden');
-      if ( $(trigger).hasClass('accordion')) {
-        $(trigger).removeClass('fa-expand');
-        $(trigger).addClass('fa-compress');
+      $(selector).removeClass("hidden");
+      if ($(trigger).hasClass("accordion")) {
+        $(trigger).removeClass("fa-expand");
+        $(trigger).addClass("fa-compress");
+      }
+      $(selector + " i.accordion").removeClass("fa-expand");
+      $(selector + " i.accordion").addClass("fa-compress");
+    } else {
+      $(selector).addClass("hidden");
+      if ($(trigger).hasClass("accordion")) {
+        $(trigger).removeClass("fa-compress");
+        $(trigger).addClass("fa-expand");
       }
     }
-    else {
-      $(selector).addClass('hidden');
-      if ( $(trigger).hasClass('accordion')) {
-        $(trigger).removeClass('fa-compress');
-        $(trigger).addClass('fa-expand');
-      }
+    if (matchTrigger != undefined && matchTrigger != "") {
+      $(matchTrigger).addClass(sel ? "option-selected" : "");
+      $(matchTrigger).removeClass(!sel ? "option-selected" : "");
     }
-    if (matchTrigger != undefined && matchTrigger != '') {
-        $(matchTrigger).addClass((sel ? "option-selected" : ""))
-        $(matchTrigger).removeClass((!sel ? "option-selected" : ""))
-    }
-  }
+  };
 
   /**
    * Expand and highlight related LOs
    */
-  related_LO_display = function (rel, selected_LO) {
-    if ($("#lo_" + selected_LO).hasClass('spotlight')) {
-	  	$('.sequence-item--collapsable')
-	  	  .removeClass('collapsed spotlight spotlight-depends spotlight-akin spotlight-applies show-connections-condition');
-	  	for (var r in rel) {
-	  		$('li[data-lo-id='+rel[r][1]+']')
-	  		 .find('.connections-icon')
-	  		 .attr('title', 'show related LOs');
-	  	}
-    }
-    else {
-      $('.sequence-item--collapsable')
-  	  .addClass('collapsed')
-  	  .removeClass('spotlight spotlight-depends spotlight-akin spotlight-applies show-connections-condition');
-	  	for (var r in rel) {
-	  	  console.log('spotlight ', rel[r][1])
-	  	  $("#lo_" + rel[r][1])
-	  		.removeClass('collapsed')
-	  		.addClass('spotlight-' + rel[r][0] + ' show-connections-condition');
-	  	}
+  related_LO_display = function(rel, selected_LO) {
+    if ($("#lo_" + selected_LO).hasClass("spotlight")) {
+      $(".sequence-item--collapsable").removeClass(
+        "collapsed spotlight spotlight-depends spotlight-akin spotlight-applies show-connections-condition"
+      );
+      for (var r in rel) {
+        $("li[data-lo-id=" + rel[r][1] + "]")
+          .find(".connections-icon")
+          .attr("title", "show related LOs");
+      }
+    } else {
+      $(".sequence-item--collapsable")
+        .addClass("collapsed")
+        .removeClass(
+          "spotlight spotlight-depends spotlight-akin spotlight-applies show-connections-condition"
+        );
+      for (var r in rel) {
+        console.log("spotlight ", rel[r][1]);
+        $("#lo_" + rel[r][1])
+          .removeClass("collapsed")
+          .addClass("spotlight-" + rel[r][0] + " show-connections-condition");
+      }
       $("#lo_" + selected_LO)
-        .removeClass('collapsed')
-        .addClass('spotlight show-connections-condition');
+        .removeClass("collapsed")
+        .addClass("spotlight show-connections-condition");
       $("#lo_" + selected_LO)
-         .find('.connections-icon')
-         .attr('title', 'exit related LOs mode');
+        .find(".connections-icon")
+        .attr("title", "exit related LOs mode");
     }
+  };
 
-  }
-
-  showIndicators = function (show) {
+  showIndicators = function(show) {
     if (show) {
-      $(".indicators-container").removeClass("hidden")
-      $("#show-indicators").attr("hidden", true)
-      $("#hide-indicators").attr("hidden", false)
+      $(".indicators-container").removeClass("hidden");
+      $("#show-indicators").attr("hidden", true);
+      $("#hide-indicators").attr("hidden", false);
+    } else {
+      $(".indicators-container").addClass("hidden");
+      $("#show-indicators").attr("hidden", false);
+      $("#hide-indicators").attr("hidden", true);
     }
-    else {
-      $(".indicators-container").addClass("hidden")
-      $("#show-indicators").attr("hidden", false)
-      $("#hide-indicators").attr("hidden", true)
-    }
-  }
-
+  };
 });
 
 /**
@@ -160,21 +172,27 @@ $(function() {
  *                            TreeTree/LO connection
  *                            being updated.
  */
-patch_from_tree_tree_form = function (tree_tree_id) {
-  explanation = $('form#tree_tree_add_edit [name="tree_tree[explanation]"]').val();
-  relationship = $('form#tree_tree_add_edit #relationship').children("option:selected").val();
-  active = $('form#tree_tree_add_edit [name="tree_tree[active]"]').prop("checked");
+patch_from_tree_tree_form = function(tree_tree_id) {
+  explanation = $(
+    'form#tree_tree_add_edit [name="tree_tree[explanation]"]'
+  ).val();
+  relationship = $("form#tree_tree_add_edit #relationship")
+    .children("option:selected")
+    .val();
+  active = $('form#tree_tree_add_edit [name="tree_tree[active]"]').prop(
+    "checked"
+  );
   console.log("ACTIVE", active);
 
   data = {
-          "source_controller": "tree_trees",
-          "source_action": "update",
-          "tree_tree[explanation]" : explanation,
-          "tree_tree[relationship]" : relationship,
-          "tree_tree[active]" : active
-        };
+    source_controller: "tree_trees",
+    source_action: "update",
+    "tree_tree[explanation]": explanation,
+    "tree_tree[relationship]": relationship,
+    "tree_tree[active]": active
+  };
   ajax_update_tree_tree(tree_tree_id, data);
-}
+};
 
 /**
  * Send a PATCH request to /tree_trees/:id with ajax
@@ -190,28 +208,32 @@ patch_from_tree_tree_form = function (tree_tree_id) {
  *                            set to active with this
  *                            update?
  */
-patch_tree_tree_activation = function (tree_tree_id, active) {
+patch_tree_tree_activation = function(tree_tree_id, active) {
   data = {
-          "source_controller": "tree_trees",
-          "source_action": "update",
-          "tree_tree[active]" : active
-        };
-  ajax_update_tree_tree(tree_tree_id, data)
-}
+    source_controller: "tree_trees",
+    source_action: "update",
+    "tree_tree[active]": active
+  };
+  ajax_update_tree_tree(tree_tree_id, data);
+};
 
-ajax_update_tree_tree = function (tree_tree_id, data) {
-  token = $("meta[name='csrf-token']").attr('content');
+ajax_update_tree_tree = function(tree_tree_id, data) {
+  token = $("meta[name='csrf-token']").attr("content");
   $.ajax({
-      "type": 'patch',
-      "url": '/tree_trees/' + tree_tree_id,
-      "headers": { 'X-CSRF-Token': token },
-      "data": data,
-      "dataType": "json",
-      "async": false
+    type: "patch",
+    url: "/tree_trees/" + tree_tree_id,
+    headers: { "X-CSRF-Token": token },
+    data: data,
+    dataType: "json",
+    async: false
+  })
+    .then(function() {
+      location.reload();
     })
-    .then(function () { location.reload() })
-    .catch(function (err) { console.log("ERROR:", err) })
-}
+    .catch(function(err) {
+      console.log("ERROR:", err);
+    });
+};
 
 /**
  * Build the add-edit form html for TreeTrees/LO connections,
@@ -221,75 +243,101 @@ ajax_update_tree_tree = function (tree_tree_id, data) {
  *                     or created.
  * @returns {string} html form for the add-edit popup.
  */
-add_edit_form = function (res) {
-  edit_mode = res.tree_tree.id != null
+add_edit_form = function(res) {
+  edit_mode = res.tree_tree.id != null;
   if (edit_mode) {
-    submit_button = '<button type="button" \
-        onclick="patch_from_tree_tree_form('
-        + res.tree_tree.id
-        +')">SAVE</button>'
+    submit_button =
+      '<button type="button" \
+        onclick="patch_from_tree_tree_form(' +
+      res.tree_tree.id +
+      ')">SAVE</button>';
+  } else {
+    submit_button = '<button type="submit">SAVE</button>';
   }
-  else {
-    submit_button = '<button type="submit">SAVE</button>'
-  }
-  return '<div class="modal-header"> \
-          <h3 id="myModalLabel"> LO '+  res.translations.relationship +'</h3> \
+  return (
+    '<div class="modal-header"> \
+          <h3 id="myModalLabel"> LO ' +
+    res.translations.relationship +
+    '</h3> \
           </div> \
           <div class="modal-body"> \
-          <form id="tree_tree_add_edit" action="/tree_trees"' + (edit_mode ? '>' : 'method="POST">')
-          + '<div> \
-          <input type="hidden" name="authenticity_token" value="' + $('[name="csrf-token"]').attr('content') + '"> \
-          <input type="hidden" name="tree_tree[tree_referencer_id]" value=' + res.tree_tree.tree_referencer_id +'> \
-          <input type="hidden" name="tree_tree[tree_referencee_id]" value=' + res.tree_tree.tree_referencee_id + '> \
+          <form id="tree_tree_add_edit" action="/tree_trees"' +
+    (edit_mode ? ">" : 'method="POST">') +
+    '<div> \
+          <input type="hidden" name="authenticity_token" value="' +
+    $('[name="csrf-token"]').attr("content") +
+    '"> \
+          <input type="hidden" name="tree_tree[tree_referencer_id]" value=' +
+    res.tree_tree.tree_referencer_id +
+    '> \
+          <input type="hidden" name="tree_tree[tree_referencee_id]" value=' +
+    res.tree_tree.tree_referencee_id +
+    '> \
           </div> \
           <fieldset> \
-          <label for="relationship">' + res.translations.relationship + '</label><br>'
-          + res.referencer_code + '<br> \
+          <label for="relationship">' +
+    res.translations.relationship +
+    "</label><br>" +
+    res.referencer_code +
+    '<br> \
           <select id="relationship" name="tree_tree[relationship]"> \
-          <option value="' + res.relation_values.applies
-          + (res.tree_tree.relationship == 'applies' ? '" selected>': '">')
-          + res.translations.applies
-          + '</option> \
-          <option value="' + res.relation_values.depends
-          + (res.tree_tree.relationship == 'depends' ? '" selected>': '">')
-          + res.translations.depends
-          + '</option> \
-          <option value="' + res.relation_values.akin
-          + (res.tree_tree.relationship == 'akin' ? '" selected>': '">')
-          + res.translations.akin
-          + '</option> \
+          <option value="' +
+    res.relation_values.applies +
+    (res.tree_tree.relationship == "applies" ? '" selected>' : '">') +
+    res.translations.applies +
+    '</option> \
+          <option value="' +
+    res.relation_values.depends +
+    (res.tree_tree.relationship == "depends" ? '" selected>' : '">') +
+    res.translations.depends +
+    '</option> \
+          <option value="' +
+    res.relation_values.akin +
+    (res.tree_tree.relationship == "akin" ? '" selected>' : '">') +
+    res.translations.akin +
+    "</option> \
           </select> \
-          <div>' + res.referencee_code + '</div><br> \
+          <div>" +
+    res.referencee_code +
+    '</div><br> \
           </fieldset> \
           <fieldset> \
-            <label for="explanation">' + res.translations.explanation_label + '<br> \
-            <textarea type="text" name="tree_tree[explanation]">'
-            + (res.translations.explanation != undefined ? res.translations.explanation : '')
-            +'</textarea> \
+            <label for="explanation">' +
+    res.translations.explanation_label +
+    '<br> \
+            <textarea type="text" name="tree_tree[explanation]">' +
+    (res.translations.explanation != undefined
+      ? res.translations.explanation
+      : "") +
+    '</textarea> \
           </fieldset> \
           <fieldset><label for="tree_tree[active]">Active?</label>\
-          <input name="tree_tree[active]" type="checkbox"'
-          + (res.tree_tree.active ? ' checked' : '') + '></input></fieldset>'
-          + submit_button
-          + '<button type="button" type="button" data-dismiss="modal" \
+          <input name="tree_tree[active]" type="checkbox"' +
+    (res.tree_tree.active ? " checked" : "") +
+    "></input></fieldset>" +
+    submit_button +
+    '<button type="button" type="button" data-dismiss="modal" \
           aria-hidden="true">CANCEL</button> \
           </div> \
           </form>'
-}
+  );
+};
 
-edit_tree_tree = function (tree_tree_id) {
-  $("#modal_popup").modal('show');
-        $.ajax({
-          "type": 'get',
-          "url": '/tree_trees/'+ tree_tree_id + '/edit/',
-          "async": false
-        })
-        .then(function (res) {
-          console.log("RESPONSE:", res.tree_tree.id)
-          $("#modal-container").html(add_edit_form(res))
-        })
-        .catch(function (err) { console.log("ERROR:", err) })
-}
+edit_tree_tree = function(tree_tree_id) {
+  $("#modal_popup").modal("show");
+  $.ajax({
+    type: "get",
+    url: "/tree_trees/" + tree_tree_id + "/edit/",
+    async: false
+  })
+    .then(function(res) {
+      console.log("RESPONSE:", res.tree_tree.id);
+      $("#modal-container").html(add_edit_form(res));
+    })
+    .catch(function(err) {
+      console.log("ERROR:", err);
+    });
+};
 
 /**
  *
@@ -299,93 +347,98 @@ edit_tree_tree = function (tree_tree_id) {
  *    behavior for LOs within and across subjects and
  *    gradebands.
  */
-initializeSortAndDrag = function () {
-   $('.sequence-page .list-group').sortable({
+initializeSortAndDrag = function() {
+  $(".sequence-page .list-group").sortable({
     //specify only .list-group-items
     //should be sortable (to
     //exclude subject headers)
-    items: '.list-group-item',
-    placeholder: 'drop-placeholder',
-    handle: '.sort-handle',
-    stop: function (e, ui) {
-      console.log('e:', e)
-      console.log('ui:', ui)
-      tree_ids = $.map($(this).find('.sequence-item'), function(el) {
-                 return el.id.split('_')[1]
-              });
+    items: ".list-group-item",
+    placeholder: "drop-placeholder",
+    handle: ".sort-handle",
+    stop: function(e, ui) {
+      console.log("e:", e);
+      console.log("ui:", ui);
+      tree_ids = $.map($(this).find(".sequence-item"), function(el) {
+        return el.id.split("_")[1];
+      });
       console.log(tree_ids);
-      token = $("meta[name='csrf-token']").attr('content');
+      token = $("meta[name='csrf-token']").attr("content");
 
       $.ajax({
-        "type": 'post',
-        "url": '/trees/reorder',
-        "headers": { 'X-CSRF-Token': token },
-        "data": {
-          "source_controller": 'trees',
-          "source_action": 'reorder',
-          "id_order": tree_ids
+        type: "post",
+        url: "/trees/reorder",
+        headers: { "X-CSRF-Token": token },
+        data: {
+          source_controller: "trees",
+          source_action: "reorder",
+          id_order: tree_ids
         },
-        "dataType": 'json',
-        "async": false
-      })
-      .catch(function (err) { console.log("ERROR:", err) })
+        dataType: "json",
+        async: false
+      }).catch(function(err) {
+        console.log("ERROR:", err);
+      });
     }
-    })
+  });
 
-   $('.sequence-page .list-group-item').draggable({
-     revert: true,
-     zIndex: 101,
-     cursorAt: {
-            top: 60,
-            left: 60
-          },
-     helper: 'clone',
-     handle: '.connect-handle',
-     start: function (e, ui) {
-        console.log(ui)
-        $(ui.helper).addClass("ui-draggable-helper");
-     },
-     drag: function (e, ui) {
+  $(".sequence-page .list-group-item").draggable({
+    revert: true,
+    zIndex: 101,
+    cursorAt: {
+      top: 60,
+      left: 60
+    },
+    helper: "clone",
+    handle: ".connect-handle",
+    start: function(e, ui) {
+      console.log(ui);
+      $(ui.helper).addClass("ui-draggable-helper");
+    },
+    drag: function(e, ui) {
       //  var el_under_mouse = document.elementFromPoint(e.clientX, e.clientY);
       // //closest() returns null if no parent found with selector
       // el_under_mouse.closest('.list-group-item').className += 'highlight';
-     },
-     stop: function (e,ui) {
-      console.log(ui)
+    },
+    stop: function(e, ui) {
+      console.log(ui);
       var el_under_mouse = document.elementFromPoint(e.clientX, e.clientY);
       //closest() returns null if no parent found with selector
-      var lo_to_connect = el_under_mouse.closest('.list-group-item')
+      var lo_to_connect = el_under_mouse.closest(".list-group-item");
       if (lo_to_connect != null) {
-        lo_to_connect = lo_to_connect.id.split('_')[1];
-        lo_being_dragged = ui.helper[0].dataset['loId']
-        console.log('under mouse', lo_to_connect, 'original obj',  lo_being_dragged);
-        $("#modal_popup").modal('show');
+        lo_to_connect = lo_to_connect.id.split("_")[1];
+        lo_being_dragged = ui.helper[0].dataset["loId"];
+        console.log(
+          "under mouse",
+          lo_to_connect,
+          "original obj",
+          lo_being_dragged
+        );
+        $("#modal_popup").modal("show");
         $.ajax({
-          "type": 'get',
-          "url": '/tree_trees/new',
-          "data": {
-            "source_controller": 'tree_trees',
-            "source_action": 'new',
+          type: "get",
+          url: "/tree_trees/new",
+          data: {
+            source_controller: "tree_trees",
+            source_action: "new",
             "tree_tree[tree_referencer_id]": lo_being_dragged,
             "tree_tree[tree_referencee_id]": lo_to_connect
           },
-          "dataType": 'json',
-          "async": false
+          dataType: "json",
+          async: false
         })
-        .then(function (res) {
-          console.log("RESPONSE:", res.tree_tree.id)
-          $("#modal-container").html(add_edit_form(res))
-        })
-        .catch(function (err) { console.log("ERROR:", err) })
-
+          .then(function(res) {
+            console.log("RESPONSE:", res.tree_tree.id);
+            $("#modal-container").html(add_edit_form(res));
+          })
+          .catch(function(err) {
+            console.log("ERROR:", err);
+          });
       }
-     }
-   })
-}
+    }
+  });
+};
 
-
-
-$(document).on('turbolinks:load', function(event, state) {
- initializeSortAndDrag();
-})
+$(document).on("turbolinks:load", function(event, state) {
+  initializeSortAndDrag();
+});
 initializeSortAndDrag();

--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -71,6 +71,10 @@ body {
       cursor: pointer;
     }
   }
+
+  .margin-bottom {
+    margin-bottom: 10px;
+  }
 }
 
 // use font awesome fonts for glyphicon classes (for bootstrap 3 treeview library)

--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -72,6 +72,12 @@ body {
     }
   }
 
+  .tooltip {
+    * {
+      width: 40vw;
+    }
+  }
+
   .margin-bottom {
     margin-bottom: 10px;
   }

--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -65,6 +65,12 @@ body {
     font-weight: bold;
     color: black;
   }
+
+  .accordion {
+    &:hover {
+      cursor: pointer;
+    }
+  }
 }
 
 // use font awesome fonts for glyphicon classes (for bootstrap 3 treeview library)

--- a/app/controllers/sectors_controller.rb
+++ b/app/controllers/sectors_controller.rb
@@ -3,7 +3,7 @@ class SectorsController < ApplicationController
 
   def index
 
-    @subjects = Subject.where(:tree_type_id => @treeTypeRec.id).order(:code)
+    @subjects = Subject.where("tree_type_id = ? AND min_grade < ?", @treeTypeRec.id, 999).order("max_grade desc", "min_grade asc", "code")
     @gbs = GradeBand.where(:tree_type_id => @treeTypeRec.id)
     @sectors = Sector.where(:sector_set_code => @treeTypeRec.sector_set_code)
     @sector = Sector.new

--- a/app/controllers/trees_controller.rb
+++ b/app/controllers/trees_controller.rb
@@ -178,6 +178,8 @@ class TreesController < ApplicationController
 
     treePrep
     @editing = params[:editme] && current_user.is_admin?
+    @show_miscon = params[:show_miscon]
+    @show_bigidea = params[:show_bigidea] || @editing
 
     @treeByParents = Hash.new{ |h, k| h[k] = {} }
     dimtrees_by_tree_id = Hash.new{ |h, k| h[k] = [] }
@@ -587,7 +589,7 @@ class TreesController < ApplicationController
       end
     end #end transaction
     @editing = true
-    redirect_to maint_trees_path(editme: true)
+    redirect_to maint_trees_path(editme: true, show_bigidea: true)
   end
 
   def update_dim_tree
@@ -616,7 +618,7 @@ class TreesController < ApplicationController
         errors << e
       end
     end #end transaction
-    redirect_to maint_trees_path(editme: true)
+    redirect_to maint_trees_path(editme: true, show_bigidea: true)
   end
 
   def show

--- a/app/controllers/trees_controller.rb
+++ b/app/controllers/trees_controller.rb
@@ -190,7 +190,7 @@ class TreesController < ApplicationController
     @dim_grades['miscon'] = { min_grade: @dim_subjs['miscon'].min_grade, max_grade: @dim_subjs['miscon'].max_grade} if @dim_subjs['miscon'].present?
 
     # Get dimensions and dimtrees for displayed curriculum
-    @dimtrees = DimTree.joins(:dimension).where(:tree_id => @trees.pluck("id"))
+    @dimtrees = DimTree.active.joins(:dimension).where(:tree_id => @trees.pluck("id"))
     dimKeys = @dimtrees.pluck('dim_explanation_key')
     @idea_subj_base_key = "#{@trees.first.subject.base_key}.name" if @trees.first.present?
     @misc_subj_base_key = "#{@trees.first.subject.base_key}.name" if @trees.first.present?
@@ -586,7 +586,8 @@ class TreesController < ApplicationController
         errors << e
       end
     end #end transaction
-    redirect_to controller: 'trees', action: 'dimensions', dim_type: dim_tree_params[:dim_type]
+    @editing = true
+    redirect_to maint_trees_path(editme: true)
   end
 
   def update_dim_tree
@@ -615,7 +616,7 @@ class TreesController < ApplicationController
         errors << e
       end
     end #end transaction
-    redirect_to controller: 'trees', action: 'dimensions', dim_type: dim_tree_params[:dim_type]
+    redirect_to maint_trees_path(editme: true)
   end
 
   def show

--- a/app/controllers/trees_controller.rb
+++ b/app/controllers/trees_controller.rb
@@ -225,7 +225,7 @@ class TreesController < ApplicationController
     end
 
     saved_dim_tree = @dimtrees.find(dim_tree_params[:id]) if (dim_tree_params && dim_tree_params[:id])
-    flash[:notice] = "Saved relationship: #{@hierarchies[@treeTypeRec.outcome_depth]} #{saved_dim_tree.tree.code} is related to the #{translate('nav_bar.'+saved_dim_tree.dimension.dim_type+'.name')}, \"#{@translations[saved_dim_tree.dimension.dim_name_key]}\"" if saved_dim_tree
+    flash[:notice] = I18n.translate("app.notice.saved_relationship", item_type_1: @hierarchies[@treeTypeRec.outcome_depth], item_desc_1: saved_dim_tree.tree.code, item_type_2: translate('nav_bar.'+saved_dim_tree.dimension.dim_type+'.name').singularize, item_desc_2: "\"#{@translations[saved_dim_tree.dimension.dim_name_key]}\"") if saved_dim_tree
 
     respond_to do |format|
       format.html { render 'maint'}

--- a/app/controllers/trees_controller.rb
+++ b/app/controllers/trees_controller.rb
@@ -246,7 +246,7 @@ class TreesController < ApplicationController
     @gradebands = ["All", *listing.joins(:grade_band).pluck('grade_bands.code').uniq]
     @subjects = {}
     subjIds = {}
-    subjects = Subject.where(:tree_type_id => @treeTypeRec.id)
+    subjects = Subject.where("tree_type_id = ? AND min_grade < ?", @treeTypeRec.id, 999).order("max_grade desc", "min_grade asc", "code")
     subjects.each do |s|
       @subjects[s.code] = s
       subjIds[s.id.to_s] = s
@@ -393,7 +393,8 @@ class TreesController < ApplicationController
     @subj_gradebands = Hash.new { |h, k| h[k] = [] }
     @subjects = {}
     subjIds = {}
-    subjects = Subject.where(:tree_type_id => @treeTypeRec.id)
+    subjects = Subject.where("tree_type_id = ? AND min_grade < ?", @treeTypeRec.id, 999).order("max_grade desc", "min_grade asc", "code")
+    @default_subj_code = subjects.first.code if subjects.count > 0
     include_science = subjects.pluck('code').include?("sci")
     subjects.each do |s|
       @subjects[s.code] = s
@@ -896,7 +897,7 @@ class TreesController < ApplicationController
   end
 
   def index_prep
-    @subjects = Subject.all.order(:code)
+    @subjects = Subject.where("tree_type_id = ? AND min_grade < ?", @treeTypeRec.id, 999).order("max_grade desc", "min_grade asc", "code")
     @gbs = GradeBand.all
     # @gbs_upper = GradeBand.where(code: ['9','13'])
     @tree = Tree.new(
@@ -910,7 +911,7 @@ class TreesController < ApplicationController
     Rails.logger.debug("*** @treeTypeRec: #{@treeTypeRec.inspect}")
     @subjects = {}
     subjIds = {}
-    Subject.where(tree_type_id: @treeTypeRec.id).each do |s|
+    Subject.where("tree_type_id = ? AND min_grade < ?", @treeTypeRec.id, 999).order("max_grade desc", "min_grade asc", "code").each do |s|
       @subjects[s.code] = s
       subjIds[s.id.to_s] = s
     end

--- a/app/controllers/trees_controller.rb
+++ b/app/controllers/trees_controller.rb
@@ -912,7 +912,8 @@ class TreesController < ApplicationController
     Rails.logger.debug("*** @treeTypeRec: #{@treeTypeRec.inspect}")
     @subjects = {}
     subjIds = {}
-    Subject.where("tree_type_id = ? AND min_grade < ?", @treeTypeRec.id, 999).order("max_grade desc", "min_grade asc", "code").each do |s|
+    @subj_list = Subject.where("tree_type_id = ? AND min_grade < ?", @treeTypeRec.id, 999).order("max_grade desc", "min_grade asc", "code")
+    @subj_list.each do |s|
       @subjects[s.code] = s
       subjIds[s.id.to_s] = s
     end
@@ -922,7 +923,7 @@ class TreesController < ApplicationController
     Rails.logger.debug("*** @gbs: #{@gbs.inspect}")
 
     # get subject from tree param or from cookie (app controller getSubjectCode)
-    if params[:tree].present? && tree_params[:subject_id].present?
+    if params[:tree].present? && tree_params[:subject_id].present? && subjIds[tree_params[:subject_id]]
       @subj = subjIds[tree_params[:subject_id]]
       Rails.logger.debug("*** index_listing params ID: #{tree_params[:subject_id]}")
     elsif @subject_code.present? && @subjects[@subject_code].present?
@@ -932,7 +933,7 @@ class TreesController < ApplicationController
       subjCode, @subj = @subjects.first
       Rails.logger.debug("*** index_listing no match: #{subjCode} #{@subj.inspect}")
     else
-      @subj = Subject.new
+      @subj = @subj_list.first || Subject.new
     end
 
     Rails.logger.debug("*** @subject_code: #{@subject_code.inspect}")

--- a/app/controllers/trees_controller.rb
+++ b/app/controllers/trees_controller.rb
@@ -180,9 +180,9 @@ class TreesController < ApplicationController
     treePrep
     dimPrep
     @editing = params[:editme] && current_user.present? && current_user.is_admin?
-    @show_miscon = cookies[:miscon_visible] == "true" #params[:show_miscon]
-    @show_bigidea = cookies[:bigidea_visible] == "true" #params[:show_bigidea]
-    @show_bigidea = @editing if !(@show_bigidea || @show_miscon)
+    @page_title = @editing ? translate('trees.maint.title') : (dim_tree_params && dim_tree_params[:dim_type] ? translate('nav_bar.'+dim_tree_params[:dim_type]+'.name') : @hierarchies[@treeTypeRec.outcome_depth].pluralize )
+    @show_miscon = dim_tree_params && dim_tree_params[:dim_type] ? (dim_tree_params[:dim_type] == @treeTypeRec.miscon_dim_type) : (cookies[:miscon_visible] == "true") #params[:show_miscon]
+    @show_bigidea = dim_tree_params && dim_tree_params[:dim_type] ? (dim_tree_params[:dim_type] == @treeTypeRec.big_ideas_dim_type) : (cookies[:bigidea_visible] == "true") #params[:show_bigidea]
 
     @treeByParents = Hash.new{ |h, k| h[k] = {} }
 
@@ -1056,12 +1056,6 @@ class TreesController < ApplicationController
     @dim_grades = Hash.new{ |h, k| h[k] = {} }
     @dim_subjs = {}
     dimKeys = []
-
-    # If loading this page for the first time or changing subjects, reset
-    if !dim_tree_params
-      cookies[:bigidea_visible] = @editing ? "true" : params[:show_bigidea]
-      cookies[:miscon_visible] = params[:show_miscon]
-    end
 
     if dim_tree_params && dim_tree_params[:bigidea_subj_id]
       @dim_subjs['bigidea'] = Subject.find(dim_tree_params[:bigidea_subj_id])

--- a/app/controllers/trees_controller.rb
+++ b/app/controllers/trees_controller.rb
@@ -201,6 +201,7 @@ class TreesController < ApplicationController
         gb_code: tree.grade_band.code,
         code: tree.code,
         last_code: tree.codeArrayAt(tree.depth-1),
+        selectors_by_parent: tree.parentCodes.map { |pc| "child-of-#{pc.split(".").join("-")}" if pc != "" }.join(" "),
         depth_name: @hierarchies[tree.depth-1],
         text: "#{tree.code}: #{translation}"
         #connections: @relations[tree.id]

--- a/app/controllers/trees_controller.rb
+++ b/app/controllers/trees_controller.rb
@@ -177,6 +177,7 @@ class TreesController < ApplicationController
     # - should be able to drag hierarchy items (and LOs) to the editing column on the left.
 
     treePrep
+    @editing = params[:editme] && current_user.is_admin?
 
     @treeByParents = Hash.new{ |h, k| h[k] = {} }
 
@@ -219,9 +220,6 @@ class TreesController < ApplicationController
       format.html { render 'maint'}
     end
 
-  end
-
-  def outcomes
   end
 
   def sequence
@@ -853,7 +851,8 @@ class TreesController < ApplicationController
       :edit_type,
       :attr_id,
       :name_translation,
-      :active
+      :active,
+      :editing,
     )
   end
 

--- a/app/controllers/trees_controller.rb
+++ b/app/controllers/trees_controller.rb
@@ -221,6 +221,9 @@ class TreesController < ApplicationController
 
   end
 
+  def outcomes
+  end
+
   def sequence
     index_prep
     @max_subjects = 6

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -127,7 +127,6 @@ class UsersController < ApplicationController
     safe_to_refresh = [
       "trees",
       "index",
-      "sequence",
       "maint",
       "dimensions?dim_type=bigidea",
       "dimensions?dim_type=miscon",

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -31,7 +31,7 @@ module ApplicationHelper
     else
       ret = []
     end
-    Subject.where(:tree_type_id => tree_type_id).each do |s|
+    Subject.where("tree_type_id = ? AND min_grade < ?", tree_type_id, 999).order("max_grade desc", "min_grade asc", "code").each do |s|
       # ret << [ @translations["sector.#{s.code}.name"], s.id ]
       ret << [s.code, s.id]
     end

--- a/app/models/subject.rb
+++ b/app/models/subject.rb
@@ -21,4 +21,10 @@ class Subject < BaseRec
     Translation.where(locale: loc, key: self.base_key+'.name').first.value
   end
 
+  def getSubjectGradeBands()
+    gbIDs = Tree.where(:subject_id => self.id).pluck('grade_band_id').uniq
+    gbRecs = GradeBand.where(:id => gbIDs).order('max_grade asc')
+    gbRecs
+  end
+
 end

--- a/app/models/tree.rb
+++ b/app/models/tree.rb
@@ -97,6 +97,16 @@ class Tree < BaseRec
     end
   end
 
+  def parentCodes
+    arr = self.codeArray
+    ret = []
+    while arr && arr.length > 0
+      arr.pop(1)
+      ret << arr.join('.')
+    end
+    ret
+  end
+
   # overrides of deprecated depth field
   def depth
     return codeArray.length

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -78,12 +78,12 @@
     end
     if controller.controller_name == 'trees' && action_name == 'outcomes' %>
       <li class="nav-item active" aria-selected='true'>
-        <a class="nav-link btn btn-primary" href=<%= outcomes_trees_path %>><%= @hierarchies[@treeTypeRec[:outcome_depth]].pluralize %></a>
+        <a class="nav-link btn btn-primary" href=<%= maint_trees_path() %>><%= @hierarchies[@treeTypeRec[:outcome_depth]].pluralize %></a>
       </li>
     <%
     else %>
       <li class="nav-item" role='menuitem'>
-        <a class="nav-link btn btn-primary" href=<%= outcomes_trees_path %>><%= @hierarchies[@treeTypeRec[:outcome_depth]].pluralize %></a>
+        <a class="nav-link btn btn-primary" href=<%= maint_trees_path() %>><%= @hierarchies[@treeTypeRec[:outcome_depth]].pluralize %></a>
       </li>
     <%
     end
@@ -128,12 +128,12 @@
     if current_user.present? && current_user.is_admin?
       if controller.controller_name == 'trees' && action_name == 'maint' %>
         <li class="nav-item active" aria-selected='true'>
-          <a class="nav-link btn btn-primary" href=<%= maint_trees_path() %>><%= translate('nav_bar.maint.name') %></a>
+          <a class="nav-link btn btn-primary" href=<%= maint_trees_path(editme: true) %>><%= translate('nav_bar.maint.name') %></a>
         </li>
   <%
       else %>
         <li class="nav-item" role='menuitem'>
-          <a class="nav-link btn btn-primary" href=<%= maint_trees_path() %>><%= translate('nav_bar.maint.name') %></a>
+          <a class="nav-link btn btn-primary" href=<%= maint_trees_path(editme: true) %>><%= translate('nav_bar.maint.name') %></a>
         </li>
   <%
       end

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -76,27 +76,18 @@
       </li>
     <%
     end
-    if controller.controller_name == 'sectors' && action_name == 'index' %>
+    if controller.controller_name == 'trees' && action_name == 'outcomes' %>
       <li class="nav-item active" aria-selected='true'>
-        <a class="nav-link btn btn-primary" href=<%= sectors_path %>><%= translate('nav_bar.sectors.name') %></a>
-      </li>
-    <% else %>
-      <li class="nav-item" role='menuitem'>
-        <a class="nav-link btn btn-primary" href=<%= sectors_path %>><%= translate('nav_bar.sectors.name') %></a>
-      </li>
-    <% end
-    if controller.controller_name == 'trees' && action_name == 'sequence' %>
-      <li class="nav-item active" aria-selected='true'>
-        <a class="nav-link btn btn-primary" href=<%= sequence_trees_path %>><%= translate('nav_bar.relations.name') %></a>
+        <a class="nav-link btn btn-primary" href=<%= outcomes_trees_path %>><%= @hierarchies[@treeTypeRec[:outcome_depth]].pluralize %></a>
       </li>
     <%
     else %>
       <li class="nav-item" role='menuitem'>
-        <a class="nav-link btn btn-primary" href=<%= sequence_trees_path %>><%= translate('nav_bar.relations.name') %></a>
+        <a class="nav-link btn btn-primary" href=<%= outcomes_trees_path %>><%= @hierarchies[@treeTypeRec[:outcome_depth]].pluralize %></a>
       </li>
     <%
     end
-    if controller.controller_name == 'trees'  && action_name == 'dimensions' && params[:dim_type] == @treeTypeRec.big_ideas_dim_type && @treeTypeRec.big_ideas_dim_type %>
+        if controller.controller_name == 'trees'  && action_name == 'dimensions' && params[:dim_type] == @treeTypeRec.big_ideas_dim_type && @treeTypeRec.big_ideas_dim_type %>
       <li class="nav-item active" aria-selected='true'>
         <a class="nav-link btn btn-primary" href=<%= dimensions_trees_path(dim_type: @treeTypeRec.big_ideas_dim_type) %>><%= translate('nav_bar.'+@treeTypeRec.big_ideas_dim_type+'.name') %></a>
       </li>
@@ -113,30 +104,27 @@
       <li class="nav-item" role='menuitem'>
         <a class="nav-link btn btn-primary" href=<%= dimensions_trees_path(dim_type: @treeTypeRec.miscon_dim_type) %>><%= translate('nav_bar.'+@treeTypeRec.miscon_dim_type+'.name') %></a>
       </li>
-    <% end %>
-
-    <li class="nav-item" role='menuitem'>
-      <button class="btn btn-primary dropdown-toggle" type="button" data-toggle="dropdown" title=<%= translate('nav_bar.connections.hover') %>>
-        <%= translate('nav_bar.connections.name') %>
-        <span class="caret"></span>
-      </button>
-      <ul class="dropdown-menu">
-        <li class="nav-item" role='menuitem'>
-        <a class="nav-link btn btn-primary" href="#"><%= translate('nav_bar.questions.name') %></a>
-        </li>
-        <li class="nav-item active" role='menuitem'>
-        <a class="nav-link btn btn-primary" href="#">
-          <%= translate('nav_bar.concepts.name') %></a>
-        </li>
-        <li class="nav-item" role='menuitem'>
-        <a class="nav-link btn btn-primary" href="#"><%= translate('nav_bar.competencies.name') %></a>
-        </li>
-        <li class="nav-item" role='menuitem'>
-        <a class="nav-link btn btn-primary" href="#"><%= translate('nav_bar.standards.name') %></a>
-        </li>
-      </ul>
-    </li>
+    <% end
+    if controller.controller_name == 'sectors' && action_name == 'index' %>
+      <li class="nav-item active" aria-selected='true'>
+        <a class="nav-link btn btn-primary" href=<%= sectors_path %>><%= @sectorName %></a>
+      </li>
+    <% else %>
+      <li class="nav-item" role='menuitem'>
+        <a class="nav-link btn btn-primary" href=<%= sectors_path %>><%= @sectorName %></a>
+      </li>
+    <% end
+    if controller.controller_name == 'trees' && action_name == 'sequence' %>
+      <li class="nav-item active" aria-selected='true'>
+        <a class="nav-link btn btn-primary" href=<%= sequence_trees_path %>><%= translate('nav_bar.relations.name') %></a>
+      </li>
     <%
+    else %>
+      <li class="nav-item" role='menuitem'>
+        <a class="nav-link btn btn-primary" href=<%= sequence_trees_path %>><%= translate('nav_bar.relations.name') %></a>
+      </li>
+    <%
+    end
     if current_user.present? && current_user.is_admin?
       if controller.controller_name == 'trees' && action_name == 'maint' %>
         <li class="nav-item active" aria-selected='true'>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -89,20 +89,20 @@
     end
         if controller.controller_name == 'trees'  && action_name == 'dimensions' && params[:dim_type] == @treeTypeRec.big_ideas_dim_type && @treeTypeRec.big_ideas_dim_type %>
       <li class="nav-item active" aria-selected='true'>
-        <a class="nav-link btn btn-primary" href=<%= maint_trees_path(show_bigidea: true) %>><%= translate('nav_bar.'+@treeTypeRec.big_ideas_dim_type+'.name') %></a>
+        <a class="nav-link btn btn-primary" href=<%= maint_trees_path(show_bigidea: true, dim_tree: {dim_type: @treeTypeRec.big_ideas_dim_type}) %>><%= translate('nav_bar.'+@treeTypeRec.big_ideas_dim_type+'.name') %></a>
       </li>
     <% elsif @treeTypeRec.big_ideas_dim_type %>
       <li class="nav-item" role='menuitem'>
-        <a class="nav-link btn btn-primary" href=<%= maint_trees_path(show_bigidea: true) %>><%= translate('nav_bar.'+@treeTypeRec.big_ideas_dim_type+'.name') %></a>
+        <a class="nav-link btn btn-primary" href=<%= maint_trees_path(show_bigidea: true, dim_tree: {dim_type: @treeTypeRec.big_ideas_dim_type}) %>><%= translate('nav_bar.'+@treeTypeRec.big_ideas_dim_type+'.name') %></a>
       </li>
     <% end
     if controller.controller_name == 'trees'  && action_name == 'dimensions' && params[:dim_type] == @treeTypeRec.miscon_dim_type && @treeTypeRec.miscon_dim_type %>
       <li class="nav-item active" aria-selected='true'>
-        <a class="nav-link btn btn-primary" href=<%= maint_trees_path(show_miscon: true) %>><%= translate('nav_bar.'+@treeTypeRec.miscon_dim_type+'.name') %></a>
+        <a class="nav-link btn btn-primary" href=<%= maint_trees_path(show_miscon: true, dim_tree: {dim_type: @treeTypeRec.micon_dim_type}) %>><%= translate('nav_bar.'+@treeTypeRec.miscon_dim_type+'.name') %></a>
       </li>
     <% elsif @treeTypeRec.miscon_dim_type %>
       <li class="nav-item" role='menuitem'>
-        <a class="nav-link btn btn-primary" href=<%= maint_trees_path(show_miscon: true) %>><%= translate('nav_bar.'+@treeTypeRec.miscon_dim_type+'.name') %></a>
+        <a class="nav-link btn btn-primary" href=<%= maint_trees_path(show_miscon: true, dim_tree: {dim_type: @treeTypeRec.miscon_dim_type}) %>><%= translate('nav_bar.'+@treeTypeRec.miscon_dim_type+'.name') %></a>
       </li>
     <% end
     if controller.controller_name == 'sectors' && action_name == 'index' %>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -125,20 +125,36 @@
       </li>
     <%
     end
-    if current_user.present? && current_user.is_admin?
-      if controller.controller_name == 'trees' && action_name == 'maint' %>
+    if controller.controller_name == 'trees' && action_name == 'maint' && current_user.present? && current_user.is_admin? %>
         <li class="nav-item active" aria-selected='true'>
           <a class="nav-link btn btn-primary" href=<%= maint_trees_path(editme: true) %>><%= translate('nav_bar.maint.name') %></a>
         </li>
   <%
-      else %>
+      elsif current_user.present? && current_user.is_admin? %>
         <li class="nav-item" role='menuitem'>
           <a class="nav-link btn btn-primary" href=<%= maint_trees_path(editme: true) %>><%= translate('nav_bar.maint.name') %></a>
         </li>
-  <%
-      end
-      if controller.controller_name == 'uploads'
-    %>
+  <% end %>
+  <li class="nav-item" role='menuitem'>
+      <button class="btn btn-primary dropdown-toggle" type="button" data-toggle="dropdown" title=<%= translate('nav_bar.connections.hover') %>>
+        <%= translate('nav_bar.connections.name') %>
+        <span class="caret"></span>
+      </button>
+      <ul class="dropdown-menu">
+        <li class="nav-item" role='menuitem'>
+        <a class="nav-link btn btn-primary" href="#"><%= translate('nav_bar.questions.name') %></a>
+        </li>
+        <li class="nav-item active" role='menuitem'>
+        <a class="nav-link btn btn-primary" href="#">
+          <%= translate('nav_bar.concepts.name') %></a>
+        </li>
+        <li class="nav-item" role='menuitem'>
+        <a class="nav-link btn btn-primary" href="#"><%= translate('nav_bar.standards.name') %></a>
+        </li>
+      </ul>
+  </li>
+  <% if current_user.present? && current_user.is_admin?
+      if controller.controller_name == 'uploads' %>
       <li class="nav-item active" aria-selected='true'>
         <a class="nav-link btn btn-primary" href=<%= uploads_path %>><%= translate('nav_bar.uploads.name') %></a>
       </li>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -89,20 +89,20 @@
     end
         if controller.controller_name == 'trees'  && action_name == 'dimensions' && params[:dim_type] == @treeTypeRec.big_ideas_dim_type && @treeTypeRec.big_ideas_dim_type %>
       <li class="nav-item active" aria-selected='true'>
-        <a class="nav-link btn btn-primary" href=<%= dimensions_trees_path(dim_type: @treeTypeRec.big_ideas_dim_type) %>><%= translate('nav_bar.'+@treeTypeRec.big_ideas_dim_type+'.name') %></a>
+        <a class="nav-link btn btn-primary" href=<%= maint_trees_path(show_bigidea: true) %>><%= translate('nav_bar.'+@treeTypeRec.big_ideas_dim_type+'.name') %></a>
       </li>
     <% elsif @treeTypeRec.big_ideas_dim_type %>
       <li class="nav-item" role='menuitem'>
-        <a class="nav-link btn btn-primary" href=<%= dimensions_trees_path(dim_type: @treeTypeRec.big_ideas_dim_type) %>><%= translate('nav_bar.'+@treeTypeRec.big_ideas_dim_type+'.name') %></a>
+        <a class="nav-link btn btn-primary" href=<%= maint_trees_path(show_bigidea: true) %>><%= translate('nav_bar.'+@treeTypeRec.big_ideas_dim_type+'.name') %></a>
       </li>
     <% end
     if controller.controller_name == 'trees'  && action_name == 'dimensions' && params[:dim_type] == @treeTypeRec.miscon_dim_type && @treeTypeRec.miscon_dim_type %>
       <li class="nav-item active" aria-selected='true'>
-        <a class="nav-link btn btn-primary" href=<%= dimensions_trees_path(dim_type: @treeTypeRec.miscon_dim_type) %>><%= translate('nav_bar.'+@treeTypeRec.miscon_dim_type+'.name') %></a>
+        <a class="nav-link btn btn-primary" href=<%= maint_trees_path(show_miscon: true) %>><%= translate('nav_bar.'+@treeTypeRec.miscon_dim_type+'.name') %></a>
       </li>
     <% elsif @treeTypeRec.miscon_dim_type %>
       <li class="nav-item" role='menuitem'>
-        <a class="nav-link btn btn-primary" href=<%= dimensions_trees_path(dim_type: @treeTypeRec.miscon_dim_type) %>><%= translate('nav_bar.'+@treeTypeRec.miscon_dim_type+'.name') %></a>
+        <a class="nav-link btn btn-primary" href=<%= maint_trees_path(show_miscon: true) %>><%= translate('nav_bar.'+@treeTypeRec.miscon_dim_type+'.name') %></a>
       </li>
     <% end
     if controller.controller_name == 'sectors' && action_name == 'index' %>

--- a/app/views/trees/_edit_dimensions.html.erb
+++ b/app/views/trees/_edit_dimensions.html.erb
@@ -11,6 +11,14 @@
     <% if @show_miscon %>
       <input type="hidden" name="show_miscon" value=true>
     <% end %>
+    <% if @bi_gb && @bi_gb[:id] %>
+      <input type="hidden" name="dim_tree[bigidea_gb_id]" value=<%= @bi_gb[:id] %>>
+    <% end %>
+    <% if @m_gb && @m_gb[:id] %>
+      <input type="hidden" name="dim_tree[miscon_gb_id]" value=<%= @m_gb[:id] %>>
+    <% end %>
+    <input type="hidden" name="dim_tree[bigidea_subj_id]" value='<%= @dim_subjs['bigidea'][:id] %>'>
+    <input type="hidden" name="dim_tree[miscon_subj_id]" value='<%= @dim_subjs['miscon'][:id] %>'>
   	<input type="hidden" name="dim_tree[tree_id]" value='<%= @dim_tree.tree_id %>'>
   	<input type="hidden" name="dim_tree[dimension_id]" value='<%= @dim_tree.dimension_id %>'>
     <input type="hidden" name="dim_tree[dim_explanation_key]" value='<%= @dim_tree.dim_explanation_key %>'>

--- a/app/views/trees/_edit_dimensions.html.erb
+++ b/app/views/trees/_edit_dimensions.html.erb
@@ -5,6 +5,12 @@
 
 <%= form_for(@dim_tree, :url => @form_path, html: { data: { modal: true } })  do |f| %>
   <div>
+    <% if @show_bigidea %>
+      <input type="hidden" name="show_bigidea" value=true>
+    <% end %>
+    <% if @show_miscon %>
+      <input type="hidden" name="show_miscon" value=true>
+    <% end %>
   	<input type="hidden" name="dim_tree[tree_id]" value='<%= @dim_tree.tree_id %>'>
   	<input type="hidden" name="dim_tree[dimension_id]" value='<%= @dim_tree.dimension_id %>'>
     <input type="hidden" name="dim_tree[dim_explanation_key]" value='<%= @dim_tree.dim_explanation_key %>'>

--- a/app/views/trees/_maint_filter.html.erb
+++ b/app/views/trees/_maint_filter.html.erb
@@ -1,0 +1,66 @@
+<%= form_for @tree, url: maint_trees_path, :html => { :method => 'GET' } do |form| %>
+  <% param_name = (col == "tree" ? col : "dim_tree" ) %>
+  <div class='row'>
+    <!-- Hidden fields -->
+    <!-- Pass setting to stay in edit mode after submitting form, if currently in edit mode -->
+    <% if @editing %>
+    <input type='hidden' name='editme' value=true></input>
+    <% end %>
+    <!-- If searching for a different set of misconceptions, don't forget the current set of big ideas. -->
+    <% if col == "miscon"
+       if @dim_subjs['bigidea'] %>
+        <input type='hidden' name='dim_tree[bigidea_subj_id]' value=<%= @dim_subjs['bigidea'].id %>></input>
+    <% end
+       if @bi_gb %>
+         <input type='hidden' name='dim_tree[bigidea_gb_id]' value=<%= @bi_gb[:id] || 0 %>></input>
+    <% end
+    end %>
+    <!-- If searching for a different set of bigideas, don't forget the current set of misconceptions. -->
+    <% if col == "bigidea"
+         if @dim_subjs['miscon'] %>
+    		  <input type='hidden' name='dim_tree[miscon_subj_id]' value=<%= @dim_subjs['miscon'].id %>></input>
+    	<% end
+    	   if @m_gb
+    	%>
+    		  <input type='hidden' name='dim_tree[miscon_gb_id]' value=<%= @m_gb[:id] || 0 %>></input>
+    <% end
+    end %>
+
+    <!-- Labels -->
+    <div class='col col-md-3'><label for='<%= param_name %>_subject'><%= translate('app.labels.subject') %></label></div>
+    <div class='col col-md-4'><label for='<%= param_name %>_grade_band'><%= translate('app.labels.grade_band') %></label></div>
+  </div>
+
+  <!-- Form input options -->
+  <div class='row'>
+    <div class='col col-md-3 subject-with-gb'><select id='<%= param_name %>_subject_id' name='<%= param_name %>[<%= param_name == "tree" ? "subject_id" : "#{col}_subj_id"%>]'>
+      <% @subjects.each do |k, s| %>
+        <% sel_code = @subject_code
+           sel_code = @dim_subjs[col].code if @dim_subjs[col]
+        %>
+        <%- selectedStr = (s.code == sel_code) ? ' selected = "selected"' : '' %>
+        <%= Rails.logger.debug(" +++ index match output: #{selectedStr}") %>
+        <option value=<%= s.id%><%= selectedStr %>><%=s.abbr( @locale_code )%></option>
+      <% end %>
+    </select></div>
+    <div id='<%= param_name %>-gb-container' class='col col-md-4'>
+      <span id='<%= param_name %>-all-gbs-select'>
+      <!-- %= collection_select(:tree, :grade_band_id, @gbs, :id, :code, include_blank: I18n.t('app.labels.all') ) % -->
+      <select id='<%= param_name %>_grade_band_id' name='<%= param_name %>[<%= param_name == "tree" ? "grade_band_id" : "#{col}_gb_id" %>]'>
+        <option value='0'><%= I18n.t('app.labels.all') %></option>
+      <% @gbs.each do |gb| %>
+        <% gbc = @grade_band_code
+           gbc = @bi_gb[:code] if (@bi_gb && col == "bigidea")
+           gbc = @m_gb[:code] if (@m_gb && col == "miscon")
+        %>
+        <%- selectedStr = (gb.code == @grade_band_code) ? ' selected = "selected"' : '' %>
+        <%= Rails.logger.debug("gb index match: #{gb.code} == #{@grade_band_code} output: #{selectedStr}") %>
+        <option value=<%= gb.id%><%= selectedStr %>><%=gb.code%></option>
+      <% end %>
+    </select>
+      </span>
+    </div>
+
+    <div class='col col-md-3 margin-bottom'><%= form.submit translate('app.labels.gen_list'), :class => 'btn-primary' %></div>
+  </div>
+<% end #form %>

--- a/app/views/trees/_maint_filter.html.erb
+++ b/app/views/trees/_maint_filter.html.erb
@@ -4,8 +4,9 @@
     <!-- Hidden fields -->
     <!-- Pass setting to stay in edit mode after submitting form, if currently in edit mode -->
     <% if @editing %>
-    <input type='hidden' name='editme' value=true></input>
+      <input type='hidden' name='editme' value=true></input>
     <% end %>
+
     <!-- If searching for a different set of misconceptions, don't forget the current set of big ideas. -->
     <% if col == "miscon"
        if @dim_subjs['bigidea'] %>
@@ -53,7 +54,7 @@
            gbc = @bi_gb[:code] if (@bi_gb && col == "bigidea")
            gbc = @m_gb[:code] if (@m_gb && col == "miscon")
         %>
-        <%- selectedStr = (gb.code == @grade_band_code) ? ' selected = "selected"' : '' %>
+        <%- selectedStr = (gb.code == gbc) ? ' selected = "selected"' : '' %>
         <%= Rails.logger.debug("gb index match: #{gb.code} == #{@grade_band_code} output: #{selectedStr}") %>
         <option value=<%= gb.id%><%= selectedStr %>><%=gb.code%></option>
       <% end %>

--- a/app/views/trees/dimensions.html.erb
+++ b/app/views/trees/dimensions.html.erb
@@ -1,7 +1,9 @@
 <% content_for(:title_code, 'trees.index.name') %>
 <% content_for(:page_class, 'trees') %>
 
-<% subject_visible = cookies["#{@page_title}_subject_visible"] || 'bio' %>
+<% subject_visible = cookies["#{@page_title}_subject_visible"] || @default_subj_code
+   subject_visible = @s_o_hash.keys.include?(subject_visible) ? subject_visible : @default_subj_code
+%>
 <br>
 <div class='text-center dimension-page'>
   <h2 id="dimension-header"><%= @page_title %></h2>

--- a/app/views/trees/maint.html.erb
+++ b/app/views/trees/maint.html.erb
@@ -9,14 +9,14 @@
 %>
 <br>
 <div class='text-center dimension-page'>
-  <h2><%= translate('trees.maint.title') %></h2>
+  <h2><%= @page_title %></h2>
 </div>
 <% if true #big_idea_dims && big_idea_dims.count > 0 %>
-  <button id="show_bigidea_btn" class="btn-info margin-bottom<%= @show_bigidea ? ' hidden' : '' %>" onclick="show_maint_col('bigidea', true);"><%= I18n.t('app.labels.show_indicators', name: ideas_title) %></button>
+  <button id="show_bigidea_btn" class="btn-secondary margin-bottom<%= @show_bigidea ? ' hidden' : '' %>" onclick="show_maint_col('bigidea', true);"><%= I18n.t('app.labels.show_indicators', name: ideas_title) %></button>
   <button id="hide_bigidea_btn" class="btn-info margin-bottom<%= @show_bigidea ? '' : ' hidden' %>" onclick="show_maint_col('bigidea', false);"><%= I18n.t('app.labels.hide_indicators', name: ideas_title) %></button>
 <% end %>
 <% if true #miscon_dims && miscon_dims.count > 0 %>
-  <button id="show_miscon_btn" class="btn-info margin-bottom<%= @show_miscon ? ' hidden' : '' %>" onclick="show_maint_col('miscon', true);"><%= I18n.t('app.labels.show_indicators', name: misc_title) %></button>
+  <button id="show_miscon_btn" class="btn-secondary margin-bottom<%= @show_miscon ? ' hidden' : '' %>" onclick="show_maint_col('miscon', true);"><%= I18n.t('app.labels.show_indicators', name: misc_title) %></button>
   <button id="hide_miscon_btn" class="btn-info margin-bottom<%= @show_miscon ? '' : ' hidden' %>" onclick="show_maint_col('miscon', false);"><%= I18n.t('app.labels.hide_indicators', name: misc_title) %></button>
 <% end %>
 <% subj_counter = 0 %>

--- a/app/views/trees/maint.html.erb
+++ b/app/views/trees/maint.html.erb
@@ -13,7 +13,7 @@
         <li class="maint-header indent-0"><%= @translations[tkey] %></li>
         <% codeh.each do |code, h| %>
           <% if h[:depth] == @treeTypeRec.outcome_depth+1 %>
-          <li class="maint-item indent-3">
+          <li class="maint-item indent-3 <%= h[:selectors_by_parent] %>">
             <a href="<%= tree_path(h[:id])%>" title="<%= h[:text] %>"><%= h[:depth_name] %>: <%= h[:last_code] %></a>
             <%= h[:text] %>
             <% if @editing %>
@@ -32,9 +32,9 @@
           </li>
           <% elsif h[:depth] > @treeTypeRec.outcome_depth+1 %>
           <% else %>
-            <li class="maint-sub-header indent-<%= h[:depth]-1 %> ">
-              <a class="" href="#">
-                <i class="fa fa-compress pull-left" title="collapse"></i>
+            <li class="maint-sub-header indent-<%= h[:depth]-1 %> <%= h[:selectors_by_parent] %>">
+              <a class="" onclick="toggle_visibility('.child-of-<%= code.split(".").join("-") %>', '#trigger-<%= code.split(".").join("-") %>')">
+                <i id="trigger-<%= code.split(".").join("-") %>" class="fa fa-compress pull-left option-selected link-blue accordion" title="collapse"></i>
               </a>
               <%= h[:depth_name] %>: <%= h[:text] %>
             </li>

--- a/app/views/trees/maint.html.erb
+++ b/app/views/trees/maint.html.erb
@@ -45,13 +45,47 @@
       </div>
     <% end %>
       </li>
-      <% @treeByParents.each do |tkey, codeh| %>
+      <%
+       ideas_title = translate('nav_bar.bigidea.name')
+       misc_title = translate('nav_bar.miscon.name')
+       @treeByParents.each do |tkey, codeh| %>
         <li class="maint-header indent-0"><%= @translations[tkey] %></li>
         <% codeh.each do |code, h| %>
           <% if h[:depth] == @treeTypeRec.outcome_depth+1 %>
+          <% ideas_str = '' #ideas_title
+             misc_str = '' #misc_title
+             ideas_found = 0
+             misc_found = 0
+           %>
           <li class="maint-item indent-3 <%= h[:selectors_by_parent] %>">
             <a href="<%= tree_path(h[:id])%>" title="<%= h[:text] %>"><%= h[:depth_name] %>: <%= h[:last_code] %></a>
             <%= h[:text] %>
+            <% if h[:dimtrees].length > 0 %>
+            <% h[:dimtrees].each do |dt|
+                 dim = dt.dimension
+                 if dim.dim_type == "bigidea"
+                    ideas_found += 1
+                    ideaSubjKey = @subj_key_by_dt_id[dt.id] || @idea_subj_base_key
+                    ideas_str += "<br/>______________<br/>"
+                    ideas_str += "[#{@translations[ideaSubjKey]}] #{@translations[dim.dim_name_key]}"
+                 else
+                    misc_found += 1
+                    miscSubjKey = @subj_key_by_dt_id[dt.id] || @misc_subj_base_key
+                    misc_str += "<br/>______________<br/>"
+                    misc_str += "[#{@translations[miscSubjKey]}] #{@translations[dim.dim_name_key]}"
+                 end
+               end
+               ideas_str = "<strong>#{(ideas_found > 1 ? ideas_title : ideas_title.singularize)}:</strong>#{ideas_str}"
+               misc_str = "<strong>#{(misc_found > 1 ? misc_title : misc_title.singularize)}:</strong>#{misc_str}"
+            %>
+            <% if ideas_found > 0 %>
+            <i class="fa fa-lightbulb-o" data-toggle="tooltip" title="<%= ideas_str %>"></i>
+            <% end
+              if misc_found > 0
+            %>
+            <i class="fa fa-exclamation-triangle" data-toggle="tooltip" title="<%= misc_str %>"></i>
+            <% end %>
+            <% end %>
             <% if @editing %>
             <div class="pull-right">
               <a class="" data-confirm="Are you sure?"  href="/<%= @locale_code %>/trees/<%= h[:id] %>?%5Bactive%5D=false">
@@ -77,6 +111,16 @@
           <% end %>
         <% end %>
       <% end %>
+      </ul>
+      <ul class="list-group maint-column bigideas-col">
+        <li class="maint-header"><%= "#{@translations[@idea_subj_base_key]} - #{ideas_title} (#{translate('app.labels.grade_band').pluralize}: #{@dim_grades['bigidea'][:min_grade]} - #{@dim_grades['bigidea'][:max_grade]})" %></li>
+        <% @dimensions.each do |dim| %>
+          <li>
+            <%= "#{translate('app.labels.subject')}: #{@translations[@idea_subj_base_key]}" %>
+            <br/>
+            <%= @translations[dim.dim_name_key] %>
+          </li>
+        <% end %>
       </ul>
     </div>
   </div>

--- a/app/views/trees/maint.html.erb
+++ b/app/views/trees/maint.html.erb
@@ -1,5 +1,6 @@
 <% content_for(:title_code, 'trees.maint.name') %>
 <% content_for(:page_class, 'trees') %>
+<% current_path = @editing ? maint_trees_path(editme: true) : maint_trees_path %>
 
 <br>
 <div class='text-center sequence-page'>
@@ -9,6 +10,40 @@
 <div id="trees" class="sequence-page">
   <div class="sequence-grid cols-<%= 2 %>">
     <ul class="list-group maint-column">
+      <li>
+        <%= form_for @tree, url: current_path, :html => { :method => 'GET' } do |form| %>
+      <div class='row'>
+        <div class='col col-md-4'><label for='tree_subject'><%= translate('app.labels.subject') %></label></div>
+        <div class='col col-md-4'><label for='tree_grade_band'><%= translate('app.labels.grade_band') %></label></div>
+        <div class='col col-md-4'><%= translate('app.labels.actions') %></div>
+      </div>
+      <div class='row'>
+        <div class='col col-md-4 subject-with-gb'><select id='tree_subject_id' name='tree[subject_id]'>
+          <% @subjects.each do |k, s| %>
+            <%- selectedStr = (s.code == @subject_code) ? ' selected = "selected"' : '' %>
+            <%= Rails.logger.debug(" +++ index match output: #{selectedStr}") %>
+            <option value=<%= s.id%><%= selectedStr %>><%=s.abbr( @locale_code )%></option>
+          <% end %>
+        </select></div>
+        <div id='gb-container' class='col col-md-4'>
+          <span id='all-gbs-select'>
+          <!-- %= collection_select(:tree, :grade_band_id, @gbs, :id, :code, include_blank: I18n.t('app.labels.all') ) % -->
+          <select id='tree_grade_band_id' name='tree[grade_band_id]'>
+            <option value='0'><%= I18n.t('app.labels.all') %></option>
+          <% gbs = @gbOptions || @gbs %>
+          <% gbs.each do |gb| %>
+            <%- selectedStr = (gb.code == @grade_band_code) ? ' selected = "selected"' : '' %>
+            <%= Rails.logger.debug("gb index match: #{gb.code} == #{@grade_band_code} output: #{selectedStr}") %>
+            <option value=<%= gb.id%><%= selectedStr %>><%=gb.code%></option>
+          <% end %>
+        </select>
+          </span>
+        </div>
+
+        <div class='col col-md-4 margin-bottom'><%= form.submit translate('app.labels.gen_list'), :class => 'btn-primary' %></div>
+      </div>
+    <% end %>
+      </li>
       <% @treeByParents.each do |tkey, codeh| %>
         <li class="maint-header indent-0"><%= @translations[tkey] %></li>
         <% codeh.each do |code, h| %>

--- a/app/views/trees/maint.html.erb
+++ b/app/views/trees/maint.html.erb
@@ -1,53 +1,65 @@
 <% content_for(:title_code, 'trees.maint.name') %>
 <% content_for(:page_class, 'trees') %>
+<% big_idea_dims = @dimensions.where(:dim_type => @treeTypeRec.big_ideas_dim_type) if @dimensions.present?
 
+   miscon_dims = @dimensions.where(:dim_type => @treeTypeRec.miscon_dim_type) if @dimensions.present?
+
+   ideas_title = translate('nav_bar.bigidea.name')
+   misc_title = translate('nav_bar.miscon.name')
+%>
 <br>
-<div class='text-center sequence-page'>
+<div class='text-center dimension-page'>
   <h2><%= translate('trees.maint.title') %></h2>
 </div>
+<% if big_idea_dims && big_idea_dims.count > 0 %>
+  <button id="show_bigidea_btn" class="btn-info margin-bottom hidden" onclick="show_maint_col('bigidea', true);"><%= I18n.t('app.labels.show_indicators', name: ideas_title) %></button>
+  <button id="hide_bigidea_btn" class="btn-info margin-bottom" onclick="show_maint_col('bigidea', false);"><%= I18n.t('app.labels.hide_indicators', name: ideas_title) %></button>
+<% end %>
+<% if miscon_dims && miscon_dims.count > 0 %>
+  <button id="show_miscon_btn" class="btn-info margin-bottom" onclick="show_maint_col('miscon', true);"><%= I18n.t('app.labels.show_indicators', name: misc_title) %></button>
+  <button id="hide_miscon_btn" class="btn-info margin-bottom hidden" onclick="show_maint_col('miscon', false);"><%= I18n.t('app.labels.hide_indicators', name: misc_title) %></button>
+<% end %>
 <% subj_counter = 0 %>
-<div id="trees" class="sequence-page">
+<div id="trees" class="dimension-page maint-page">
   <div class="sequence-grid cols-<%= 2 %>">
     <ul class="list-group maint-column">
       <li>
         <%= form_for @tree, url: maint_trees_path, :html => { :method => 'GET' } do |form| %>
-      <div class='row'>
-        <% if @editing %>
-        <input type='hidden' name='editme' value=true></input>
-        <% end %>
-        <div class='col col-md-4'><label for='tree_subject'><%= translate('app.labels.subject') %></label></div>
-        <div class='col col-md-4'><label for='tree_grade_band'><%= translate('app.labels.grade_band') %></label></div>
-        <div class='col col-md-4'><%= translate('app.labels.actions') %></div>
-      </div>
-      <div class='row'>
-        <div class='col col-md-4 subject-with-gb'><select id='tree_subject_id' name='tree[subject_id]'>
-          <% @subjects.each do |k, s| %>
-            <%- selectedStr = (s.code == @subject_code) ? ' selected = "selected"' : '' %>
-            <%= Rails.logger.debug(" +++ index match output: #{selectedStr}") %>
-            <option value=<%= s.id%><%= selectedStr %>><%=s.abbr( @locale_code )%></option>
-          <% end %>
-        </select></div>
-        <div id='gb-container' class='col col-md-4'>
-          <span id='all-gbs-select'>
-          <!-- %= collection_select(:tree, :grade_band_id, @gbs, :id, :code, include_blank: I18n.t('app.labels.all') ) % -->
-          <select id='tree_grade_band_id' name='tree[grade_band_id]'>
-            <option value='0'><%= I18n.t('app.labels.all') %></option>
-          <% @gbs.each do |gb| %>
-            <%- selectedStr = (gb.code == @grade_band_code) ? ' selected = "selected"' : '' %>
-            <%= Rails.logger.debug("gb index match: #{gb.code} == #{@grade_band_code} output: #{selectedStr}") %>
-            <option value=<%= gb.id%><%= selectedStr %>><%=gb.code%></option>
-          <% end %>
-        </select>
-          </span>
-        </div>
+          <div class='row'>
+            <% if @editing %>
+            <input type='hidden' name='editme' value=true></input>
+            <% end %>
+            <div class='col col-md-4'><label for='tree_subject'><%= translate('app.labels.subject') %></label></div>
+            <div class='col col-md-4'><label for='tree_grade_band'><%= translate('app.labels.grade_band') %></label></div>
+            <div class='col col-md-4'><%= translate('app.labels.actions') %></div>
+          </div>
+          <div class='row'>
+            <div class='col col-md-4 subject-with-gb'><select id='tree_subject_id' name='tree[subject_id]'>
+              <% @subjects.each do |k, s| %>
+                <%- selectedStr = (s.code == @subject_code) ? ' selected = "selected"' : '' %>
+                <%= Rails.logger.debug(" +++ index match output: #{selectedStr}") %>
+                <option value=<%= s.id%><%= selectedStr %>><%=s.abbr( @locale_code )%></option>
+              <% end %>
+            </select></div>
+            <div id='gb-container' class='col col-md-4'>
+              <span id='all-gbs-select'>
+              <!-- %= collection_select(:tree, :grade_band_id, @gbs, :id, :code, include_blank: I18n.t('app.labels.all') ) % -->
+              <select id='tree_grade_band_id' name='tree[grade_band_id]'>
+                <option value='0'><%= I18n.t('app.labels.all') %></option>
+              <% @gbs.each do |gb| %>
+                <%- selectedStr = (gb.code == @grade_band_code) ? ' selected = "selected"' : '' %>
+                <%= Rails.logger.debug("gb index match: #{gb.code} == #{@grade_band_code} output: #{selectedStr}") %>
+                <option value=<%= gb.id%><%= selectedStr %>><%=gb.code%></option>
+              <% end %>
+            </select>
+              </span>
+            </div>
 
-        <div class='col col-md-4 margin-bottom'><%= form.submit translate('app.labels.gen_list'), :class => 'btn-primary' %></div>
-      </div>
-    <% end %>
+            <div class='col col-md-4 margin-bottom'><%= form.submit translate('app.labels.gen_list'), :class => 'btn-primary' %></div>
+          </div>
+        <% end #form %>
       </li>
       <%
-       ideas_title = translate('nav_bar.bigidea.name')
-       misc_title = translate('nav_bar.miscon.name')
        @treeByParents.each do |tkey, codeh| %>
         <li class="maint-header indent-0"><%= @translations[tkey] %></li>
         <% codeh.each do |code, h| %>
@@ -57,7 +69,7 @@
              ideas_found = 0
              misc_found = 0
            %>
-          <li class="maint-item indent-3 <%= h[:selectors_by_parent] %>">
+          <li id="<%= h[:subj_code] %>_lo_<%= h[:id] %>" class="maint-item indent-3 <%= h[:selectors_by_parent] %> list-group-item" data-loid="<%= h[:id] %>">
             <a href="<%= tree_path(h[:id])%>" title="<%= h[:text] %>"><%= h[:depth_name] %>: <%= h[:last_code] %></a>
             <%= h[:text] %>
             <% if h[:dimtrees].length > 0 %>
@@ -112,16 +124,47 @@
         <% end %>
       <% end %>
       </ul>
-      <ul class="list-group maint-column bigideas-col">
-        <li class="maint-header"><%= "#{@translations[@idea_subj_base_key]} - #{ideas_title} (#{translate('app.labels.grade_band').pluralize}: #{@dim_grades['bigidea'][:min_grade]} - #{@dim_grades['bigidea'][:max_grade]})" %></li>
-        <% @dimensions.each do |dim| %>
-          <li>
-            <%= "#{translate('app.labels.subject')}: #{@translations[@idea_subj_base_key]}" %>
-            <br/>
-            <%= @translations[dim.dim_name_key] %>
-          </li>
-        <% end %>
-      </ul>
+      <% grades_str = translate('app.labels.grade_band').pluralize %>
+      <% if big_idea_dims && big_idea_dims.count > 0 %>
+        <ul class="list-group maint-column bigidea-col">
+          <li class="maint-header"><%= "#{@translations[@idea_subj_base_key]} - #{ideas_title} (#{grades_str}: #{@dim_grades['bigidea'][:min_grade]} - #{@dim_grades['bigidea'][:max_grade]})" %></li>
+          <% big_idea_dims.each do |dim| %>
+            <li id="<%= "#{@translations[@idea_subj_base_key]}-dim-#{dim.id}"%>" class="dim-item dim-item--collapsable list-group-item ui-draggable" data-dimid="<%= dim.id %>">
+              <span class='pull-left'><strong><%= "#{translate('app.labels.subject')}:"%></strong> <%="#{@translations[@idea_subj_base_key]}" %></span>
+                <br/>
+                <span class='pull-left'><strong><%= "#{grades_str}: " %></strong> <%= "#{@dim_grades['bigidea'][:min_grade]} - #{@dim_grades['bigidea'][:max_grade]}" %></span>
+
+              <br/>
+              <span class='pull-left'><strong><%= "#{ideas_title.singularize}:" %></strong></span>
+              <br/>
+              <%= @translations[dim.dim_name_key] %>
+              <br/>
+              <% if current_user.present? && current_user.is_admin? && @editing%>
+                <a class="connect-handle lo-handle pull-right" onclick=""><i class="fa fa-link" title="make a connection"></i></a>
+            <% end %>
+            </li>
+          <% end %>
+        </ul>
+      <% end #if big_idea_dims
+         if miscon_dims && miscon_dims.count > 0
+      %>
+        <ul class="list-group maint-column miscon-col hidden">
+          <li class="maint-header"><%= "#{@translations[@misc_subj_base_key]} - #{misc_title} (#{grades_str}: #{@dim_grades['miscon'][:min_grade]} - #{@dim_grades['miscon'][:max_grade]})" %></li>
+          <% miscon_dims.each do |dim| %>
+            <li id="<%= "#{@translations[@misc_subj_base_key]}-dim-#{dim.id}"%>" class="dim-item dim-item--collapsable list-group-item ui-draggable" data-dimid="<%= dim.id %>">
+              <span class='pull-left'><strong><%= "#{translate('app.labels.subject')}:"%></strong> <%="#{@translations[@misc_subj_base_key]}" %></span>
+              <br/>
+              <span class='pull-left'><strong><%= "#{misc_title.singularize}:" %></strong></span>
+              <br/>
+              <%= @translations[dim.dim_name_key] %>
+              <br/>
+              <% if current_user.present? && current_user.is_admin? && @editing%>
+                <a class="connect-handle lo-handle pull-right" onclick=""><i class="fa fa-link" title="make a connection"></i></a>
+            <% end %>
+            </li>
+          <% end %>
+        </ul>
+      <% end #if miscon_dims %>
     </div>
   </div>
 </div>

--- a/app/views/trees/maint.html.erb
+++ b/app/views/trees/maint.html.erb
@@ -21,43 +21,10 @@
 <% end %>
 <% subj_counter = 0 %>
 <div id="trees" class="dimension-page maint-page">
-  <div class="sequence-grid cols-<%= 2 %>">
+  <div class="sequence-grid cols-<%= @show_miscon && @show_bigidea ? 3 : 2 %>">
     <ul class="list-group maint-column">
       <li>
-        <%= form_for @tree, url: maint_trees_path, :html => { :method => 'GET' } do |form| %>
-          <div class='row'>
-            <% if @editing %>
-            <input type='hidden' name='editme' value=true></input>
-            <% end %>
-            <div class='col col-md-4'><label for='tree_subject'><%= translate('app.labels.subject') %></label></div>
-            <div class='col col-md-4'><label for='tree_grade_band'><%= translate('app.labels.grade_band') %></label></div>
-            <div class='col col-md-4'><%= translate('app.labels.actions') %></div>
-          </div>
-          <div class='row'>
-            <div class='col col-md-4 subject-with-gb'><select id='tree_subject_id' name='tree[subject_id]'>
-              <% @subjects.each do |k, s| %>
-                <%- selectedStr = (s.code == @subject_code) ? ' selected = "selected"' : '' %>
-                <%= Rails.logger.debug(" +++ index match output: #{selectedStr}") %>
-                <option value=<%= s.id%><%= selectedStr %>><%=s.abbr( @locale_code )%></option>
-              <% end %>
-            </select></div>
-            <div id='gb-container' class='col col-md-4'>
-              <span id='all-gbs-select'>
-              <!-- %= collection_select(:tree, :grade_band_id, @gbs, :id, :code, include_blank: I18n.t('app.labels.all') ) % -->
-              <select id='tree_grade_band_id' name='tree[grade_band_id]'>
-                <option value='0'><%= I18n.t('app.labels.all') %></option>
-              <% @gbs.each do |gb| %>
-                <%- selectedStr = (gb.code == @grade_band_code) ? ' selected = "selected"' : '' %>
-                <%= Rails.logger.debug("gb index match: #{gb.code} == #{@grade_band_code} output: #{selectedStr}") %>
-                <option value=<%= gb.id%><%= selectedStr %>><%=gb.code%></option>
-              <% end %>
-            </select>
-              </span>
-            </div>
-
-            <div class='col col-md-4 margin-bottom'><%= form.submit translate('app.labels.gen_list'), :class => 'btn-primary' %></div>
-          </div>
-        <% end #form %>
+        <%= render partial: "maint_filter", locals: {col: "tree"} %>
       </li>
       <%
        @treeByParents.each do |tkey, codeh| %>
@@ -127,6 +94,9 @@
       <% grades_str = translate('app.labels.grade_band').pluralize %>
       <% if big_idea_dims && big_idea_dims.count > 0 %>
         <ul class="list-group maint-column bigidea-col<%= @show_bigidea ? '' : ' hidden' %>">
+          <li>
+            <%= render partial: "maint_filter", locals: {col: "bigidea"} %>
+          </li>
           <li class="maint-header"><%= "#{@translations[@idea_subj_base_key]} - #{ideas_title} (#{grades_str}: #{@dim_grades['bigidea'][:min_grade]} - #{@dim_grades['bigidea'][:max_grade]})" %></li>
           <% big_idea_dims.each do |dim| %>
             <li id="<%= "#{@translations[@idea_subj_base_key]}-dim-#{dim.id}"%>" class="dim-item dim-item--collapsable list-group-item ui-draggable" data-dimid="<%= dim.id %>">

--- a/app/views/trees/maint.html.erb
+++ b/app/views/trees/maint.html.erb
@@ -16,6 +16,7 @@
           <li class="maint-item indent-3">
             <a href="<%= tree_path(h[:id])%>" title="<%= h[:text] %>"><%= h[:depth_name] %>: <%= h[:last_code] %></a>
             <%= h[:text] %>
+            <% if @editing %>
             <div class="pull-right">
               <a class="" data-confirm="Are you sure?"  href="/<%= @locale_code %>/trees/<%= h[:id] %>?%5Bactive%5D=false">
                 <i class="fa fa-times pull-right" title="deactivate this LO"></i>
@@ -27,6 +28,7 @@
                 <i class="fa fa-edit pull-right" title="edit this LO"></i>
               </a>
             </div>
+            <% end %>
           </li>
           <% elsif h[:depth] > @treeTypeRec.outcome_depth+1 %>
           <% else %>

--- a/app/views/trees/maint.html.erb
+++ b/app/views/trees/maint.html.erb
@@ -11,11 +11,11 @@
 <div class='text-center dimension-page'>
   <h2><%= translate('trees.maint.title') %></h2>
 </div>
-<% if big_idea_dims && big_idea_dims.count > 0 %>
+<% if true #big_idea_dims && big_idea_dims.count > 0 %>
   <button id="show_bigidea_btn" class="btn-info margin-bottom<%= @show_bigidea ? ' hidden' : '' %>" onclick="show_maint_col('bigidea', true);"><%= I18n.t('app.labels.show_indicators', name: ideas_title) %></button>
   <button id="hide_bigidea_btn" class="btn-info margin-bottom<%= @show_bigidea ? '' : ' hidden' %>" onclick="show_maint_col('bigidea', false);"><%= I18n.t('app.labels.hide_indicators', name: ideas_title) %></button>
 <% end %>
-<% if miscon_dims && miscon_dims.count > 0 %>
+<% if true #miscon_dims && miscon_dims.count > 0 %>
   <button id="show_miscon_btn" class="btn-info margin-bottom<%= @show_miscon ? ' hidden' : '' %>" onclick="show_maint_col('miscon', true);"><%= I18n.t('app.labels.show_indicators', name: misc_title) %></button>
   <button id="hide_miscon_btn" class="btn-info margin-bottom<%= @show_miscon ? '' : ' hidden' %>" onclick="show_maint_col('miscon', false);"><%= I18n.t('app.labels.hide_indicators', name: misc_title) %></button>
 <% end %>
@@ -92,12 +92,13 @@
       <% end %>
       </ul>
       <% grades_str = translate('app.labels.grade_band').pluralize %>
-      <% if big_idea_dims && big_idea_dims.count > 0 %>
-        <ul class="list-group maint-column bigidea-col<%= @show_bigidea ? '' : ' hidden' %>">
-          <li>
-            <%= render partial: "maint_filter", locals: {col: "bigidea"} %>
-          </li>
-          <li class="maint-header"><%= "#{@translations[@idea_subj_base_key]} - #{ideas_title} (#{grades_str}: #{@dim_grades['bigidea'][:min_grade]} - #{@dim_grades['bigidea'][:max_grade]})" %></li>
+
+      <ul class="list-group maint-column bigidea-col<%= @show_bigidea ? '' : ' hidden' %>">
+        <li>
+          <%= render partial: "maint_filter", locals: {col: "bigidea"} %>
+        </li>
+        <li class="maint-header"><%= "#{@translations[@idea_subj_base_key]} - #{ideas_title} (#{grades_str}: #{@dim_grades['bigidea'][:min_grade]} - #{@dim_grades['bigidea'][:max_grade]})" %></li>
+        <% if big_idea_dims && big_idea_dims.count > 0 %>
           <% big_idea_dims.each do |dim| %>
             <li id="<%= "#{@translations[@idea_subj_base_key]}-dim-#{dim.id}"%>" class="dim-item dim-item--collapsable list-group-item ui-draggable" data-dimid="<%= dim.id %>">
               <span class='pull-left'><strong><%= "#{translate('app.labels.subject')}:"%></strong> <%="#{@translations[@idea_subj_base_key]}" %></span>
@@ -114,12 +115,15 @@
             <% end %>
             </li>
           <% end %>
-        </ul>
-      <% end #if big_idea_dims
-         if miscon_dims && miscon_dims.count > 0
-      %>
-        <ul class="list-group maint-column miscon-col<%= @show_miscon ? '' : ' hidden' %>">
-          <li class="maint-header"><%= "#{@translations[@misc_subj_base_key]} - #{misc_title} (#{grades_str}: #{@dim_grades['miscon'][:min_grade]} - #{@dim_grades['miscon'][:max_grade]})" %></li>
+        <% end #if big_idea_dims %>
+      </ul>
+
+      <ul class="list-group maint-column miscon-col<%= @show_miscon ? '' : ' hidden' %>">
+        <li>
+          <%= render partial: "maint_filter", locals: {col: "miscon"} %>
+        </li>
+        <li class="maint-header"><%= "#{@translations[@misc_subj_base_key]} - #{misc_title} (#{grades_str}: #{@dim_grades['miscon'][:min_grade]} - #{@dim_grades['miscon'][:max_grade]})" %></li>
+         <% if  miscon_dims && miscon_dims.count > 0 %>
           <% miscon_dims.each do |dim| %>
             <li id="<%= "#{@translations[@misc_subj_base_key]}-dim-#{dim.id}"%>" class="dim-item dim-item--collapsable list-group-item ui-draggable" data-dimid="<%= dim.id %>">
               <span class='pull-left'><strong><%= "#{translate('app.labels.subject')}:"%></strong> <%="#{@translations[@misc_subj_base_key]}" %></span>
@@ -133,8 +137,8 @@
             <% end %>
             </li>
           <% end %>
-        </ul>
-      <% end #if miscon_dims %>
+        <% end #if miscon_dims %>
+      </ul>
     </div>
   </div>
 </div>

--- a/app/views/trees/maint.html.erb
+++ b/app/views/trees/maint.html.erb
@@ -12,12 +12,12 @@
   <h2><%= translate('trees.maint.title') %></h2>
 </div>
 <% if big_idea_dims && big_idea_dims.count > 0 %>
-  <button id="show_bigidea_btn" class="btn-info margin-bottom hidden" onclick="show_maint_col('bigidea', true);"><%= I18n.t('app.labels.show_indicators', name: ideas_title) %></button>
-  <button id="hide_bigidea_btn" class="btn-info margin-bottom" onclick="show_maint_col('bigidea', false);"><%= I18n.t('app.labels.hide_indicators', name: ideas_title) %></button>
+  <button id="show_bigidea_btn" class="btn-info margin-bottom<%= @show_bigidea ? ' hidden' : '' %>" onclick="show_maint_col('bigidea', true);"><%= I18n.t('app.labels.show_indicators', name: ideas_title) %></button>
+  <button id="hide_bigidea_btn" class="btn-info margin-bottom<%= @show_bigidea ? '' : ' hidden' %>" onclick="show_maint_col('bigidea', false);"><%= I18n.t('app.labels.hide_indicators', name: ideas_title) %></button>
 <% end %>
 <% if miscon_dims && miscon_dims.count > 0 %>
-  <button id="show_miscon_btn" class="btn-info margin-bottom" onclick="show_maint_col('miscon', true);"><%= I18n.t('app.labels.show_indicators', name: misc_title) %></button>
-  <button id="hide_miscon_btn" class="btn-info margin-bottom hidden" onclick="show_maint_col('miscon', false);"><%= I18n.t('app.labels.hide_indicators', name: misc_title) %></button>
+  <button id="show_miscon_btn" class="btn-info margin-bottom<%= @show_miscon ? ' hidden' : '' %>" onclick="show_maint_col('miscon', true);"><%= I18n.t('app.labels.show_indicators', name: misc_title) %></button>
+  <button id="hide_miscon_btn" class="btn-info margin-bottom<%= @show_miscon ? '' : ' hidden' %>" onclick="show_maint_col('miscon', false);"><%= I18n.t('app.labels.hide_indicators', name: misc_title) %></button>
 <% end %>
 <% subj_counter = 0 %>
 <div id="trees" class="dimension-page maint-page">
@@ -126,7 +126,7 @@
       </ul>
       <% grades_str = translate('app.labels.grade_band').pluralize %>
       <% if big_idea_dims && big_idea_dims.count > 0 %>
-        <ul class="list-group maint-column bigidea-col">
+        <ul class="list-group maint-column bigidea-col<%= @show_bigidea ? '' : ' hidden' %>">
           <li class="maint-header"><%= "#{@translations[@idea_subj_base_key]} - #{ideas_title} (#{grades_str}: #{@dim_grades['bigidea'][:min_grade]} - #{@dim_grades['bigidea'][:max_grade]})" %></li>
           <% big_idea_dims.each do |dim| %>
             <li id="<%= "#{@translations[@idea_subj_base_key]}-dim-#{dim.id}"%>" class="dim-item dim-item--collapsable list-group-item ui-draggable" data-dimid="<%= dim.id %>">
@@ -148,7 +148,7 @@
       <% end #if big_idea_dims
          if miscon_dims && miscon_dims.count > 0
       %>
-        <ul class="list-group maint-column miscon-col hidden">
+        <ul class="list-group maint-column miscon-col<%= @show_miscon ? '' : ' hidden' %>">
           <li class="maint-header"><%= "#{@translations[@misc_subj_base_key]} - #{misc_title} (#{grades_str}: #{@dim_grades['miscon'][:min_grade]} - #{@dim_grades['miscon'][:max_grade]})" %></li>
           <% miscon_dims.each do |dim| %>
             <li id="<%= "#{@translations[@misc_subj_base_key]}-dim-#{dim.id}"%>" class="dim-item dim-item--collapsable list-group-item ui-draggable" data-dimid="<%= dim.id %>">

--- a/app/views/trees/maint.html.erb
+++ b/app/views/trees/maint.html.erb
@@ -1,6 +1,5 @@
 <% content_for(:title_code, 'trees.maint.name') %>
 <% content_for(:page_class, 'trees') %>
-<% current_path = @editing ? maint_trees_path(editme: true) : maint_trees_path %>
 
 <br>
 <div class='text-center sequence-page'>
@@ -11,8 +10,11 @@
   <div class="sequence-grid cols-<%= 2 %>">
     <ul class="list-group maint-column">
       <li>
-        <%= form_for @tree, url: current_path, :html => { :method => 'GET' } do |form| %>
+        <%= form_for @tree, url: maint_trees_path, :html => { :method => 'GET' } do |form| %>
       <div class='row'>
+        <% if @editing %>
+        <input type='hidden' name='editme' value=true></input>
+        <% end %>
         <div class='col col-md-4'><label for='tree_subject'><%= translate('app.labels.subject') %></label></div>
         <div class='col col-md-4'><label for='tree_grade_band'><%= translate('app.labels.grade_band') %></label></div>
         <div class='col col-md-4'><%= translate('app.labels.actions') %></div>
@@ -30,8 +32,7 @@
           <!-- %= collection_select(:tree, :grade_band_id, @gbs, :id, :code, include_blank: I18n.t('app.labels.all') ) % -->
           <select id='tree_grade_band_id' name='tree[grade_band_id]'>
             <option value='0'><%= I18n.t('app.labels.all') %></option>
-          <% gbs = @gbOptions || @gbs %>
-          <% gbs.each do |gb| %>
+          <% @gbs.each do |gb| %>
             <%- selectedStr = (gb.code == @grade_band_code) ? ' selected = "selected"' : '' %>
             <%= Rails.logger.debug("gb index match: #{gb.code} == #{@grade_band_code} output: #{selectedStr}") %>
             <option value=<%= gb.id%><%= selectedStr %>><%=gb.code%></option>

--- a/config/locales/pages.en.yml
+++ b/config/locales/pages.en.yml
@@ -80,6 +80,8 @@ en:
       missing_version_record: "error - missing Version Record"
       missing_version_code: "error - invalid Version Code"
       max_subj_display_count: "A maximum of %{num} subjects can be displayed at once."
+    notice:
+      saved_relationship: "Saved relationship: %{item_type_1} [%{item_desc_1}] is related to the %{item_type_2} [%{item_desc_2}]"
   home:
     name: "Curriculum Home Page"
     title: "Curriculum Home Page"

--- a/config/locales/pages.en.yml
+++ b/config/locales/pages.en.yml
@@ -97,8 +97,8 @@ en:
       name: "Relations"
       hover: "Display the Relations between Curriculum Items"
     maint:
-      name: "Maintenance"
-      hover: "Page for Maintenance of Curriculum Items"
+      name: "Editing"
+      hover: "Page for Editing of Curriculum Items"
     connections:
       name: "Other"
       hover: "Other Connections"
@@ -172,7 +172,7 @@ en:
     sequencing:
       title: "Relations"
     maint:
-      title: "Maintenance"
+      title: "Editing"
     miscon:
       title: "Misconceptions"
       singular: "Misconception"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -33,7 +33,6 @@ scope "(:locale)", locale: /tr|en/ do
       get 'index_listing'
       post 'index_listing'
       get 'sequence'
-      get 'outcomes'
       get 'dimensions'
       get 'edit_dimensions'
       post 'reorder'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -33,6 +33,7 @@ scope "(:locale)", locale: /tr|en/ do
       get 'index_listing'
       post 'index_listing'
       get 'sequence'
+      get 'outcomes'
       get 'dimensions'
       get 'edit_dimensions'
       post 'reorder'

--- a/db/migrate/20200303163027_add_grades_to_grade_bands.rb
+++ b/db/migrate/20200303163027_add_grades_to_grade_bands.rb
@@ -1,0 +1,6 @@
+class AddGradesToGradeBands < ActiveRecord::Migration[5.1]
+  def change
+    add_column :grade_bands, :min_grade, :integer, default: 999, null: false
+    add_column :grade_bands, :max_grade, :integer, default: 999, null: false
+  end
+end

--- a/db/migrate/20200303163049_add_grades_to_dimensions.rb
+++ b/db/migrate/20200303163049_add_grades_to_dimensions.rb
@@ -1,0 +1,6 @@
+class AddGradesToDimensions < ActiveRecord::Migration[5.1]
+  def change
+    add_column :dimensions, :min_grade, :integer, default: 999, null: false
+    add_column :dimensions, :max_grade, :integer, default: 999, null: false
+  end
+end

--- a/db/migrate/20200303165934_add_grades_to_subjects.rb
+++ b/db/migrate/20200303165934_add_grades_to_subjects.rb
@@ -1,0 +1,7 @@
+# Gets updated to match the existing data for the subject.
+class AddGradesToSubjects < ActiveRecord::Migration[5.1]
+  def change
+    add_column :subjects, :min_grade, :integer, default: 999, null: false
+    add_column :subjects, :max_grade, :integer, default: 999, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20200213233406) do
+ActiveRecord::Schema.define(version: 20200303165934) do
 
   create_table "dimension_trees", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.bigint "dimension_id", null: false
@@ -32,6 +32,8 @@ ActiveRecord::Schema.define(version: 20200213233406) do
     t.integer "dim_order", default: 0
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "min_grade", default: 999, null: false
+    t.integer "max_grade", default: 999, null: false
     t.index ["dim_code"], name: "index_dimensions_on_dim_code"
     t.index ["dim_type", "dim_code"], name: "index_dimensions_on_dim_type_and_dim_code"
     t.index ["subject_id"], name: "index_dimensions_on_subject_id"
@@ -44,6 +46,8 @@ ActiveRecord::Schema.define(version: 20200213233406) do
     t.datetime "updated_at", null: false
     t.integer "sort_order", default: 0
     t.boolean "active", default: true
+    t.integer "min_grade", default: 999, null: false
+    t.integer "max_grade", default: 999, null: false
     t.index ["tree_type_id"], name: "index_grade_bands_on_tree_type_id"
   end
 
@@ -83,6 +87,8 @@ ActiveRecord::Schema.define(version: 20200213233406) do
     t.datetime "updated_at", null: false
     t.string "base_key"
     t.boolean "active", default: true
+    t.integer "min_grade", default: 999, null: false
+    t.integer "max_grade", default: 999, null: false
     t.index ["tree_type_id"], name: "index_subjects_on_tree_type_id"
   end
 

--- a/lib/tasks/set_min_max_grades.rake
+++ b/lib/tasks/set_min_max_grades.rake
@@ -1,0 +1,64 @@
+namespace :set_min_max_grades do
+
+  desc "set the min_grade and max_grade field for Dimensions, Subjects, and Gradebands with min and max grades set to 999"
+  task run: :environment do
+    subjects = Subject.all;
+    gbs = GradeBand.all;
+    dims = Dimension.all;
+
+    # Add code for gradebands covering more than one grade,
+    # or gradebands with a non-integer code
+    gb_grade_map = {
+    	k: {min: 0, max: 0},
+    	fresh: {min: 13, max: 13},
+    	soph: {min: 14, max: 14},
+    	junior: {min: 15, max: 15},
+    	senior: {min: 16, max: 16},
+    }
+
+    gbs.each do |gb|
+      if gb.min_grade == 999
+	      gb_grades = gb_grade_map[gb[:code]] ? gb_grade_map[gb[:code]] : {min: gb[:code], max: gb[:code]}
+	      gb.min_grade = gb_grades[:min]
+	      gb.max_grade = gb_grades[:max]
+	      gb.save!
+	      puts "Updated GradeBand #{gb[:code]}: min_grade = #{gb[:min_grade]} and max_grade = #{gb[:max_grade]}"
+      end
+    end
+
+    # If any curriculum tree items reference this subject,
+    # change the min/max grades to reflect existing curriculum
+    # Max/min grades should be set for gradebands before this is attempted.
+    subjects.each do |s|
+      subj_gbs = GradeBand.where(:id => Tree.where(:subject_id => s.id).pluck("grade_band_id").uniq)
+      min_grades = subj_gbs.order("min_grade asc").pluck("min_grade").uniq
+      max_grades = subj_gbs.order("max_grade desc").pluck("max_grade").uniq
+      if min_grades.length > 0 && max_grades.length > 0
+      	s.min_grade = min_grades[0]
+      	s.max_grade = max_grades[0]
+      	s.save!
+      	puts "Updated Subject #{s[:code]}: min_grade = #{s[:min_grade]} and max_grade = #{s[:max_grade]}"
+      end
+    end
+
+
+    # Set default min and max grades for Dimensions to match their subject.
+    # Note: these values may be adjusted by users in the app to be more or less
+    #       restrictive than the values on the subject. Therefore, only set
+    #       values for dimensions with a min and max grade of 999
+    dims.each do |d|
+      if d.min_grade == 999
+        begin
+          dim_subj = Subject.find(d.subject_id)
+          d.min_grade = dim_subj.min_grade
+          d.max_grade = dim_subj.max_grade
+          d.save!
+          puts "Updated Dimension #{d[:code]}: min_grade = #{d[:min_grade]} and max_grade = #{d[:max_grade]}"
+        rescue
+          puts "Could not update Dimension #{d[:code]}"
+        end
+      end
+    end
+
+  end
+end


### PR DESCRIPTION
resolves #87 

App: 
- "Competecies," Big Ideas, and Misconceptions views of the "Editing" page, which are reflected in topnav
- Enables user to select Subject and Grade of Competencies, Big Ideas, and Misconceptions on all views of the maint page
- Enables user to create and edit connections between Big Ideas or Misconceptions and competencies from the editing page.
- Show/Hide for the Big Ideas and Misconceptions columns

DB:
- migrations to add "min_grade" and "max_grade" to Subjects, GradeBands, and Dimensions