### PR TITLE
Add Essential Questions (or, K-12 Big Ideas) Column to Editing/Maint/Etc page

### DIFF
--- a/app/controllers/trees_controller.rb
+++ b/app/controllers/trees_controller.rb
@@ -193,7 +193,7 @@ class TreesController < ApplicationController
     @page_title = @editing ? translate('trees.maint.title') : (@dim_type ? translate('nav_bar.'+@dim_type+'.name') : @hierarchies[@treeTypeRec.outcome_depth].pluralize )
     @show_miscon = @dim_type ? (@dim_type == @treeTypeRec.miscon_dim_type) : (cookies[:miscon_visible] == "true") #params[:show_miscon]
     @show_bigidea = @dim_type ? (@dim_type == @treeTypeRec.big_ideas_dim_type) : (cookies[:bigidea_visible] == "true") #params[:show_bigidea]
-    @show_ess_q = @dim_type ? (@dim_type == @treeTypeRec.ess_q_dim_type) : true #(cookies[:ess_q_visible] == "true")
+    @show_ess_q = @dim_type ? (@dim_type == @treeTypeRec.ess_q_dim_type) : (cookies[:essq_visible] == "true")
 
     @ideas_title = Translation.find_translation_name(@locale_code, Dimension.get_dim_type_key(@treeTypeRec.big_ideas_dim_type, @treeTypeRec.code, @versionRec.code), nil) || translate('nav_bar.bigidea.name')
 

--- a/app/controllers/trees_controller.rb
+++ b/app/controllers/trees_controller.rb
@@ -190,7 +190,7 @@ class TreesController < ApplicationController
     dimPrep
     @editing = params[:editme] && current_user.present? && current_user.is_admin?
     @dim_type = dim_tree_params && dim_tree_params[:dim_type] ? dim_tree_params[:dim_type] : nil
-    @page_title = @editing ? translate('trees.maint.title') : (@dim_type ? translate('nav_bar.'+@dim_type+'.name') : @hierarchies[@treeTypeRec.outcome_depth].pluralize )
+    @page_title = @editing ? translate('trees.maint.title') : (@dim_type ? (Translation.find_translation_name(@locale_code, Dimension.get_dim_type_key(@dim_type, @treeTypeRec.code, @versionRec.code), nil) || translate('nav_bar.'+@dim_type+'.name')) : @hierarchies[@treeTypeRec.outcome_depth].pluralize )
     @show_miscon = @dim_type ? (@dim_type == @treeTypeRec.miscon_dim_type) : (cookies[:miscon_visible] == "true") #params[:show_miscon]
     @show_bigidea = @dim_type ? (@dim_type == @treeTypeRec.big_ideas_dim_type) : (cookies[:bigidea_visible] == "true") #params[:show_bigidea]
     @show_ess_q = @dim_type ? (@dim_type == @treeTypeRec.ess_q_dim_type) : (cookies[:essq_visible] == "true")
@@ -632,6 +632,7 @@ class TreesController < ApplicationController
   def edit_dimensions
     errors = []
     @explanation = ''
+    @show_ess_q = true if params[:show_ess_q]
     @show_bigidea = true if params[:show_bigidea]
     @show_miscon = true if params[:show_miscon]
     @tree = Tree.find(tree_params[:tree_id])
@@ -699,6 +700,7 @@ class TreesController < ApplicationController
       end
     end #end transaction
     options = {editme: true}
+    options[:show_ess_q] = true if params[:show_ess_q]
     options[:show_bigidea] = true if params[:show_bigidea]
     options[:show_miscon] = true if params[:show_miscon]
     options[:dim_tree] = { id: @dim_tree.id }
@@ -736,6 +738,7 @@ class TreesController < ApplicationController
       end
     end #end transaction
     options = {editme: true}
+    options[:show_ess_q] = true if params[:show_ess_q]
     options[:show_bigidea] = true if params[:show_bigidea]
     options[:show_miscon] = true if params[:show_miscon]
     options[:dim_tree] = { id: @dim_tree.id }

--- a/app/controllers/trees_controller.rb
+++ b/app/controllers/trees_controller.rb
@@ -195,11 +195,13 @@ class TreesController < ApplicationController
     @show_bigidea = @dim_type ? (@dim_type == @treeTypeRec.big_ideas_dim_type) : (cookies[:bigidea_visible] == "true") #params[:show_bigidea]
     @show_ess_q = @dim_type ? (@dim_type == @treeTypeRec.ess_q_dim_type) : true #(cookies[:ess_q_visible] == "true")
 
-    @ideas_title = Translation.find_translation_name(@locale_code, Dimension.get_dim_type_key(@treeTypeRec.big_ideas_dim_type, @treeTypeRec.code, @version_code), nil) || translate('nav_bar.bigidea.name')
+    @ideas_title = Translation.find_translation_name(@locale_code, Dimension.get_dim_type_key(@treeTypeRec.big_ideas_dim_type, @treeTypeRec.code, @versionRec.code), nil) || translate('nav_bar.bigidea.name')
 
-    @miscon_title = Translation.find_translation_name(@locale_code, Dimension.get_dim_type_key(@treeTypeRec.miscon_dim_type, @treeTypeRec.code, @version_code), nil) || translate('nav_bar.miscon.name')
+    @miscon_title = Translation.find_translation_name(@locale_code, Dimension.get_dim_type_key(@treeTypeRec.miscon_dim_type, @treeTypeRec.code, @versionRec.code), nil) || translate('nav_bar.miscon.name')
 
