### PR TITLE
Bugfix For Saving DimTrees on the Editing Page

### DIFF
--- a/app/assets/javascripts/dimensions.js
+++ b/app/assets/javascripts/dimensions.js
@@ -142,13 +142,18 @@ initializeDrag = function() {
           source_controller: "trees",
           source_action: "edit_dimensions",
           "tree[tree_id]": tree_id,
-          "tree[dimension_id]": dimension_id
+          "tree[dimension_id]": dimension_id,
+          "dim_tree[bigidea_subj_id]": $("#bigidea-col").data("subjid"),
+          "dim_tree[miscon_subj_id]": $("#miscon-col").data("subjid"),
+          "dim_tree[bigidea_gb_id]": $("#bigidea-col").data("gbid"),
+          "dim_tree[miscon_gb_id]": $("#miscon-col").data("gbid")
         };
         if ($(".bigidea-col:not('.hidden')").length > 0)
           data["show_bigidea"] = true;
         if ($(".miscon-col:not('.hidden')").length > 0)
           data["show_miscon"] = true;
-        console.log("data");
+
+        console.log(JSON.stringify(data));
         $.ajax({
           type: "get",
           url: "/trees/edit_dimensions",

--- a/app/views/trees/maint.html.erb
+++ b/app/views/trees/maint.html.erb
@@ -93,7 +93,7 @@
       </ul>
       <% grades_str = translate('app.labels.grade_band').pluralize %>
 
-      <ul class="list-group maint-column bigidea-col<%= @show_bigidea ? '' : ' hidden' %>">
+      <ul id="bigidea-col" class="list-group maint-column bigidea-col<%= @show_bigidea ? '' : ' hidden' %>" data-subjid="<%= @dim_subjs['bigidea'].id %>" data-gbid="<%= @bi_gb ? (@bi_gb[:id] || 0) : 0 %>">
         <li>
           <%= render partial: "maint_filter", locals: {col: "bigidea"} %>
         </li>
@@ -118,7 +118,7 @@
         <% end #if big_idea_dims %>
       </ul>
 
-      <ul class="list-group maint-column miscon-col<%= @show_miscon ? '' : ' hidden' %>">
+      <ul id="miscon-col" class="list-group maint-column miscon-col<%= @show_miscon ? '' : ' hidden' %>" data-subjid="<%= @dim_subjs['miscon'].id %>" data-gbid="<%= @m_gb ? (@m_gb[:id] || 0) : 0 %>">
         <li>
           <%= render partial: "maint_filter", locals: {col: "miscon"} %>
         </li>


### PR DESCRIPTION
- Stop server exception when changing curriculum versions immediately after saving a new DimTree on the editing page. 
- Remember dimension subjects and gradebands selected when saving a DimTree.