### PR TITLE
Base subjects

### DIFF
--- a/app/assets/javascripts/dimensions.js
+++ b/app/assets/javascripts/dimensions.js
@@ -143,8 +143,8 @@ initializeDrag = function() {
           source_action: "edit_dimensions",
           "tree[tree_id]": tree_id,
           "tree[dimension_id]": dimension_id,
-          "dim_tree[bigidea_subj_id]": $("#bigidea-col").data("subjid"),
-          "dim_tree[miscon_subj_id]": $("#miscon-col").data("subjid"),
+          "dim_tree[bigidea_subj_code]": $("#bigidea-col").data("subjcode"),
+          "dim_tree[miscon_subj_code]": $("#miscon-col").data("subjcode"),
           "dim_tree[bigidea_gb_id]": $("#bigidea-col").data("gbid"),
           "dim_tree[miscon_gb_id]": $("#miscon-col").data("gbid")
         };

--- a/app/controllers/trees_controller.rb
+++ b/app/controllers/trees_controller.rb
@@ -1089,13 +1089,13 @@ class TreesController < ApplicationController
       if dim_tree_params[:bigidea_gb_id] != "0"
         @bi_gb = GradeBand.find(dim_tree_params[:bigidea_gb_id])
       else
-        subjs = Subject.where(:code => @dim_subjs['bigidea'])
-        @bi_gb = {min_grade: subjs.order("min_grade asc").pluck("min_grade")[0], max_grade: subjs.order("max_grade desc").pluck("max_grade")[0]}
+        subjs = Subject.where('code = ? AND max_grade < ?', @dim_subjs['bigidea'], 999)
+        @bi_gb = subjs.count > 0 ? {min_grade: subjs.order("min_grade asc").pluck("min_grade")[0], max_grade: subjs.order("max_grade desc").pluck("max_grade")[0]} : { min_grade: GradeBand::MIN_GRADE, max_grade: GradeBand::MAX_GRADE}
       end
       @dim_grades['bigidea'] = { min_grade: @bi_gb[:min_grade], max_grade: @bi_gb[:max_grade]}
     elsif @dim_subjs['bigidea']
-      subjs = Subject.where(:code => @dim_subjs['bigidea'])
-      @dim_grades['bigidea'] = {min_grade: subjs.order("min_grade asc").pluck("min_grade")[0], max_grade: subjs.order("max_grade desc").pluck("max_grade")[0]}
+      subjs = Subject.where('code = ? AND max_grade < ?', @dim_subjs['bigidea'], 999)
+      @dim_grades['bigidea'] = subjs.count > 0 ? {min_grade: subjs.order("min_grade asc").pluck("min_grade")[0], max_grade: subjs.order("max_grade desc").pluck("max_grade")[0]} : { min_grade: GradeBand::MIN_GRADE, max_grade: GradeBand::MAX_GRADE}
     else
       @dim_grades['bigidea'] = { min_grade: GradeBand::MIN_GRADE, max_grade: GradeBand::MAX_GRADE}
     end
@@ -1104,13 +1104,13 @@ class TreesController < ApplicationController
       if dim_tree_params[:miscon_gb_id] != "0"
         @m_gb = GradeBand.find(dim_tree_params[:miscon_gb_id])
       else
-        subjs = Subject.where(:code => @dim_subjs['miscon'])
-        @m_gb = {min_grade: subjs.order("min_grade asc").pluck("min_grade")[0], max_grade: subjs.order("max_grade desc").pluck("max_grade")[0]}
+        subjs = Subject.where('code = ? AND max_grade < ?', @dim_subjs['miscon'], 999)
+        @m_gb = subjs.count > 0 ? {min_grade: subjs.order("min_grade asc").pluck("min_grade")[0], max_grade: subjs.order("max_grade desc").pluck("max_grade")[0]} : { min_grade: GradeBand::MIN_GRADE, max_grade: GradeBand::MAX_GRADE }
       end
       @dim_grades['miscon'] = { min_grade: @m_gb[:min_grade], max_grade: @m_gb[:max_grade]}
     elsif @dim_subjs['miscon']