-    @ess_q_title = Translation.find_translation_name(@locale_code, Dimension.get_dim_type_key(@treeTypeRec.ess_q_dim_type, @treeTypeRec.code, @version_code), nil) || translate('nav_bar.ess_q.name')
+    @ess_q_title = Translation.find_translation_name(@locale_code, Dimension.get_dim_type_key(@treeTypeRec.ess_q_dim_type, @treeTypeRec.code, @versionRec.code), nil) || translate('nav_bar.ess_q.name')
+
+    puts "ESSENTIAL QUESTION TRANSLATION #{@ess_q_title}"
 
     @treeByParents = Hash.new{ |h, k| h[k] = {} }
 

--- a/app/models/dimension.rb
+++ b/app/models/dimension.rb
@@ -27,6 +27,10 @@ class Dimension < BaseRec
     return ret
   end
 
+  def self.get_dim_type_key(dim_type, tree_type, version)
+    return "curriculum.#{tree_type}.#{version}.#{dim_type}"
+  end
+
   ###############################################
 
   private

--- a/app/models/dimension.rb
+++ b/app/models/dimension.rb
@@ -3,11 +3,12 @@ class Dimension < BaseRec
   # dim_type field valid options
   BIG_IDEA = 'bigidea'
   MISCONCEPTION = 'miscon'
+  ESSENTIAL_QUESTION = 'essq'
   QUESTION = 'question'
   CONCEPT = 'concept'
   COMPETENCY = 'comp'
   STANDARD = 'standard'
-  VAL_DIM_TYPES = [BIG_IDEA, MISCONCEPTION]
+  VAL_DIM_TYPES = [BIG_IDEA, MISCONCEPTION, ESSENTIAL_QUESTION]
 
   validate :valid_dim_type
 

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -1,3 +1,6 @@
+<%
+  essq_name = Translation.find_translation_name(@locale_code, Dimension.get_dim_type_key(@treeTypeRec.ess_q_dim_type, @treeTypeRec.code, @versionRec.code), nil) || translate('nav_bar.questions.name')
+%>
 <header id='pageHeader' class='d-flex flex-row justify-content-between'>
   <a id='pageHeaderLogo' class='' href='#'>
     <div class='logoImage'></div>
@@ -142,7 +145,7 @@
       </button>
       <ul class="dropdown-menu">
         <li class="nav-item" role='menuitem'>
-        <a class="nav-link btn btn-primary" href="#"><%= translate('nav_bar.questions.name') %></a>
+        <a class="nav-link btn btn-primary" href="<%= maint_trees_path(show_ess_q: true, dim_tree: {dim_type: @treeTypeRec.ess_q_dim_type}) %>" ><%= essq_name %></a>
         </li>
         <li class="nav-item active" role='menuitem'>
         <a class="nav-link btn btn-primary" href="#">

--- a/app/views/trees/_dim_column.html.erb
+++ b/app/views/trees/_dim_column.html.erb
@@ -1,0 +1,32 @@
+<ul id="<%= dim_type %>-col" class="list-group maint-column <%= dim_type %>-col<%= show_dim ? '' : ' hidden' %>" data-subjcode="<%= @dim_subjs[dim_type] %>" data-gbid="<%= dim_gb ? (dim_gb[:id] || 0) : 0 %>">
+  <li>
+    <%= render partial: "maint_filter", locals: {col: (dim_type == @treeTypeRec.ess_q_dim_type ? "ess_q" : dim_type)} %>
+  </li>
+  <li class="maint-header"><%= "#{@translations[dim_subj_base_key]} - #{dim_title} (#{grades_str}: #{@dim_grades[dim_type][:min_grade]} - #{@dim_grades[dim_type][:max_grade]})" %>
+    <% if @editing %>
+      <%= link_to(fa_icon("plus"), dimension_form_trees_path( dimension: { dim_type: dim_type }), {:remote => true, 'data-toggle' =>  "modal", 'data-target' => '#modal_popup'}) %>
+    <% end %>
+  </li>
+  <% if dims && dims.count > 0 %>
+    <% dims.each do |dim| %>
+      <li id="<%= "#{@translations[dim_subj_base_key]}-dim-#{dim.id}"%>" class="dim-item dim-item--collapsable list-group-item ui-draggable" data-dimid="<%= dim.id %>">
+        <span class='pull-left'><strong><%= "#{translate('app.labels.subject')}:"%></strong> <%="#{@translations[dim_subj_base_key]}" %></span>
+          <br/>
+          <span class='pull-left'><strong><%= "#{grades_str}: " %></strong> <%= "#{dim.min_grade} - #{dim.max_grade}" %></span>
+
+        <br/>
+        <span class='pull-left'><strong><%= "#{dim_title.singularize}:" %></strong></span>
+        <br/>
+        <%= @translations[dim.dim_name_key] %>
+        <br/>
+        <% if current_user.present? && current_user.is_admin? && @editing%>
+          <div class="pull-right">
+              <a class="connect-handle lo-handle" onclick=""><i class="fa fa-link pull-right" title="make a connection"></i></a>
+              <%= link_to(fa_icon("times", class: "pull-right"), update_dimension_trees_path(dimension: { id: dim.id, active: false}), {'data-confirm' => I18n.t('app.labels.confirm_deactivate', item: @translations[dim.dim_name_key]), method: :patch}) %>
+              <%= link_to(fa_icon("edit", class: "pull-right"), dimension_form_trees_path( dimension: { id: dim.id}), {:remote => true, 'data-toggle' =>  "modal", 'data-target' => '#modal_popup'}) %>
+          </div>
+      <% end %>
+      </li>
+    <% end %>
+  <% end #if dims %>
+</ul>

