### PR TITLE
Optional Sub-Units, Identify Outcome-Level Trees on Maint Page by "tree.outcome"

### DIFF
--- a/app/models/outcome.rb
+++ b/app/models/outcome.rb
@@ -16,7 +16,8 @@ class Outcome < BaseRec
   end
 
   def set_base_key(tree_base_key)
-    base_key = tree_base_key + '.outc'
+    self.base_key = tree_base_key + '.outc'
+    self.save
   end
 
 end

--- a/app/models/outcome.rb
+++ b/app/models/outcome.rb
@@ -15,9 +15,8 @@ class Outcome < BaseRec
     return base_key + ".explain"
   end
 
-  def set_base_key(tree_base_key)
-    self.base_key = tree_base_key + '.outc'
-    self.save
+  def get_base_key(tree_base_key)
+    return tree_base_key + '.outc'
   end
 
 end

--- a/app/models/tree.rb
+++ b/app/models/tree.rb
@@ -252,9 +252,25 @@ class Tree < BaseRec
   def getAllParents
     parents = []
     parent = self.getParentRec
-    while parent.present? do
-      parents << parent
-      parent = parent.getParentRec
+    self_code = self.code.split('.')
+    self_code.pop(1)
+    while self_code.length > 0 do
+      puts "self_code: #{self_code}"
+      if parent.present?
+        parents << parent
+        parent = parent.getParentRec
+        self_code.pop(1)
+      else
+        parents << nil
+        self_code.pop(1)
+        parent = Tree.where(
+            tree_type_id: self.tree_type_id,
+            version_id: self.version_id,
+            subject_id: self.subject_id,
+            grade_band_id: self.grade_band_id,
+            code: self_code.join(".")
+          ).first
+      end
     end
     Rails.logger.debug("*** tree parents: #{parents.inspect}")
     return parents
@@ -271,7 +287,7 @@ class Tree < BaseRec
   def getAllTransNameKeys
     parents = self.getAllParents
     allRecs = parents.concat([self])
-    treeKeys = (allRecs).map { |rec| rec.name_key}
+    treeKeys = (allRecs).map { |rec| rec.name_key if rec}
   end
 
   # Tree.find_or_add_code_in_tree

--- a/app/models/tree.rb
+++ b/app/models/tree.rb
@@ -19,7 +19,7 @@ class Tree < BaseRec
   belongs_to :version
   belongs_to :subject
   belongs_to :grade_band
-  belongs_to :outcome
+  belongs_to :outcome, optional: true
 
   has_many :tree_referencers, foreign_key: :tree_referencer_id, class_name: 'TreeTree'
   # has_many :tree_referencer_trees, through: :tree_referencers

--- a/app/views/trees/maint.html.erb
+++ b/app/views/trees/maint.html.erb
@@ -67,12 +67,7 @@
             <% end %>
             <% if @editing %>
             <div class="pull-right">
-              <a class="" data-confirm="Are you sure?"  href="/<%= @locale_code %>/trees/<%= h[:id] %>?%5Bactive%5D=false">
-                <i class="fa fa-times pull-right" title="deactivate this LO"></i>
-              </a>
-              <a class="sort-handle lo-handle ui-sortable-handle" onclick="" href="#">
-                <i class="fa fa-thumb-tack pull-right" title="resequence this LO"></i>
-              </a>
+              <!-- TO DO: Implement working resequence button and deactivate button -->
               <a class="" href="/<%= @locale_code %>/trees/<%= h[:id] %>?editme=<%= h[:id] %>">
                 <i class="fa fa-edit pull-right" title="edit this LO"></i>
               </a>

--- a/app/views/trees/maint.html.erb
+++ b/app/views/trees/maint.html.erb
@@ -30,7 +30,7 @@
        @treeByParents.each do |tkey, codeh| %>
         <li class="maint-header indent-0"><%= @translations[tkey] %></li>
         <% codeh.each do |code, h| %>
-          <% if h[:depth] == @treeTypeRec.outcome_depth+1 %>
+          <% if h[:outcome] %>
           <% ideas_str = '' #ideas_title
              misc_str = '' #misc_title
              ideas_found = 0
@@ -79,6 +79,7 @@
             </div>
             <% end %>
           </li>
+          <!-- TO DO: Find a different workaround for hiding indicator-level items -->
           <% elsif h[:depth] > @treeTypeRec.outcome_depth+1 %>
           <% else %>
             <li class="maint-sub-header indent-<%= h[:depth]-1 %> <%= h[:selectors_by_parent] %>">