-      subjs = Subject.where(:code => @dim_subjs['miscon'])
-      @dim_grades['miscon'] = {min_grade: subjs.order("min_grade asc").pluck("min_grade")[0], max_grade: subjs.order("max_grade desc").pluck("max_grade")[0]}
+      subjs = Subject.where('code = ? AND max_grade < ?', @dim_subjs['miscon'], 999)
+      @dim_grades['miscon'] = subjs.count > 0 ? {min_grade: subjs.order("min_grade asc").pluck("min_grade")[0], max_grade: subjs.order("max_grade desc").pluck("max_grade")[0]} : { min_grade: GradeBand::MIN_GRADE.min_grade, max_grade: GradeBand::MAX_GRADE }
     else
       @dim_grades['miscon'] = { min_grade: GradeBand::MIN_GRADE.min_grade, max_grade: GradeBand::MAX_GRADE }
     end

--- a/app/controllers/trees_controller.rb
+++ b/app/controllers/trees_controller.rb
@@ -180,9 +180,10 @@ class TreesController < ApplicationController
     treePrep
     dimPrep
     @editing = params[:editme] && current_user.present? && current_user.is_admin?
-    @page_title = @editing ? translate('trees.maint.title') : (dim_tree_params && dim_tree_params[:dim_type] ? translate('nav_bar.'+dim_tree_params[:dim_type]+'.name') : @hierarchies[@treeTypeRec.outcome_depth].pluralize )
-    @show_miscon = dim_tree_params && dim_tree_params[:dim_type] ? (dim_tree_params[:dim_type] == @treeTypeRec.miscon_dim_type) : (cookies[:miscon_visible] == "true") #params[:show_miscon]
-    @show_bigidea = dim_tree_params && dim_tree_params[:dim_type] ? (dim_tree_params[:dim_type] == @treeTypeRec.big_ideas_dim_type) : (cookies[:bigidea_visible] == "true") #params[:show_bigidea]
+    @dim_type = dim_tree_params && dim_tree_params[:dim_type] ? dim_tree_params[:dim_type] : nil
+    @page_title = @editing ? translate('trees.maint.title') : (@dim_type ? translate('nav_bar.'+@dim_type+'.name') : @hierarchies[@treeTypeRec.outcome_depth].pluralize )
+    @show_miscon = @dim_type ? (@dim_type == @treeTypeRec.miscon_dim_type) : (cookies[:miscon_visible] == "true") #params[:show_miscon]
+    @show_bigidea = @dim_type ? (@dim_type == @treeTypeRec.big_ideas_dim_type) : (cookies[:bigidea_visible] == "true") #params[:show_bigidea]
 
     @treeByParents = Hash.new{ |h, k| h[k] = {} }
 

--- a/app/models/base_rec.rb
+++ b/app/models/base_rec.rb
@@ -33,6 +33,19 @@ class BaseRec < ActiveRecord::Base
   LOCALE_TR_TR = 'tr_TR'
   VALID_LOCALES = [LOCALE_TR, LOCALE_EN]
   DEFAULT_LOCALE = LOCALE_EN
+  BASE_SUBJECTS = [
+    'bio', #Biology
+    'cap', #Capstones
+    'che', #Chemistry
+    'edu', #Education
+    'eng', #English
+    'mat', #Math
+    'mec', #Mechanics
+    'phy', #Physics
+    'sci', #Science
+    'ear', #Earth Science
+    'geo', #Geology
+  ]
 
 
   # only used in uploads

--- a/app/views/trees/_edit_dimensions.html.erb
+++ b/app/views/trees/_edit_dimensions.html.erb
@@ -17,8 +17,8 @@
     <% if @m_gb && @m_gb[:id] %>
       <input type="hidden" name="dim_tree[miscon_gb_id]" value=<%= @m_gb[:id] %>>
     <% end %>
-    <input type="hidden" name="dim_tree[bigidea_subj_id]" value='<%= @dim_subjs['bigidea'][:id] %>'>
-    <input type="hidden" name="dim_tree[miscon_subj_id]" value='<%= @dim_subjs['miscon'][:id] %>'>
+    <input type="hidden" name="dim_tree[bigidea_subj_code]" value='<%= @dim_subjs['bigidea'] %>'>
+    <input type="hidden" name="dim_tree[miscon_subj_code]" value='<%= @dim_subjs['miscon'] %>'>
   	<input type="hidden" name="dim_tree[tree_id]" value='<%= @dim_tree.tree_id %>'>
   	<input type="hidden" name="dim_tree[dimension_id]" value='<%= @dim_tree.dimension_id %>'>
     <input type="hidden" name="dim_tree[dim_explanation_key]" value='<%= @dim_tree.dim_explanation_key %>'>

--- a/app/views/trees/_maint_filter.html.erb
+++ b/app/views/trees/_maint_filter.html.erb
@@ -6,22 +6,25 @@
     <% if @editing %>
       <input type='hidden' name='editme' value=true></input>
     <% end %>