--- a/app/views/trees/_dimension_form.html.erb
+++ b/app/views/trees/_dimension_form.html.erb
@@ -1,5 +1,8 @@
+<% dim_type_name = Translation.find_translation_name(@locale_code, Dimension.get_dim_type_key(@dimension.dim_type, @treeTypeRec.code, @versionRec.code), nil) || translate('trees.' + @dimension.dim_type + '.title')
+  dim_type_name = dim_type_name.singularize
+%>
 <div class="modal-header">
-   <h3 id="myModalLabel"><%= translate('trees.' + @dimension.dim_type + '.title') %></h3>
+   <h3 id="myModalLabel"><%= dim_type_name %></h3>
  </div>
  <div class="modal-body">
 
@@ -51,7 +54,7 @@
 
   <fieldset>
     <div>
-    <div><label for='name'><%= translate('trees.' + @dimension.dim_type + '.textlabel') %>:</label></div>
+    <div><label for='name'><%= translate('trees.dimension.textlabel', dim_name: dim_type_name) %>:</label></div>
     <%= f.text_area :name, name: 'dimension[text]', id: 'name', value: @dimension_text %>
     </div>
   </fieldset>

--- a/app/views/trees/_maint_filter.html.erb
+++ b/app/views/trees/_maint_filter.html.erb
@@ -10,34 +10,63 @@
       <input type='hidden' name='dim_tree[dim_type]' value="<%= @dim_type%>"></input>
     <% end %>
 
-    <!-- If searching for a different set of misconceptions, don't forget the current set of big ideas. -->
+    <!-- If searching for a different set of essential questions, don't forget the current set of misconceptions and big ideas. -->
+    <% if col == @treeTypeRec.ess_q_dim_type
+         if @dim_subjs['miscon'] && @dim_type != @treeTypeRec.ess_q_dim_type %>
+          <input type='hidden' name='dim_tree[miscon_subj_code]' value=<%= @dim_subjs['miscon'] %>></input>
+      <% end
+         if @dim_subjs['bigidea'] && @dim_type != @treeTypeRec.ess_q_dim_type %>
+        <input type='hidden' name='dim_tree[bigidea_subj_code]' value=<%= @dim_subjs['bigidea'] %>></input>
+    <% end
+       if @m_gb && @dim_type != 'bigidea'
+      %>
+          <input type='hidden' name='dim_tree[miscon_gb_id]' value=<%= @m_gb[:id] || 0 %>></input>
+    <% end
+       if @bi_gb && @dim_type != @treeTypeRec.ess_q_dim_type %>
+         <input type='hidden' name='dim_tree[bigidea_gb_id]' value=<%= @eq_gb[:id] || 0 %>></input>
+    <% end
+    end %>
+
+    <!-- If searching for a different set of misconceptions, don't forget the current set of big ideas and essential questions. -->
     <% if col == "miscon"
        if @dim_subjs['bigidea'] && @dim_type != 'miscon' %>
         <input type='hidden' name='dim_tree[bigidea_subj_code]' value=<%= @dim_subjs['bigidea'] %>></input>
     <% end
+      if @dim_subjs[@treeTypeRec.ess_q_dim_type] && @dim_type != 'miscon' %>
+        <input type='hidden' name='dim_tree[ess_q_subj_code]' value=<%= @dim_subjs[@treeTypeRec.ess_q_dim_type] %>></input>
+    <% end
        if @bi_gb && @dim_type != 'miscon' %>
          <input type='hidden' name='dim_tree[bigidea_gb_id]' value=<%= @bi_gb[:id] || 0 %>></input>
     <% end
+       if @eq_gb && @dim_type != 'miscon' %>
+         <input type='hidden' name='dim_tree[ess_q_gb_id]' value=<%= @eq_gb[:id] || 0 %>></input>
+    <% end
     end %>
-    <!-- If searching for a different set of bigideas, don't forget the current set of misconceptions. -->
+    <!-- If searching for a different set of bigideas, don't forget the current set of misconceptions and essential questions. -->
     <% if col == "bigidea"
          if @dim_subjs['miscon'] && @dim_type != 'bigidea' %>
     		  <input type='hidden' name='dim_tree[miscon_subj_code]' value=<%= @dim_subjs['miscon'] %>></input>
     	<% end
-    	   if @m_gb && @dim_type != 'bigidea'
+         if @dim_subjs[@treeTypeRec.ess_q_dim_type] && @dim_type != 'bigidea' %>
+        <input type='hidden' name='dim_tree[ess_q_subj_code]' value=<%= @dim_subjs[@treeTypeRec.ess_q_dim_type] %>></input>
+    <% end
+    	 if @m_gb && @dim_type != 'bigidea'
     	%>
     		  <input type='hidden' name='dim_tree[miscon_gb_id]' value=<%= @m_gb[:id] || 0 %>></input>
+    <% end
+       if @eq_gb && @dim_type != 'bigidea' %>
+         <input type='hidden' name='dim_tree[ess_q_gb_id]' value=<%= @eq_gb[:id] || 0 %>></input>
     <% end
     end %>
 
     <!-- Labels -->
     <div class='col col-md-3'><label for='<%= param_name %>_subject'><%= translate('app.labels.subject') %></label></div>
-    <div class='col col-md-4'><label for='<%= param_name %>_grade_band'><%= translate('app.labels.grade_band') %></label></div>
+    <div class='col col-md-2'><label for='<%= param_name %>_grade_band'><%= translate('app.labels.grade_band') %></label></div>
   </div>
 
   <!-- Form input options -->
   <div class='row'>