--- a/app/views/trees/show.html.erb
+++ b/app/views/trees/show.html.erb
@@ -17,14 +17,16 @@
       <% @hierarchies.each_with_index do |e, i|
          if i <= @treeTypeRec[:outcome_depth]
            rec = (i == @treeTypeRec[:outcome_depth] ? tree : tree_parents[tree_parents.length - 1 - i])
-           label_text = @translations[rec.buildNameKey]
-       %>
-         <div class='row subject-<%= e.downcase %>-row'><div class='col col-lg-6 text-left'><%= "#{"#{@subjectByCode[tree.subject.code][:name]} " if i == 0}#{e}#{" " + rec.codeArrayAt(i) if i > 0}" %>: <%= label_text %>
-           <% if i == @treeTypeRec[:outcome_depth] %>
-             <%= link_to(fa_icon("edit"), edit_tree_path(@tree.id, tree: { edit_type: 'outcome'}), {:remote => true, 'data-toggle' =>  "modal", 'data-target' => '#modal_popup'}) if @editMe %>
-           <% end %>
-         </div></div>
-      <% end
+           if rec
+             label_text = @translations[rec.buildNameKey]
+           %>
+             <div class='row subject-<%= e.downcase %>-row'><div class='col col-lg-6 text-left'><%= "#{"#{@subjectByCode[tree.subject.code][:name]} " if i == 0 && rec}#{e} #{rec.codeArrayAt(i) if i > 0 && rec}" %>: <%= label_text %>
+               <% if i == @treeTypeRec[:outcome_depth] %>
+                 <%= link_to(fa_icon("edit"), edit_tree_path(@tree.id, tree: { edit_type: 'outcome'}), {:remote => true, 'data-toggle' =>  "modal", 'data-target' => '#modal_popup'}) if @editMe %>
+               <% end %>
+             </div></div>
+      <%  end
+        end
       end %>
 
       <div class='col col-lg-12 text-right'>

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -12,7 +12,7 @@
 
 ActiveRecord::Schema.define(version: 20200326015125) do
 
-  create_table "dimension_trees", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci" do |t|
+  create_table "dimension_trees", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.bigint "dimension_id", null: false
     t.bigint "tree_id", null: false
     t.string "dim_explanation_key"
@@ -23,7 +23,7 @@ ActiveRecord::Schema.define(version: 20200326015125) do
     t.index ["tree_id"], name: "index_dimension_trees_on_tree_id"
   end
 
-  create_table "dimensions", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci" do |t|
+  create_table "dimensions", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.bigint "subject_id"
     t.string "dim_type"
     t.string "dim_code"
@@ -109,8 +109,7 @@ ActiveRecord::Schema.define(version: 20200326015125) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["key"], name: "index_translations_on_key"
-    t.index ["locale", "key"], name: "index_translations_on_keys"
-    t.index ["value"], name: "index_translations_on_value", length: { value: 256 }
+    t.index ["value"], name: "index_translations_on_value", length: { value: 255 }
   end
 
   create_table "tree_trees", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|

--- a/lib/tasks/seed_turkey_v02a.rake
+++ b/lib/tasks/seed_turkey_v02a.rake
@@ -50,7 +50,7 @@ namespace :seed_turkey_v02a do
     Tree.all.each do |t|
       tt = t.tree_type
       if tt.outcome_depth > 0
-        if t.depth == tt.outcome_depth && t.outcome_id != nil
+        if t.depth == tt.outcome_depth && t.outcome_id == nil
           out = Outcome.new()
           out.set_base_key(t.base_key)
           out.save


### PR DESCRIPTION
- Treat tree records as outcomes if the tree record belongs to an outcome.
- Handle optional subunits-- tested with both missing sub-units and existing subunit records
- Fix rake task, "seed_turkey_v02a:populate" to: 
  - create Outcome records for existing outcome-level trees (at the correct tree depth for both curriculum versions)
  - create Translation record for the subunit level of the hierarchy
  - added, utilized, then commented out section at the end, which was used to alter local db records for testing out tree codes with gaps in the hierarchy (e.g., missing subunit in the tree with the code "8.1..2")
- Don't show parent record info on the tree detail page if a record for the parent (e.g., a subunit) does not exist.
- Make it possible to save new Tree records with `outcome_id = nil` by making the belongs_to relationship to an outcome optional for the trees model
- fix Outcome model function: 'set_base_key'
- Temporarily get rid of non-functional deactivate and resequence buttons for trees on the editing page