+    <% if @dim_type %>
+      <input type='hidden' name='dim_tree[dim_type]' value="<%= @dim_type%>"></input>
+    <% end %>
 
     <!-- If searching for a different set of misconceptions, don't forget the current set of big ideas. -->
     <% if col == "miscon"
-       if @dim_subjs['bigidea'] %>
+       if @dim_subjs['bigidea'] && @dim_type != 'miscon' %>
         <input type='hidden' name='dim_tree[bigidea_subj_code]' value=<%= @dim_subjs['bigidea'] %>></input>
     <% end
-       if @bi_gb %>
+       if @bi_gb && @dim_type != 'miscon' %>
          <input type='hidden' name='dim_tree[bigidea_gb_id]' value=<%= @bi_gb[:id] || 0 %>></input>
     <% end
     end %>
     <!-- If searching for a different set of bigideas, don't forget the current set of misconceptions. -->
     <% if col == "bigidea"
-         if @dim_subjs['miscon'] %>
+         if @dim_subjs['miscon'] && @dim_type != 'bigidea' %>
     		  <input type='hidden' name='dim_tree[miscon_subj_code]' value=<%= @dim_subjs['miscon'] %>></input>
     	<% end
-    	   if @m_gb
+    	   if @m_gb && @dim_type != 'bigidea'
     	%>
     		  <input type='hidden' name='dim_tree[miscon_gb_id]' value=<%= @m_gb[:id] || 0 %>></input>
     <% end

--- a/app/views/trees/_maint_filter.html.erb
+++ b/app/views/trees/_maint_filter.html.erb
@@ -40,12 +40,12 @@
             <% sel_code = @subject_code %>
             <%- selectedStr = (s.code == sel_code) ? ' selected = "selected"' : '' %>
             <%= Rails.logger.debug(" +++ index match output: #{selectedStr}") %>
-            <option value=<%= s.id %><%= selectedStr %>><%= s.abbr( @locale_code ) %></option>
+            <option value=<%= s.id %><%= selectedStr %>><%= @translations["subject.base.#{s.code}.abbr"] %></option>
           <% end %>
         <% else # if col != "tree" %>
           <% BaseRec::BASE_SUBJECTS.each do |s| %>
             <% sel_code = @dim_subjs[col] if @dim_subjs[col]
-               opt_name = @translations["subject.base.#{s}.name"]
+               opt_name = @translations["subject.base.#{s}.abbr"]
             %>
             <%- selectedStr = (s == sel_code) ? ' selected = "selected"' : '' %>
             <option value=<%= s %><%= selectedStr %>><%= opt_name %></option>

--- a/app/views/trees/_maint_filter.html.erb
+++ b/app/views/trees/_maint_filter.html.erb
@@ -10,7 +10,7 @@
     <!-- If searching for a different set of misconceptions, don't forget the current set of big ideas. -->
     <% if col == "miscon"
        if @dim_subjs['bigidea'] %>
-        <input type='hidden' name='dim_tree[bigidea_subj_id]' value=<%= @dim_subjs['bigidea'].id %>></input>
+        <input type='hidden' name='dim_tree[bigidea_subj_code]' value=<%= @dim_subjs['bigidea'] %>></input>
     <% end
        if @bi_gb %>
          <input type='hidden' name='dim_tree[bigidea_gb_id]' value=<%= @bi_gb[:id] || 0 %>></input>
@@ -19,7 +19,7 @@
     <!-- If searching for a different set of bigideas, don't forget the current set of misconceptions. -->
     <% if col == "bigidea"
          if @dim_subjs['miscon'] %>
-    		  <input type='hidden' name='dim_tree[miscon_subj_id]' value=<%= @dim_subjs['miscon'].id %>></input>
+    		  <input type='hidden' name='dim_tree[miscon_subj_code]' value=<%= @dim_subjs['miscon'] %>></input>
     	<% end
     	   if @m_gb
     	%>
@@ -34,15 +34,23 @@
 
   <!-- Form input options -->
   <div class='row'>