-    <div class='col col-md-3 subject-with-gb'><select id='<%= param_name %>_subject_id' name='<%= param_name %>[<%= param_name == "tree" ? "subject_id" : "#{col}_subj_code"%>]'>
+    <div class='col col-md-2 subject-with-gb'><select id='<%= param_name %>_subject_id' name='<%= param_name %>[<%= param_name == "tree" ? "subject_id" : "#{col}_subj_code"%>]'>
         <% if col == "tree" %>
           <% @subjects.each do |k, s| %>
             <% sel_code = @subject_code %>

--- a/app/views/trees/_show_maint_col_buttons.html.erb
+++ b/app/views/trees/_show_maint_col_buttons.html.erb
@@ -1,0 +1,2 @@
+<button id="show_<%= dim_type %>_btn" class="btn-secondary margin-bottom<%= show_dim ? ' hidden' : '' %>" onclick="show_maint_col('<%= dim_type %>', true);"><%= I18n.t('app.labels.show_indicators', name: dim_title) %></button>
+  <button id="hide_<%= dim_type %>_btn" class="btn-info margin-bottom<%= show_dim ? '' : ' hidden' %>" onclick="show_maint_col('<%= dim_type %>', false);"><%= I18n.t('app.labels.hide_indicators', name: dim_title) %></button>

--- a/app/views/trees/maint.html.erb
+++ b/app/views/trees/maint.html.erb
@@ -1,27 +1,24 @@
 <% content_for(:title_code, 'trees.maint.name') %>
 <% content_for(:page_class, 'trees') %>
-<% big_idea_dims = @dimensions_bigideas
-
-   miscon_dims = @dimensions_miscons
-
-   ideas_title = translate('nav_bar.bigidea.name')
-   misc_title = translate('nav_bar.miscon.name')
+<%
+   grades_str = translate('app.labels.grade_band').pluralize
+   num_cols = 1 + (@show_bigidea ? 1 : 0) + (@show_miscon ? 1 : 0) + (@show_ess_q ? 1 :0)
 %>
 <br>
 <div class='text-center dimension-page'>
   <h2><%= @page_title %></h2>
 </div>
 <% if !@dim_type #big_idea_dims && big_idea_dims.count > 0 %>
-  <button id="show_bigidea_btn" class="btn-secondary margin-bottom<%= @show_bigidea ? ' hidden' : '' %>" onclick="show_maint_col('bigidea', true);"><%= I18n.t('app.labels.show_indicators', name: ideas_title) %></button>
-  <button id="hide_bigidea_btn" class="btn-info margin-bottom<%= @show_bigidea ? '' : ' hidden' %>" onclick="show_maint_col('bigidea', false);"><%= I18n.t('app.labels.hide_indicators', name: ideas_title) %></button>
+  <button id="show_bigidea_btn" class="btn-secondary margin-bottom<%= @show_bigidea ? ' hidden' : '' %>" onclick="show_maint_col('bigidea', true);"><%= I18n.t('app.labels.show_indicators', name: @ideas_title) %></button>
+  <button id="hide_bigidea_btn" class="btn-info margin-bottom<%= @show_bigidea ? '' : ' hidden' %>" onclick="show_maint_col('bigidea', false);"><%= I18n.t('app.labels.hide_indicators', name: @ideas_title) %></button>
 <% end %>
 <% if !@dim_type #miscon_dims && miscon_dims.count > 0 %>
-  <button id="show_miscon_btn" class="btn-secondary margin-bottom<%= @show_miscon ? ' hidden' : '' %>" onclick="show_maint_col('miscon', true);"><%= I18n.t('app.labels.show_indicators', name: misc_title) %></button>
-  <button id="hide_miscon_btn" class="btn-info margin-bottom<%= @show_miscon ? '' : ' hidden' %>" onclick="show_maint_col('miscon', false);"><%= I18n.t('app.labels.hide_indicators', name: misc_title) %></button>
+  <button id="show_miscon_btn" class="btn-secondary margin-bottom<%= @show_miscon ? ' hidden' : '' %>" onclick="show_maint_col('miscon', true);"><%= I18n.t('app.labels.show_indicators', name: @miscon_title) %></button>
+  <button id="hide_miscon_btn" class="btn-info margin-bottom<%= @show_miscon ? '' : ' hidden' %>" onclick="show_maint_col('miscon', false);"><%= I18n.t('app.labels.hide_indicators', name: @miscon_title) %></button>
 <% end %>
 <% subj_counter = 0 %>
 <div id="trees" class="dimension-page maint-page">
-  <div class="sequence-grid cols-<%= @show_miscon && @show_bigidea ? 3 : 2 %>">
+  <div class="sequence-grid cols-<%= num_cols %>">
     <ul class="list-group maint-column">
       <li>
         <%= render partial: "maint_filter", locals: {col: "tree"} %>
@@ -31,8 +28,11 @@
         <li class="maint-header indent-0"><%= @translations[tkey] %></li>
         <% codeh.each do |code, h| %>
           <% if h[:outcome] %>
-          <% ideas_str = '' #ideas_title
-             misc_str = '' #misc_title
+          <%
+             ess_q_str = ''
+             ideas_str = '' #@ideas_title
+             misc_str = '' #@misc_title
+             ess_q_found = 0
              ideas_found = 0
              misc_found = 0
            %>
@@ -42,7 +42,12 @@
             <% if h[:dimtrees].length > 0 %>
             <% h[:dimtrees].each do |dt|
                  dim = dt.dimension
-                 if dim.dim_type == "bigidea"
+                 if dim.dim_type == @treeTypeRec.ess_q_dim_type
+                    ess_q_found += 1
+                    essqSubjKey = @subj_key_by_dt_id[dt.id] || @ess_q_subj_base_key
+                    ess_q_str += "<br/>______________<br/>"
+                    ess_q_str += "[#{@translations[essqSubjKey]}] #{@translations[dim.dim_name_key]}"
+                 elsif dim.dim_type == "bigidea"
                     ideas_found += 1
                     ideaSubjKey = @subj_key_by_dt_id[dt.id] || @idea_subj_base_key
                     ideas_str += "<br/>______________<br/>"
@@ -54,15 +59,19 @@
                     misc_str += "[#{@translations[miscSubjKey]}] #{@translations[dim.dim_name_key]}"
                  end
                end
-               ideas_str = "<strong>#{(ideas_found > 1 ? ideas_title : ideas_title.singularize)}:</strong>#{ideas_str}"
-               misc_str = "<strong>#{(misc_found > 1 ? misc_title : misc_title.singularize)}:</strong>#{misc_str}"
+               ess_q_str = "<strong>#{(ess_q_found > 1 ? @ess_q_title : @ess_q_title.singularize)}:</strong>#{ess_q_str}"
+               ideas_str = "<strong>#{(ideas_found > 1 ? @ideas_title : @ideas_title.singularize)}:</strong>#{ideas_str}"
+               misc_str = "<strong>#{(misc_found > 1 ? @misc_title : @miscon_title.singularize)}:</strong>#{misc_str}"
             %>
-            <% if ideas_found > 0 %>
-            <i class="fa fa-lightbulb-o" data-toggle="tooltip" title="<%= ideas_str %>"></i>
+            <% if ess_q_found > 0 %>
+                <i class="fa fa-question" data-toggle="tooltip" title="<%= ess_q_str %>"></i>
+            <% end
+               if ideas_found > 0 %>
+                <i class="fa fa-lightbulb-o" data-toggle="tooltip" title="<%= ideas_str %>"></i>
             <% end
               if misc_found > 0
             %>
-            <i class="fa fa-exclamation-triangle" data-toggle="tooltip" title="<%= misc_str %>"></i>
+                <i class="fa fa-exclamation-triangle" data-toggle="tooltip" title="<%= misc_str %>"></i>
             <% end %>
             <% end %>
             <% if @editing %>
@@ -87,70 +96,48 @@
         <% end %>
       <% end %>
       </ul>
-      <% grades_str = translate('app.labels.grade_band').pluralize %>
 
-      <ul id="bigidea-col" class="list-group maint-column bigidea-col<%= @show_bigidea ? '' : ' hidden' %>" data-subjcode="<%= @dim_subjs['bigidea'] %>" data-gbid="<%= @bi_gb ? (@bi_gb[:id] || 0) : 0 %>">
-        <li>
-          <%= render partial: "maint_filter", locals: {col: "bigidea"} %>
-        </li>
-        <li class="maint-header"><%= "#{@translations[@idea_subj_base_key]} - #{ideas_title} (#{grades_str}: #{@dim_grades['bigidea'][:min_grade]} - #{@dim_grades['bigidea'][:max_grade]})" %>
-          <% if @editing %>
-            <%= link_to(fa_icon("plus"), dimension_form_trees_path( dimension: { dim_type: @treeTypeRec.big_ideas_dim_type }), {:remote => true, 'data-toggle' =>  "modal", 'data-target' => '#modal_popup'}) %>
-          <% end %>
-        </li>
-        <% if big_idea_dims && big_idea_dims.count > 0 %>
-          <% big_idea_dims.each do |dim| %>
-            <li id="<%= "#{@translations[@idea_subj_base_key]}-dim-#{dim.id}"%>" class="dim-item dim-item--collapsable list-group-item ui-draggable" data-dimid="<%= dim.id %>">
-              <span class='pull-left'><strong><%= "#{translate('app.labels.subject')}:"%></strong> <%="#{@translations[@idea_subj_base_key]}" %></span>
-                <br/>
-                <span class='pull-left'><strong><%= "#{grades_str}: " %></strong> <%= "#{dim.min_grade} - #{dim.max_grade}" %></span>
+      <%= if @treeTypeRec.ess_q_dim_type != ""
+            render partial: "dim_column", locals: {
+            dim_type: @treeTypeRec.ess_q_dim_type,
+            show_dim: @show_ess_q,
+            dim_gb: @eq_gb,
+            dim_subj_base_key: @ess_q_subj_base_key,
+            dim_title: @ess_q_title,
+            dims: @dimensions_ess_q,
+            grades_str: grades_str
+            }
+          end
+      %>
 