-    <div class='col col-md-3 subject-with-gb'><select id='<%= param_name %>_subject_id' name='<%= param_name %>[<%= param_name == "tree" ? "subject_id" : "#{col}_subj_id"%>]'>
-      <% @subjects.each do |k, s| %>
-        <% sel_code = @subject_code
-           sel_code = @dim_subjs[col].code if @dim_subjs[col]
-        %>
-        <%- selectedStr = (s.code == sel_code) ? ' selected = "selected"' : '' %>
-        <%= Rails.logger.debug(" +++ index match output: #{selectedStr}") %>
-        <option value=<%= s.id%><%= selectedStr %>><%=s.abbr( @locale_code )%></option>
-      <% end %>
+    <div class='col col-md-3 subject-with-gb'><select id='<%= param_name %>_subject_id' name='<%= param_name %>[<%= param_name == "tree" ? "subject_id" : "#{col}_subj_code"%>]'>
+        <% if col == "tree" %>
+          <% @subjects.each do |k, s| %>
+            <% sel_code = @subject_code %>
+            <%- selectedStr = (s.code == sel_code) ? ' selected = "selected"' : '' %>
+            <%= Rails.logger.debug(" +++ index match output: #{selectedStr}") %>
+            <option value=<%= s.id %><%= selectedStr %>><%= s.abbr( @locale_code ) %></option>
+          <% end %>
+        <% else # if col != "tree" %>
+          <% BaseRec::BASE_SUBJECTS.each do |s| %>
+            <% sel_code = @dim_subjs[col] if @dim_subjs[col]
+               opt_name = @translations["subject.base.#{s}.name"]
+            %>
+            <%- selectedStr = (s == sel_code) ? ' selected = "selected"' : '' %>
+            <option value=<%= s %><%= selectedStr %>><%= opt_name %></option>
+          <% end %>
+        <% end # if col == "tree" %>
     </select></div>
     <div id='<%= param_name %>-gb-container' class='col col-md-4'>
       <span id='<%= param_name %>-all-gbs-select'>

--- a/app/views/trees/maint.html.erb
+++ b/app/views/trees/maint.html.erb
@@ -11,11 +11,11 @@
 <div class='text-center dimension-page'>
   <h2><%= @page_title %></h2>
 </div>
-<% if true #big_idea_dims && big_idea_dims.count > 0 %>
+<% if !@dim_type #big_idea_dims && big_idea_dims.count > 0 %>
   <button id="show_bigidea_btn" class="btn-secondary margin-bottom<%= @show_bigidea ? ' hidden' : '' %>" onclick="show_maint_col('bigidea', true);"><%= I18n.t('app.labels.show_indicators', name: ideas_title) %></button>
   <button id="hide_bigidea_btn" class="btn-info margin-bottom<%= @show_bigidea ? '' : ' hidden' %>" onclick="show_maint_col('bigidea', false);"><%= I18n.t('app.labels.hide_indicators', name: ideas_title) %></button>
 <% end %>
-<% if true #miscon_dims && miscon_dims.count > 0 %>
+<% if !@dim_type #miscon_dims && miscon_dims.count > 0 %>
   <button id="show_miscon_btn" class="btn-secondary margin-bottom<%= @show_miscon ? ' hidden' : '' %>" onclick="show_maint_col('miscon', true);"><%= I18n.t('app.labels.show_indicators', name: misc_title) %></button>
   <button id="hide_miscon_btn" class="btn-info margin-bottom<%= @show_miscon ? '' : ' hidden' %>" onclick="show_maint_col('miscon', false);"><%= I18n.t('app.labels.hide_indicators', name: misc_title) %></button>
 <% end %>

--- a/app/views/trees/maint.html.erb
+++ b/app/views/trees/maint.html.erb
@@ -93,7 +93,7 @@
       </ul>
       <% grades_str = translate('app.labels.grade_band').pluralize %>
 
-      <ul id="bigidea-col" class="list-group maint-column bigidea-col<%= @show_bigidea ? '' : ' hidden' %>" data-subjid="<%= @dim_subjs['bigidea'].id %>" data-gbid="<%= @bi_gb ? (@bi_gb[:id] || 0) : 0 %>">
+      <ul id="bigidea-col" class="list-group maint-column bigidea-col<%= @show_bigidea ? '' : ' hidden' %>" data-subjcode="<%= @dim_subjs['bigidea'] %>" data-gbid="<%= @bi_gb ? (@bi_gb[:id] || 0) : 0 %>">
         <li>
           <%= render partial: "maint_filter", locals: {col: "bigidea"} %>
         </li>
@@ -118,7 +118,7 @@
         <% end #if big_idea_dims %>
       </ul>
 