-              <br/>
-              <span class='pull-left'><strong><%= "#{ideas_title.singularize}:" %></strong></span>
-              <br/>
-              <%= @translations[dim.dim_name_key] %>
-              <br/>
-              <% if current_user.present? && current_user.is_admin? && @editing%>
-                <div class="pull-right">
-                    <a class="connect-handle lo-handle" onclick=""><i class="fa fa-link pull-right" title="make a connection"></i></a>
-                    <%= link_to(fa_icon("times", class: "pull-right"), update_dimension_trees_path(dimension: { id: dim.id, active: false}), {'data-confirm' => I18n.t('app.labels.confirm_deactivate', item: @translations[dim.dim_name_key]), method: :patch}) %>
-                    <%= link_to(fa_icon("edit", class: "pull-right"), dimension_form_trees_path( dimension: { id: dim.id}), {:remote => true, 'data-toggle' =>  "modal", 'data-target' => '#modal_popup'}) %>
-                </div>
-            <% end %>
-            </li>
-          <% end %>
-        <% end #if big_idea_dims %>
-      </ul>
+      <%= if @treeTypeRec.big_ideas_dim_type != ""
+            render partial: "dim_column", locals: {
+            dim_type: @treeTypeRec.big_ideas_dim_type,
+            show_dim: @show_bigidea,
+            dim_gb: @bi_gb,
+            dim_subj_base_key: @idea_subj_base_key,
+            dim_title: @ideas_title,
+            dims: @dimensions_bigideas,
+            grades_str: grades_str
+            }
+          end
+      %>
 
-      <ul id="miscon-col" class="list-group maint-column miscon-col<%= @show_miscon ? '' : ' hidden' %>" data-subjcode="<%= @dim_subjs['miscon'] %>" data-gbid="<%= @m_gb ? (@m_gb[:id] || 0) : 0 %>">
-        <li>
-          <%= render partial: "maint_filter", locals: {col: "miscon"} %>
-        </li>
-        <li class="maint-header"><%= "#{@translations[@misc_subj_base_key]} - #{misc_title} (#{grades_str}: #{@dim_grades['miscon'][:min_grade]} - #{@dim_grades['miscon'][:max_grade]})" %>
-          <% if @editing %>
-           <%= link_to(fa_icon("plus"), dimension_form_trees_path( dimension: { dim_type: @treeTypeRec.miscon_dim_type }), {:remote => true, 'data-toggle' =>  "modal", 'data-target' => '#modal_popup'}) %>
-          <% end %>
-        </li>
-         <% if  miscon_dims && miscon_dims.count > 0 %>
-          <% miscon_dims.each do |dim| %>
-            <li id="<%= "#{@translations[@misc_subj_base_key]}-dim-#{dim.id}"%>" class="dim-item dim-item--collapsable list-group-item ui-draggable" data-dimid="<%= dim.id %>">
-              <span class='pull-left'><strong><%= "#{translate('app.labels.subject')}:"%></strong> <%="#{@translations[@misc_subj_base_key]}" %></span>
-              <br/>
-              <span class='pull-left'><strong><%= "#{grades_str}: " %></strong> <%= "#{dim.min_grade} - #{dim.max_grade}" %></span>
-              <br/>
-              <span class='pull-left'><strong><%= "#{misc_title.singularize}:" %></strong></span>
-              <br/>
-              <%= @translations[dim.dim_name_key] %>
-              <br/>
-              <% if current_user.present? && current_user.is_admin? && @editing%>
-                <a class="connect-handle lo-handle" onclick=""><i class="fa fa-link pull-right" title="make a connection"></i></a>
-                <%= link_to(fa_icon("times", class: "pull-right"), update_dimension_trees_path(dimension: { id: dim.id, active: false}), {'data-confirm' => I18n.t('app.labels.confirm_deactivate', item: @translations[dim.dim_name_key]), method: :patch}) %>
-                <%= link_to(fa_icon("edit", class: "pull-right"), dimension_form_trees_path( dimension: { id: dim.id}), {:remote => true, 'data-toggle' =>  "modal", 'data-target' => '#modal_popup'}) %>
-            <% end %>
-            </li>
-          <% end %>
-        <% end #if miscon_dims %>
-      </ul>
+      <%= if @treeTypeRec.miscon_dim_type != ""
+            render partial: "dim_column", locals: {
+            dim_type: @treeTypeRec.miscon_dim_type,
+            show_dim: @show_miscon,
+            dim_gb: @m_gb,
+            dim_subj_base_key: @misc_subj_base_key,
+            dim_title: @miscon_title,
+            dims: @dimensions_miscons,
+            grades_str: grades_str
+            }
+          end
+      %>
+
+
+
     </div>
   </div>
 </div>

--- a/app/views/trees/maint.html.erb
+++ b/app/views/trees/maint.html.erb
@@ -8,7 +8,7 @@
 <div class='text-center dimension-page'>
   <h2><%= @page_title %></h2>
 </div>
-<% if !@dim_type #big_idea_dims && big_idea_dims.count > 0 %>
+<% if !@dim_type && @treeTypeRec.ess_q_dim_type != ""  %>
   <%=
       render partial: "show_maint_col_buttons", locals: {
       dim_type: @treeTypeRec.ess_q_dim_type,
@@ -17,7 +17,7 @@
       }
   %>
 <% end %>
-<% if !@dim_type #big_idea_dims && big_idea_dims.count > 0 %>
+<% if !@dim_type && @treeTypeRec.big_ideas_dim_type != "" %>
   <%=
       render partial: "show_maint_col_buttons", locals: {
       dim_type: @treeTypeRec.big_ideas_dim_type,
@@ -26,7 +26,7 @@
       }
   %>
 <% end %>
-<% if !@dim_type #miscon_dims && miscon_dims.count > 0 %>
+<% if !@dim_type && @treeTypeRec.miscon_dim_type != ""  %>
   <%=
       render partial: "show_maint_col_buttons", locals: {
       dim_type: @treeTypeRec.miscon_dim_type,

--- a/app/views/trees/maint.html.erb
+++ b/app/views/trees/maint.html.erb
@@ -9,12 +9,31 @@
   <h2><%= @page_title %></h2>
 </div>
 <% if !@dim_type #big_idea_dims && big_idea_dims.count > 0 %>
-  <button id="show_bigidea_btn" class="btn-secondary margin-bottom<%= @show_bigidea ? ' hidden' : '' %>" onclick="show_maint_col('bigidea', true);"><%= I18n.t('app.labels.show_indicators', name: @ideas_title) %></button>
-  <button id="hide_bigidea_btn" class="btn-info margin-bottom<%= @show_bigidea ? '' : ' hidden' %>" onclick="show_maint_col('bigidea', false);"><%= I18n.t('app.labels.hide_indicators', name: @ideas_title) %></button>
+  <%=
+      render partial: "show_maint_col_buttons", locals: {
+      dim_type: @treeTypeRec.ess_q_dim_type,
+      show_dim: @show_ess_q,
+      dim_title: @ess_q_title
+      }
+  %>
+<% end %>
+<% if !@dim_type #big_idea_dims && big_idea_dims.count > 0 %>
+  <%=
+      render partial: "show_maint_col_buttons", locals: {
+      dim_type: @treeTypeRec.big_ideas_dim_type,
+      show_dim: @show_bigidea,
+      dim_title: @ideas_title
+      }
+  %>
 <% end %>
 <% if !@dim_type #miscon_dims && miscon_dims.count > 0 %>
-  <button id="show_miscon_btn" class="btn-secondary margin-bottom<%= @show_miscon ? ' hidden' : '' %>" onclick="show_maint_col('miscon', true);"><%= I18n.t('app.labels.show_indicators', name: @miscon_title) %></button>
-  <button id="hide_miscon_btn" class="btn-info margin-bottom<%= @show_miscon ? '' : ' hidden' %>" onclick="show_maint_col('miscon', false);"><%= I18n.t('app.labels.hide_indicators', name: @miscon_title) %></button>
+  <%=
+      render partial: "show_maint_col_buttons", locals: {
+      dim_type: @treeTypeRec.miscon_dim_type,
+      show_dim: @show_miscon,
+      dim_title: @miscon_title
+      }
+  %>
 <% end %>
 <% subj_counter = 0 %>
 <div id="trees" class="dimension-page maint-page">

--- a/config/locales/pages.en.yml
+++ b/config/locales/pages.en.yml
@@ -113,7 +113,7 @@ en:
     miscon:
       name: "Misconceptions"
       hover: "Displays Misconceptions"
-    ess_q:
+    essq:
       name: "Essential Questions"
       hover: "Displays Essential Questions"
     questions:

--- a/config/locales/pages.en.yml
+++ b/config/locales/pages.en.yml
@@ -181,15 +181,15 @@ en:
       title: "Relations"
     maint:
       title: "Editing"
+    dimension:
+      textlabel: "%{dim_name} Text"
     miscon:
       title: "Misconceptions"
       singular: "Misconception"
-      textlabel: "Misconception Text"
     bigidea:
       title: "Big Ideas"
       singular: "Big Idea"
       relates_to: "relates to"
-      textlabel: "Big Idea Text"
     show:
       name: "Curriculum Detail Page"
     labels:

--- a/config/locales/pages.en.yml
+++ b/config/locales/pages.en.yml
@@ -113,6 +113,9 @@ en:
     miscon:
       name: "Misconceptions"
       hover: "Displays Misconceptions"
+    ess_q:
+      name: "Essential Questions"
+      hover: "Displays Essential Questions"
     questions:
       name: "Essential Questions"
       hover: "Displays Essential Questions"

--- a/lib/tasks/seed_eg_stem.rake
+++ b/lib/tasks/seed_eg_stem.rake
@@ -27,7 +27,11 @@ namespace :seed_eg_stem do
       version_id: @v01.id,
       working_status: true,
       miscon_dim_type: 'miscon',
-      big_ideas_dim_type: 'bigidea'
+      big_ideas_dim_type: 'bigidea',
+      ess_q_dim_type: 'essq',
+      tree_code_format: 'grade,unit,lo',
+      detail_headers: 'grade,sem,unit,lo,indicator,[subj_big_idea],[ess_q],{explain},[miscon],[sector],[connect],[refs]',
+      grid_headers: 'grade,unit,(sub_unit),comp,[subj_big_idea],[ess_q],explain,[miscon],[connect],[refs]'
     }
     if myTreeType.count < 1
       TreeType.create(myTreeTypeValues)

--- a/lib/tasks/seed_turkey.rake
+++ b/lib/tasks/seed_turkey.rake
@@ -24,7 +24,11 @@ namespace :seed_turkey do
       version_id: @v01.id,
       working_status: true,
       miscon_dim_type: 'miscon',
-      big_ideas_dim_type: 'bigidea'
+      big_ideas_dim_type: 'bigidea',
+      ess_q_dim_type: 'essq',
+      tree_code_format: 'grade,unit,sub_unit,comp',
+      detail_headers: 'grade,unit,chapt,attain,[subj_big_idea],[ess_q],{explain},[miscon],[sector],[connect],[refs]',
+      grid_headers: 'grade,unit,chapt,attain,[subj_big_idea],[ess_q],explain,[miscon],[connect],[refs]'
 
     }
     if myTreeType.count < 1

--- a/lib/tasks/seed_turkey_v02.rake
+++ b/lib/tasks/seed_turkey_v02.rake
@@ -45,7 +45,7 @@ namespace :seed_turkey_v02 do
     throw "Invalid Tree Type Count" if TreeType.where(code: 'tfv').count != 2
     @tfv = TreeType.where(code: 'tfv', version_id: @v02.id).first
 