-      <ul id="miscon-col" class="list-group maint-column miscon-col<%= @show_miscon ? '' : ' hidden' %>" data-subjid="<%= @dim_subjs['miscon'].id %>" data-gbid="<%= @m_gb ? (@m_gb[:id] || 0) : 0 %>">
+      <ul id="miscon-col" class="list-group maint-column miscon-col<%= @show_miscon ? '' : ' hidden' %>" data-subjcode="<%= @dim_subjs['miscon'] %>" data-gbid="<%= @m_gb ? (@m_gb[:id] || 0) : 0 %>">
         <li>
           <%= render partial: "maint_filter", locals: {col: "miscon"} %>
         </li>

--- a/db/migrate/20200317014904_add_subject_code_to_dimensions.rb
+++ b/db/migrate/20200317014904_add_subject_code_to_dimensions.rb
@@ -1,0 +1,5 @@
+class AddSubjectCodeToDimensions < ActiveRecord::Migration[5.1]
+  def change
+    add_column :dimensions, :subject_code, :string, default: "", null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20200303165934) do
+ActiveRecord::Schema.define(version: 20200317014904) do
 
   create_table "dimension_trees", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.bigint "dimension_id", null: false
@@ -34,6 +34,7 @@ ActiveRecord::Schema.define(version: 20200303165934) do
     t.datetime "updated_at", null: false
     t.integer "min_grade", default: 999, null: false
     t.integer "max_grade", default: 999, null: false
+    t.string "subject_code", default: "", null: false
     t.index ["dim_code"], name: "index_dimensions_on_dim_code"
     t.index ["dim_type", "dim_code"], name: "index_dimensions_on_dim_type_and_dim_code"
     t.index ["subject_id"], name: "index_dimensions_on_subject_id"

--- a/lib/tasks/dimensions.rake
+++ b/lib/tasks/dimensions.rake
@@ -1,0 +1,19 @@
+namespace :dimensions do
+  desc "set the subject_code field for Dimensions (if not already set), from the subject_id"
+  task set_subject_codes: :environment do
+
+  	dimensions = Dimension.where(subject_code: "")
+  	dimensions.each do |d|
+  		begin
+        code = Subject.find(d.subject_id).code
+        d.subject_code = code
+        d.save!
+         puts "Saved subject code '#{d.subject_code}' for dimension id: #{d.id}"
+  		rescue
+        puts "Failed to save subject code for dimension id: #{d.id}"
+  		end
+  	end
+
+  end #task set_subject_codes: :environment do
+
+end

--- a/lib/tasks/dimensions.rake
+++ b/lib/tasks/dimensions.rake
@@ -14,6 +14,27 @@ namespace :dimensions do
   		end
   	end
 
+    s_lookup = {
+      bio: 'Biology',
+      cap: 'Capstones',
+      che: 'Chemistry',
+      edu: 'Education',
+      eng: 'English',
+      mat: 'Math',
+      mec: 'Mechanics',
+      phy: 'Physics',
+      sci: 'Science',
+      ear: 'Earth Science',
+      geo: 'Geology'
+    }
+    BaseRec::BASE_SUBJECTS.each do |s|
+        rec, status, message = Translation.find_or_update_translation(BaseRec::LOCALE_EN, "subject.base.#{s}.abbr", "#{s}")
+        throw "ERROR updating subject translation: #{message}" if status == BaseRec::REC_ERROR
+        rec, status, message =  Translation.find_or_update_translation(BaseRec::LOCALE_EN, "subject.base.#{s}.name", "#{s_lookup[:"#{s}"]}")
+        throw "ERROR updating subject translation: #{message}" if status == BaseRec::REC_ERROR
+        puts "Saved Translations for #{s}, #{s_lookup[:"#{s}"]}"
+    end
+
   end #task set_subject_codes: :environment do
 
 end


### PR DESCRIPTION
Resolves #91 
- Add subject_code column to Dimensions table. (May eventually replace subject_id column in Dimensions, but subject_id is still needed temporarily for setting the subject_code of pre-existing dimension records-- and it may be preferable to keep the ability to associate dimensions with a particular program/curriculum).
- Add BASE_SUBJECTS const to BaseRec model. Contains all valid subject codes for the app.
-  Add rake process to get subject codes for existing Dimensions from their subject_ids, and add translations for base subjects.
- Use subject code instead of subject ID on the editing/competencies/big ideas/etc page to set which dimensions should be displayed. 
- Don't show the show/hide misconceptions buttons when viewing the dimensions pages.

AFTER MERGING CODE: 
Run rake task, "dimensions:get_subject_codes" to get subject codes for existing Dimensions from their subject_ids, and add translations for base subjects.