-    rec, status, message = Translation.find_or_update_translation(BaseRec::LOCALE_EN, Dimension.get_dim_type_key(myTreeType.ess_q_dim_type, myTreeType.code, @v02.code), 'K-12 Big Idea')
+    rec, status, message = Translation.find_or_update_translation(BaseRec::LOCALE_EN, Dimension.get_dim_type_key(myTreeType.ess_q_dim_type, myTreeType.code, @v02.code), 'K-12 Big Ideas')
     throw "ERROR updating sector translation: #{message}" if status == BaseRec::REC_ERROR
     STDOUT.puts 'Create translation record for essential questions as K-12 Big Ideas.'
 

--- a/lib/tasks/seed_turkey_v02.rake
+++ b/lib/tasks/seed_turkey_v02.rake
@@ -22,17 +22,20 @@ namespace :seed_turkey_v02 do
     myTreeType = TreeType.where(code: 'tfv', version_id: @v02.id)
     myTreeTypeValues = {
       code: 'tfv',
-      hierarchy_codes: 'grade,unit,comp',
+      hierarchy_codes: 'grade,unit,sub_unit,comp',
       valid_locales: BaseRec::LOCALE_EN+','+BaseRec::LOCALE_TR,
-      sector_set_code: 'future',
+      sector_set_code: 'future,hide',
       sector_set_name_key: 'sector.set.future.name',
       curriculum_title_key: 'curriculum.tfv.title', # 'Turkey STEM Curriculum'
-      outcome_depth: 2,
+      outcome_depth: 3,
       version_id: @v02.id,
       working_status: true,
       miscon_dim_type: 'miscon',
-      big_ideas_dim_type: 'bigidea'
-
+      big_ideas_dim_type: 'bigidea',
+      ess_q_dim_type: 'essq',
+      tree_code_format: 'grade,unit,sub_unit,comp',
+      detail_headers: 'grade,unit,(sub_unit),comp,[subj_big_idea],[ess_q],{explain},[miscon],[sector],[connect],[refs]',
+      grid_headers: 'grade,unit,(sub_unit),comp,[subj_big_idea],[ess_q],explain,[miscon],[connect],[refs]'
     }
     if myTreeType.count < 1
       TreeType.create(myTreeTypeValues)
@@ -42,9 +45,17 @@ namespace :seed_turkey_v02 do
     throw "Invalid Tree Type Count" if TreeType.where(code: 'tfv').count != 2
     @tfv = TreeType.where(code: 'tfv', version_id: @v02.id).first
 
+    rec, status, message = Translation.find_or_update_translation(BaseRec::LOCALE_EN, Dimension.get_dim_type_key(myTreeType.ess_q_dim_type, myTreeType.code, @v02.code), 'K-12 Big Idea')
+    throw "ERROR updating sector translation: #{message}" if status == BaseRec::REC_ERROR
+    STDOUT.puts 'Create translation record for essential questions as K-12 Big Ideas.'
+
     # Create translation(s) for hierarchy codes
     rec, status, message = Translation.find_or_update_translation(BaseRec::LOCALE_EN, 'curriculum.tfv.hierarchy.comp', 'Competency')
     throw "ERROR updating sector translation: #{message}" if status == BaseRec::REC_ERROR
+
+    rec, status, message = Translation.find_or_update_translation(BaseRec::LOCALE_EN, 'curriculum.tfv.hierarchy.sub_unit', 'Sub-Unit')
+    throw "ERROR updating sector translation: #{message}" if status == BaseRec::REC_ERROR
+    STDOUT.puts 'Create translation record for Sub-Unit.'
 
     puts "Curriculum (Tree Type) is created for tfv "
     puts "  Created Curriculum: #{@tfv.code} with Hierarchy: #{@tfv.hierarchy_codes}"

--- a/lib/tasks/seed_turkey_v02a.rake
+++ b/lib/tasks/seed_turkey_v02a.rake
@@ -46,6 +46,10 @@ namespace :seed_turkey_v02a do
     puts "Curriculum (Tree Type) is updated for tfv "
     puts "  Updated Curriculum: #{@tfv.code} with Hierarchy: #{@tfv.hierarchy_codes}"
 
+    rec, status, message = Translation.find_or_update_translation(BaseRec::LOCALE_EN, Dimension.get_dim_type_key(myTreeType.ess_q_dim_type, myTreeType.code, @v02.code), 'K-12 Big Ideas')
+    throw "ERROR updating sector translation: #{message}" if status == BaseRec::REC_ERROR
+    STDOUT.puts 'Create translation record for essential questions as K-12 Big Ideas.'
+
     # Create translation(s) for hierarchy codes
     rec, status, message = Translation.find_or_update_translation(BaseRec::LOCALE_EN, 'curriculum.tfv.hierarchy.sub_unit', 'Sub-Unit')
     throw "ERROR updating sector translation: #{message}" if status == BaseRec::REC_ERROR


### PR DESCRIPTION
- Add Essential Questions (or, K-12 Big Ideas) Column to Editing/Maint/Etc page, with show/hide buttons
- Enable CRUD operations and DimTree connections for Essential Questions
- Translate Essential Questions as "K-12 Big Ideas" for the Turkey v02 curriculum
- Refactor maint.html.erb to use partials for repetitive code (dimension columns, show/hide buttons, etc)
- Display the Essential Questions Dimension types in a standard dimension page, accessible through the "other" dropdown menu.
- also fix subunits in seed files