### PR TITLE
Outcome Detail Page and Use Flag in TreeType::sector_set_code

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -150,6 +150,7 @@ class ApplicationController < ActionController::Base
         raise I18n.translate('app.errors.missing_version_code')
       end
       @appTitle += " #{@versionRec.code} [#{@treeTypeRec.working_status ? I18n.t('app.labels.working_version') : I18n.t('app.labels.final_version')}]"
+      @essqTitle = Translation.find_translation_name(@locale_code, Dimension.get_dim_type_key(@treeTypeRec.ess_q_dim_type, @treeTypeRec.code, @versionRec.code), nil) || translate('nav_bar.ess_q.name')
     end
 
     def initTypeCode

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -150,7 +150,7 @@ class ApplicationController < ActionController::Base
         raise I18n.translate('app.errors.missing_version_code')
       end
       @appTitle += " #{@versionRec.code} [#{@treeTypeRec.working_status ? I18n.t('app.labels.working_version') : I18n.t('app.labels.final_version')}]"
-      @essqTitle = Translation.find_translation_name(@locale_code, Dimension.get_dim_type_key(@treeTypeRec.ess_q_dim_type, @treeTypeRec.code, @versionRec.code), nil) || translate('nav_bar.ess_q.name')
+      @essqTitle = Translation.find_translation_name(@locale_code, Dimension.get_dim_type_key(@treeTypeRec.ess_q_dim_type, @treeTypeRec.code, @versionRec.code), nil) || translate('nav_bar.essq.name')
     end
 
     def initTypeCode

--- a/app/controllers/sectors_controller.rb
+++ b/app/controllers/sectors_controller.rb
@@ -5,7 +5,7 @@ class SectorsController < ApplicationController
 
     @subjects = Subject.where("tree_type_id = ? AND min_grade < ?", @treeTypeRec.id, 999).order("max_grade desc", "min_grade asc", "code")
     @gbs = GradeBand.where(:tree_type_id => @treeTypeRec.id)
-    @sectors = Sector.where(:sector_set_code => @treeTypeRec.sector_set_code)
+    @sectors = Sector.where(:sector_set_code => TreeType.get_sector_set_code(@treeTypeRec.sector_set_code))
     @sector = Sector.new
 
     # get translation from hash of pre-cached translations.
@@ -22,7 +22,7 @@ class SectorsController < ApplicationController
       @sector_id = params[:tree][:sector_id].present? ? params[:tree][:sector_id] : nil
     end
     @subjectOptions = helpers.subjectsOptions(@subject_id, false, @treeTypeRec.id)
-    @sectorsOptions = helpers.sectorsOptions(@sector_id, @translations, @treeTypeRec.sector_set_code)
+    @sectorsOptions = helpers.sectorsOptions(@sector_id, @translations, TreeType.get_sector_set_code(@treeTypeRec.sector_set_code))
 
     @rptRows = []
     if params[:tree].present?

--- a/app/controllers/trees_controller.rb
+++ b/app/controllers/trees_controller.rb
@@ -29,7 +29,7 @@ class TreesController < ApplicationController
       parent = treeHash[code_arr.shift] if code_arr.length > 1
       while code_arr.length > 1
         c = code_arr.shift
-        parent = parent[:nodes][c] if c != ""
+        parent = parent[:nodes][c] if c != "" && parent[:nodes][c]
       end
 
       case depth
@@ -1195,7 +1195,7 @@ class TreesController < ApplicationController
     Rails.logger.debug("*** @grade_band_code: #{@grade_band_code.inspect}")
     Rails.logger.debug("*** @gb: #{@gb.inspect}")
 
-    listing = Tree.where(
+    listing = Tree.active.where(
       tree_type_id: @treeTypeRec.id,
       version_id: @versionRec.id
     )

--- a/app/controllers/trees_controller.rb
+++ b/app/controllers/trees_controller.rb
@@ -900,7 +900,7 @@ class TreesController < ApplicationController
           @rel = SectorTree.find(tree_params[:attr_id]) if (@edit_type == "sector")
         else
           @rel = SectorTree.new
-          @sectors = Sector.where(:sector_set_code => @treeTypeRec.sector_set_code)
+          @sectors = Sector.where(:sector_set_code => TreeType.get_sector_set_code(@treeTypeRec.sector_set_code))
           @sector_names = Translation.translationsByKeys(@locale_code, @sectors.pluck('name_key'))
         end
         @rel = DimTree.find(tree_params[:attr_id]) if (@edit_type == "dimtree")

--- a/app/controllers/trees_controller.rb
+++ b/app/controllers/trees_controller.rb
@@ -875,7 +875,6 @@ class TreesController < ApplicationController
           name_key
         )
         @translation = translation[name_key]
-        @comment = Translation.find_translation_name(@locale_code,@tree.outcome.get_explain_key, "")
       elsif @edit_type == "indicator"
         @indicator = Tree.find(tree_params[:attr_id])
         @attr_id = @indicator.id
@@ -885,7 +884,8 @@ class TreesController < ApplicationController
           name_key
         )
         @translation = translation[name_key]
-        @comment = Translation.find_translation_name(@locale_code,@tree.outcome.get_explain_key, "")
+      elsif @edit_type == "comment"
+         @comment = Translation.find_translation_name(@locale_code,@tree.outcome.get_explain_key, "")
       elsif @edit_type == "treetree"
         @rel = TreeTree.find(tree_params[:attr_id])
         @attr_id = @rel.id

--- a/app/controllers/trees_controller.rb
+++ b/app/controllers/trees_controller.rb
@@ -875,6 +875,7 @@ class TreesController < ApplicationController
           name_key
         )
         @translation = translation[name_key]
+        @comment = Translation.find_translation_name(@locale_code,@tree.outcome.get_explain_key, "")
       elsif @edit_type == "indicator"
         @indicator = Tree.find(tree_params[:attr_id])
         @attr_id = @indicator.id
@@ -884,6 +885,7 @@ class TreesController < ApplicationController
           name_key
         )
         @translation = translation[name_key]
+        @comment = Translation.find_translation_name(@locale_code,@tree.outcome.get_explain_key, "")
       elsif @edit_type == "treetree"
         @rel = TreeTree.find(tree_params[:attr_id])
         @attr_id = @rel.id
@@ -940,6 +942,7 @@ class TreesController < ApplicationController
     update = tree_params[:edit_type]
     if update
       save_translation = true
+      Translation.find_or_update_translation(@locale_code, @tree.outcome.get_explain_key, tree_params[:comment]) if tree_params[:comment]
       if update == 'outcome'
         name_key = @tree.buildNameKey
       elsif update == 'indicator'
@@ -1043,6 +1046,7 @@ class TreesController < ApplicationController
       :name_translation,
       :active,
       :editing,
+      :comment
     )
   end
 

--- a/app/controllers/trees_controller.rb
+++ b/app/controllers/trees_controller.rb
@@ -761,6 +761,23 @@ class TreesController < ApplicationController
       # @trees = Tree.where('depth = 3 AND tree_type_id = ? AND version_id = ? AND subject_id = ? AND grade_band_id = ? AND code LIKE ?', @tree.tree_type_id, @tree.version_id, @tree.subject_id, @tree.grade_band_id, "#{@tree.code}%")
       @trees = [@tree]
       process_tree = true
+      detail_areas = @treeTypeRec.detail_headers.split(",")
+      @detail_headers = []
+      @detail_areas = []
+      detail_areas.each do |a|
+        detail_type = 'header'
+        detail = a
+        if a.first == "{" && a.last == "}"
+          detail_type = 'single'
+          detail = a[1..a.length - 2]
+        elsif a.first == "[" && a.last == "]"
+          detail_type = 'multi'
+          detail = a[1..a.length - 2]
+        end
+        detail = detail.split("_").join("")
+        @detail_headers << {type: detail_type, name: detail} if detail_type == 'header'
+        @detail_areas << {type: detail_type, name: detail} if detail_type != 'header'
+      end
     else
       # not a detail page, go back to index page
       index_prep

--- a/app/models/tree.rb
+++ b/app/models/tree.rb
@@ -52,6 +52,9 @@ class Tree < BaseRec
     # where(active: true)
   }
 
+  scope :not_blank, -> { where.not(:base_key => ["", nil]) }
+  scope :active, -> { not_blank.where(:active => true) }
+
   # Field Translations
 
   ####################################################

--- a/app/models/tree_type.rb
+++ b/app/models/tree_type.rb
@@ -17,4 +17,9 @@ class TreeType < BaseRec
     end
     ret_hash
   end
+
+  def hide_sectors
+    return self.sector_set_code.split(",").length > 1
+  end
+
 end

--- a/app/models/tree_type.rb
+++ b/app/models/tree_type.rb
@@ -1,4 +1,9 @@
 class TreeType < BaseRec
+
+  def self.get_sector_set_code(code)
+    return code.split(",")[0]
+  end
+
   def self.versions_hash()
     ret_hash = Hash.new { |hash, key| hash[key] = [] }
     all.each do |tree_type|

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -108,11 +108,11 @@
         <a class="nav-link btn btn-primary" href=<%= maint_trees_path(show_miscon: true, dim_tree: {dim_type: @treeTypeRec.miscon_dim_type}) %>><%= translate('nav_bar.'+@treeTypeRec.miscon_dim_type+'.name') %></a>
       </li>
     <% end
-    if controller.controller_name == 'sectors' && action_name == 'index' %>
+    if controller.controller_name == 'sectors' && action_name == 'index' && !@treeTypeRec.hide_sectors %>
       <li class="nav-item active" aria-selected='true'>
         <a class="nav-link btn btn-primary" href=<%= sectors_path %>><%= @sectorName %></a>
       </li>
-    <% else %>
+    <% elsif !@treeTypeRec.hide_sectors %>
       <li class="nav-item" role='menuitem'>
         <a class="nav-link btn btn-primary" href=<%= sectors_path %>><%= @sectorName %></a>
       </li>
@@ -146,6 +146,9 @@
       <ul class="dropdown-menu">
         <li class="nav-item" role='menuitem'>
         <a class="nav-link btn btn-primary" href="<%= maint_trees_path(show_ess_q: true, dim_tree: {dim_type: @treeTypeRec.ess_q_dim_type}) %>" ><%= essq_name %></a>
+        </li>
+        <li class="nav-item" role='menuitem'>
+          <a class="nav-link btn btn-primary" href=<%= sectors_path %>><%= @sectorName %></a>
         </li>
         <li class="nav-item active" role='menuitem'>
         <a class="nav-link btn btn-primary" href="#">

--- a/app/views/trees/_edit.html.erb
+++ b/app/views/trees/_edit.html.erb
@@ -14,6 +14,7 @@
 	  <label for='name_translation' class="pull-left"><%= @edit_type == "outcome"  ? "#{I18n.translate('app.labels.outcome')}:" : "#{I18n.translate('app.labels.indicator')}:" %></label>
   	<%= f.text_area :name_translation, name: 'tree[name_translation]', id: 'name_translation', style: {className: "pull-left"}, value: @translation  %>
   </fieldset>
+  <% elsif @edit_type == 'comment' %>
   <fieldset>
     <label for="comment" class="pull-left"><%= I18n.translate('app.labels.comments') %></label>
     <%= f.text_area :comment, name: 'tree[comment]', id: 'comment', style: {className: "pull-left"}, value: @comment %>

--- a/app/views/trees/_edit.html.erb
+++ b/app/views/trees/_edit.html.erb
@@ -14,6 +14,10 @@
 	  <label for='name_translation' class="pull-left"><%= @edit_type == "outcome"  ? "#{I18n.translate('app.labels.outcome')}:" : "#{I18n.translate('app.labels.indicator')}:" %></label>
   	<%= f.text_area :name_translation, name: 'tree[name_translation]', id: 'name_translation', style: {className: "pull-left"}, value: @translation  %>
   </fieldset>
+  <fieldset>
+    <label for="comment" class="pull-left"><%= I18n.translate('app.labels.comments') %></label>
+    <%= f.text_area :comment, name: 'tree[comment]', id: 'comment', style: {className: "pull-left"}, value: @comment %>
+  </fieldset>
   <!--build fields for editing treetree and sector relationships-->
   <% elsif @edit_type == 'treetree' || @edit_type == 'sector' || @edit_type == 'dimtree' %>
   <fieldset>

--- a/app/views/trees/_maint_filter.html.erb
+++ b/app/views/trees/_maint_filter.html.erb
@@ -1,17 +1,21 @@
 <%= form_for @tree, url: maint_trees_path, :html => { :method => 'GET' } do |form| %>
   <% param_name = (col == "tree" ? col : "dim_tree" ) %>
+  <!-- Workaround for inconsistently named essq/ess_q -->
+  <% dim_key = col.split("_").join("") %>
+
   <div class='row'>
     <!-- Hidden fields -->
     <!-- Pass setting to stay in edit mode after submitting form, if currently in edit mode -->
     <% if @editing %>
       <input type='hidden' name='editme' value=true></input>
     <% end %>
+    <!-- If @dim_type is defined, we are rendering one of the dimension-specific pages (e.g., the Misconceptions page) -->
     <% if @dim_type %>
       <input type='hidden' name='dim_tree[dim_type]' value="<%= @dim_type%>"></input>
     <% end %>
 
     <!-- If searching for a different set of essential questions, don't forget the current set of misconceptions and big ideas. -->
-    <% if col == @treeTypeRec.ess_q_dim_type
+    <% if dim_key == @treeTypeRec.ess_q_dim_type
          if @dim_subjs['miscon'] && @dim_type != @treeTypeRec.ess_q_dim_type %>
           <input type='hidden' name='dim_tree[miscon_subj_code]' value=<%= @dim_subjs['miscon'] %>></input>
       <% end
@@ -23,7 +27,7 @@
           <input type='hidden' name='dim_tree[miscon_gb_id]' value=<%= @m_gb[:id] || 0 %>></input>
     <% end
        if @bi_gb && @dim_type != @treeTypeRec.ess_q_dim_type %>
-         <input type='hidden' name='dim_tree[bigidea_gb_id]' value=<%= @eq_gb[:id] || 0 %>></input>
+         <input type='hidden' name='dim_tree[bigidea_gb_id]' value=<%= @bi_gb[:id] || 0 %>></input>
     <% end
     end %>
 
@@ -76,7 +80,7 @@
           <% end %>
         <% else # if col != "tree" %>
           <% BaseRec::BASE_SUBJECTS.each do |s| %>
-            <% sel_code = @dim_subjs[col] if @dim_subjs[col]
+            <% sel_code = @dim_subjs[dim_key] if @dim_subjs[dim_key]
                opt_name = @translations["subject.base.#{s}.abbr"]
             %>
             <%- selectedStr = (s == sel_code) ? ' selected = "selected"' : '' %>
@@ -93,6 +97,7 @@
         <% gbc = @grade_band_code
            gbc = @bi_gb[:code] if (@bi_gb && col == "bigidea")
            gbc = @m_gb[:code] if (@m_gb && col == "miscon")
+           gbc = @eq_gb[:code] if (@eq_gb && dim_key == @treeTypeRec.ess_q_dim_type)
         %>
         <%- selectedStr = (gb.code == gbc) ? ' selected = "selected"' : '' %>
         <%= Rails.logger.debug("gb index match: #{gb.code} == #{@grade_band_code} output: #{selectedStr}") %>

--- a/app/views/trees/index.html.erb
+++ b/app/views/trees/index.html.erb
@@ -7,10 +7,10 @@
 <br>
 <div class='text-center'>
   <%
-  @hierarchies.each_with_index do |h, ix|
+  @hierarchiesInTrees.each_with_index do |h, ix|
     if ix > 0 && ix <= @treeTypeRec.outcome_depth
   %>
-      <button id='showAreas' class='btn-info' onclick="$('#tree').treeview({data: otcTree, levels: <%= ix+1 %>, enableLinks: true/* , showCheckbox: true*/})"><%= I18n.t('app.labels.show') %> <%= @hierarchies[ix].pluralize if @hierarchies.length > ix %></button>
+      <button id='showAreas' class='btn-info' onclick="$('#tree').treeview({data: otcTree, levels: <%= ix+1 %>, enableLinks: true/* , showCheckbox: true*/})"><%= I18n.t('app.labels.show') %> <%= @hierarchiesInTrees[ix].pluralize if @hierarchiesInTrees.length > ix %></button>
   <%
     end
   end

--- a/app/views/trees/show.html.erb
+++ b/app/views/trees/show.html.erb
@@ -43,7 +43,7 @@
       <% @detail_areas.each do |area|
           detail_lookup = {
             "explanation": {tree: tree, indicator: true}, #indicator
-            "explain": {tree: tree}, #explanatory comment
+            "explain": {tree: tree, comment: true}, #explanatory comment
             "bigidea": {title: @bigIdeasTitle, expl: I18n.t('app.labels.explanation'), details: tree.dim_trees.where(:active => true), dim: true},
             "miscon": {title: @misconTitle, expl: I18n.t('app.labels.explanation'), details: tree.dim_trees.where(:active => true), dim: true},
             "essq": {title: @essqTitle, expl: I18n.t('app.labels.explanation'), details: tree.dim_trees.where(:active => true), dim: true},
@@ -76,7 +76,8 @@
           <%=
             render partial: "trees/show/tree_detail_area", locals: {
                 tree: detail[:tree],
-                indicator: detail[:indicator]
+                indicator: detail[:indicator],
+                comment: detail[:comment]
               }
           %>
           <%

--- a/app/views/trees/show.html.erb
+++ b/app/views/trees/show.html.erb
@@ -7,7 +7,7 @@
   component = outcome.present? ? outcome.getParentRec : nil
   area = component.present? ? component.getParentRec : nil
 %>
-<%= @detail_areas.inspect %>
+
 <div class='container'>
   <!--  loop through all tree items to display (to display multimle LOs when asked to display detail for higher Level tree item) -->
   <% @tree_items_to_display.each do |tree| %>
@@ -39,38 +39,11 @@
           <% end %>
         </div>
 
-      <!-- Related Indicators Table -->
-      <% if @hierarchies.count > @treeTypeRec[:outcome_depth] + 1 %>
-      <div class='related-indicators'>
-        <div class='row center-label-bold top-label'>
-          <div class='col col-lg-12'>
-            <%= @indicator_name %>
-          </div>
-        </div>
-        <% tree.getAllChildren.each do |c| %>
-        <div class='row'>
-          <div class='col col-lg-2 ind-col'>
-            <%= c.code %>
-          </div>
-          <div class='col col-lg-10 ind-col last-col'>
-            <%= @translations[c.buildNameKey] %>
-            <%= link_to(fa_icon("edit"), edit_tree_path(@tree.id, tree: { edit_type: 'indicator', attr_id: c.id}), {:remote => true, 'data-toggle' =>  "modal", 'data-target' => '#modal_popup'}) if @editMe %>
-          </div>
-        </div>
-        <% end %>
-        <%
-          ind_codes = JSON.load(tree.matching_codes)
-          ind_codes.each do |ia|
-            code = "#{tree.buildRootKey}.#{ia}.name"
-        %>
-          <p><%= "#{I18n.translate('app.labels.indicator')} #{ia}: #{@translations[code]}" %></p>
-        <% end %>
-      </div>
-      <% end %>
-
       <!-- Dynamically Ordered Tables -->
       <% @detail_areas.each do |area|
           detail_lookup = {
+            "explanation": {tree: tree, indicator: true}, #indicator
+            "explain": {tree: tree}, #explanatory comment
             "bigidea": {title: @bigIdeasTitle, expl: I18n.t('app.labels.explanation'), details: tree.dim_trees.where(:active => true), dim: true},
             "miscon": {title: @misconTitle, expl: I18n.t('app.labels.explanation'), details: tree.dim_trees.where(:active => true), dim: true},
             "essq": {title: @essqTitle, expl: I18n.t('app.labels.explanation'), details: tree.dim_trees.where(:active => true), dim: true},
@@ -97,6 +70,15 @@
             <%=
               render partial: "trees/show/connect_detail", locals: { detail_title: detail[:title] }
             %>
+          <%
+          elsif detail && detail[:tree]
+          %>
+          <%=
+            render partial: "trees/show/tree_detail_area", locals: {
+                tree: detail[:tree],
+                indicator: detail[:indicator]
+              }
+          %>
           <%
           end #detail && (detail[:dim] || detail[:sector]
           %>

--- a/app/views/trees/show.html.erb
+++ b/app/views/trees/show.html.erb
@@ -47,7 +47,7 @@
             "bigidea": {title: @bigIdeasTitle, expl: I18n.t('app.labels.explanation'), details: tree.dim_trees.where(:active => true), dim: true},
             "miscon": {title: @misconTitle, expl: I18n.t('app.labels.explanation'), details: tree.dim_trees.where(:active => true), dim: true},
             "essq": {title: @essqTitle, expl: I18n.t('app.labels.explanation'), details: tree.dim_trees.where(:active => true), dim: true},
-            "sector": {title: I18n.t('nav_bar.sectors.name'), expl: I18n.t('trees.labels.how_sectors_related'), details: tree.sector_trees.active, sector: true },
+            "sector": {title: @sectorName, expl: I18n.t('trees.labels.how_sectors_related'), details: tree.sector_trees.active, sector: true },
              "connect": {title: I18n.t('trees.labels.outcome_connections', outcome: (@hierarchies[tree.depth - 1].pluralize if @hierarchies.length > tree.depth - 1)), outcomes: true }
           }
           detail = detail_lookup[:"#{area[:name]}"]

--- a/app/views/trees/show.html.erb
+++ b/app/views/trees/show.html.erb
@@ -7,6 +7,7 @@
   component = outcome.present? ? outcome.getParentRec : nil
   area = component.present? ? component.getParentRec : nil
 %>
+<%= @detail_areas.inspect %>
 <div class='container'>
   <!--  loop through all tree items to display (to display multimle LOs when asked to display detail for higher Level tree item) -->
   <% @tree_items_to_display.each do |tree| %>
@@ -67,191 +68,41 @@
       </div>
       <% end %>
 
-      <!-- Related Big Ideas Table -->
-      <% if  @treeTypeRec.big_ideas_dim_type %>
-        <div class='related-items-table'>
-          <div class='row center-label-bold top-label'>
-            <div class='col col-lg-12'>
-              <%= @bigIdeasTitle %>
-            </div>
-            <div class='col col-lg-6 rel-reason-col center-label'>
-              <%= I18n.t('app.labels.explanation') %>
-            </div>
-          </div>
-          <% tree.dim_trees.where(:active => true).each do |dt|
-          d = dt.dimension
-          if d.dim_type == @treeTypeRec.big_ideas_dim_type
+      <!-- Dynamically Ordered Tables -->
+      <% @detail_areas.each do |area|
+          detail_lookup = {
+            "bigidea": {title: @bigIdeasTitle, expl: I18n.t('app.labels.explanation'), details: tree.dim_trees.where(:active => true), dim: true},
+            "miscon": {title: @misconTitle, expl: I18n.t('app.labels.explanation'), details: tree.dim_trees.where(:active => true), dim: true},
+            "essq": {title: @essqTitle, expl: I18n.t('app.labels.explanation'), details: tree.dim_trees.where(:active => true), dim: true},
+            "sector": {title: I18n.t('nav_bar.sectors.name'), expl: I18n.t('trees.labels.how_sectors_related'), details: tree.sector_trees.active, sector: true },
+             "connect": {title: I18n.t('trees.labels.outcome_connections', outcome: (@hierarchies[tree.depth - 1].pluralize if @hierarchies.length > tree.depth - 1)), outcomes: true }
+          }
+          detail = detail_lookup[:"#{area[:name]}"]
           %>
-          <div class='row'>
-            <div class='col col-lg-6 rel-sectors'>
-              <%= @translations[d.dim_name_key] %>
-            </div>
-            <div class='col col-lg-6 ind-col last-col'>
-              <%= @translations[dt.dim_explanation_key] %>
-              <% if @editMe %>
-              <%= link_to(fa_icon("times"), tree_path(@tree.id, tree: { edit_type: 'dimtree', attr_id: dt[:id], active: false}, sector_tree: {active: false}), {:class => "fa-lg pull-right", 'data-confirm' => I18n.t('app.labels.confirm_deactivate', item: @translations[d.dim_name_key]), method: :patch}) if @editMe %>
-              <%= link_to(fa_icon("edit"), edit_tree_path(@tree.id, tree: { edit_type: 'dimtree', attr_id: dt[:id]}), {:remote => true, :class => "fa-lg pull-right", 'data-toggle' =>  "modal", 'data-target' => '#modal_popup'}) if @editMe %>
-              <% end %>
-            </div>
-          </div>
-        <%
-          end
-        end
-        %>
-        </div>
-      <% end %>
+          <%
+          if detail && (detail[:dim] || detail[:sector])%>
+          <%=
+          render partial: "trees/show/detail_area", locals: {
+              detail_title: detail[:title],
+              expl_header: detail[:expl],
+              details: detail[:details],
+              dim: detail[:dim],
+              outcomes: detail[:outcome],
+              sector: detail[:sector]
+             }
+          %>
+          <%
+          elsif detail && detail[:outcomes]
+            %>
+            <%=
+              render partial: "trees/show/connect_detail", locals: { detail_title: detail[:title] }
+            %>
+          <%
+          end #detail && (detail[:dim] || detail[:sector]
+          %>
+      <% end #@detail_areas.each do |area| %>
 
 
-      <!-- Related Misconceptions Table -->
-      <% if @treeTypeRec.miscon_dim_type %>
-        <div class='related-items-table'>
-          <div class='row center-label-bold top-label'>
-            <div class='col col-lg-12'>
-              <%= @misconTitle %>
-            </div>
-            <div class='col col-lg-6 rel-reason-col center-label'>
-              <%= I18n.t('app.labels.explanation') %>
-            </div>
-          </div>
-        <% tree.dim_trees.where(:active => true).each do |dt|
-          d = dt.dimension
-          if d.dim_type == @treeTypeRec.miscon_dim_type
-        %>
-          <div class='row'>
-            <div class='col col-lg-6 rel-sectors'>
-              <%= @translations[d.dim_name_key] %>
-            </div>
-            <div class='col col-lg-6 ind-col last-col'>
-            <%= @translations[dt.dim_explanation_key] %>
-            <% if @editMe %>
-              <%= link_to(fa_icon("times"), tree_path(@tree.id, tree: { edit_type: 'dimtree', attr_id: dt[:id], active: false}, sector_tree: {active: false}), {:class => "fa-lg pull-right", 'data-confirm' => I18n.t('app.labels.confirm_deactivate', item: @translations[d.dim_name_key]), method: :patch}) if @editMe %>
-              <%= link_to(fa_icon("edit"), edit_tree_path(@tree.id, tree: { edit_type: 'dimtree', attr_id: dt[:id]}), {:remote => true, :class => "fa-lg pull-right", 'data-toggle' =>  "modal", 'data-target' => '#modal_popup'}) if @editMe %>
-            <% end %>
-            </div>
-          </div>
-        <%
-          end
-        end
-        %>
-        </div>
-      <% end %>
-
-      <!-- Future Sectors Table -->
-      <div class='related-items-table'>
-        <div class='row center-label-bold top-label'>
-          <div class='col col-lg-12'>
-            <%= I18n.t('nav_bar.sectors.name') %>
-              <% if @editMe %>
-                <%= link_to(fa_icon("plus-square"), edit_tree_path(@tree.id, tree: { edit_type: 'sector', attr_id: 'new'}), {:remote => true, :class => "fa-lg pull-right", 'data-toggle' =>  "modal", 'data-target' => '#modal_popup'}) if @editMe %>
-              <% end %>
-          </div>
-        </div>
-        <div class='row'>
-          <div class='col col-lg-6 rel-sector-col center-label'>
-            <%= I18n.t('trees.labels.related_sectors') %>
-          </div>
-          <div class='col col-lg-6 rel-reason-col center-label'>
-            <%= I18n.t('trees.labels.how_sectors_related') %>
-          </div>
-        </div>
-        <% tree.sector_trees.active.each do |st| %>
-          <div class='row'>
-            <div class='col col-lg-6 rel-sectors'>
-              <%= link_to(
-                "#{@translations[st.sector.name_key]}",
-                sectors_path(
-                  controller: 'sector',
-                  action: 'index',
-                  tree: {
-                    sector_id: "#{st.sector.id}",
-                    grade_band_id: "#{@tree.grade_band_id}",
-                    subject_id: "#{@tree.subject_id}"
-                  }
-                ),
-                html_options = {data: { :sector => st.sector.id }}
-              ) %>
-            </div>
-            <div class='col col-lg-6 rel-reason-col val'>
-              <%= @translations["#{st.explanation_key}"] %>
-              <% if @editMe %>
-                <%= link_to(fa_icon("times"), tree_path(@tree.id, tree: { edit_type: 'sector', attr_id: st[:id], active: false}, sector_tree: {active: false}), {:class => "fa-lg pull-right", 'data-confirm' => I18n.t('app.labels.confirm_deactivate', item: @translations[st.sector.name_key]), method: :patch}) if @editMe %>
-                <%= link_to(fa_icon("edit"), edit_tree_path(@tree.id, tree: { edit_type: 'sector', attr_id: st[:id]}), {:remote => true, :class => "fa-lg pull-right", 'data-toggle' =>  "modal", 'data-target' => '#modal_popup'}) if @editMe %>
-              <% end %>
-            </div>
-          </div>
-        <% end %>
-      </div>
-
-      <!-- Connections to Other Outcomes Table -->
-      <div class='related-items-table'>
-        <div class='row subject-relations center-label-bold top-label'>
-          <div class='col col-lg-12'>
-            <%= I18n.t('trees.labels.outcome_connections', outcome: (@hierarchies[3].pluralize if @hierarchies.length > 3)) %>
-              <% if @editMe && false %>
-                <a href="#"><span class="pull-right">
-                  <i class="fa fa-plus-square fa-lg"></i>
-                </span></a>
-              <% end %>
-          </div>
-        </div>
-        <div class='connections-grid'>
-          <div class='connections-header'>
-            <div class='center-label sub-header-margin'>
-              <%= I18n.t('trees.labels.relation') %>
-            </div>
-          </div>
-          <div class='connections-header'>
-            <div class='center-label sub-header-margin'>
-              <%= I18n.t('app.labels.subject') %>
-            </div>
-          </div>
-          <div class='connections-header'>
-            <div class='center-label sub-header-margin'>
-              <%= I18n.t('app.labels.code') %>
-            </div>
-          </div>
-          <div class='connections-header'>
-            <div class='center-label sub-header-margin'>
-              <%= I18n.t('app.labels.description') %>
-            </div>
-          </div>
-          <div class='connections-header'>
-            <div class='center-label sub-header-margin'>
-              <%= I18n.t('trees.labels.how_outcome_related') %>
-            </div>
-          </div>
-
-        </div>
-        <div class='connections-grid'>
-          <% @relatedBySubj.each do |subj, rel|%>
-            <% rel.each do |r| %>
-              <div class='connections-item'>
-                <%= r[:relationship] %>
-              </div>
-              <div class='connections-item'>
-                <%= I18n.t("trees.labels.#{subj}") %>
-              </div>
-              <div class='connections-item'>
-                <%= r[:code] %>
-              </div>
-              <div class='connections-item'>
-                <% if r[:tid] == 0 %>
-                  <%= @translations[r[:tkey]] %>
-                <% else %>
-                  <a href='/<%= @locale_code %>/trees/<%= r[:tid] %>'><%= @translations[r[:tkey]] %></a>
-                <% end %>
-              </div>
-              <div class='connections-item'>
-                <%= @translations[r[:explanation]] %>
-                <% if @editMe %>
-                  <%= link_to(fa_icon("times"), tree_path(@tree.id, tree: { edit_type: 'treetree', attr_id: r[:ttid], active: false}, tree_tree: {active: false}), {:class => "fa-lg pull-right", 'data-confirm' => I18n.t('app.labels.confirm_deactivate', item: I18n.t("trees.labels.#{subj}") + ": " + r[:code]), method: :patch}) if @editMe %>
-                  <%= link_to(fa_icon("edit"), edit_tree_path(@tree.id, tree: { edit_type: 'treetree', attr_id: r[:ttid]}), {:remote => true, :class => "fa-lg pull-right", 'data-toggle' =>  "modal", 'data-target' => '#modal_popup'}) if @editMe %>
-                <% end %>
-              </div>
-            <% end %>
-          <% end %>
-        </div>
-      </div>
 
       <!-- Supporting Resources Table -->
       <div class='row teacher-label top-label'>

--- a/app/views/trees/show/_connect_detail.html.erb
+++ b/app/views/trees/show/_connect_detail.html.erb
@@ -1,0 +1,70 @@
+<!-- Connections to Other Outcomes Table -->
+      <div class='related-items-table'>
+        <div class='row subject-relations center-label-bold top-label'>
+          <div class='col col-lg-12'>
+            <%= detail_title %>
+              <% if @editMe && false %>
+                <a href="#"><span class="pull-right">
+                  <i class="fa fa-plus-square fa-lg"></i>
+                </span></a>
+              <% end %>
+          </div>
+        </div>
+        <div class='connections-grid'>
+          <div class='connections-header'>
+            <div class='center-label sub-header-margin'>
+              <%= I18n.t('trees.labels.relation') %>
+            </div>
+          </div>
+          <div class='connections-header'>
+            <div class='center-label sub-header-margin'>
+              <%= I18n.t('app.labels.subject') %>
+            </div>
+          </div>
+          <div class='connections-header'>
+            <div class='center-label sub-header-margin'>
+              <%= I18n.t('app.labels.code') %>
+            </div>
+          </div>
+          <div class='connections-header'>
+            <div class='center-label sub-header-margin'>
+              <%= I18n.t('app.labels.description') %>
+            </div>
+          </div>
+          <div class='connections-header'>
+            <div class='center-label sub-header-margin'>
+              <%= I18n.t('trees.labels.how_outcome_related') %>
+            </div>
+          </div>
+
+        </div>
+        <div class='connections-grid'>
+          <% @relatedBySubj.each do |subj, rel|%>
+            <% rel.each do |r| %>
+              <div class='connections-item'>
+                <%= r[:relationship] %>
+              </div>
+              <div class='connections-item'>
+                <%= I18n.t("trees.labels.#{subj}") %>
+              </div>
+              <div class='connections-item'>
+                <%= r[:code] %>
+              </div>
+              <div class='connections-item'>
+                <% if r[:tid] == 0 %>
+                  <%= @translations[r[:tkey]] %>
+                <% else %>
+                  <a href='/<%= @locale_code %>/trees/<%= r[:tid] %>'><%= @translations[r[:tkey]] %></a>
+                <% end %>
+              </div>
+              <div class='connections-item'>
+                <%= @translations[r[:explanation]] %>
+                <% if @editMe %>
+                  <%= link_to(fa_icon("times"), tree_path(@tree.id, tree: { edit_type: 'treetree', attr_id: r[:ttid], active: false}, tree_tree: {active: false}), {:class => "fa-lg pull-right", 'data-confirm' => I18n.t('app.labels.confirm_deactivate', item: I18n.t("trees.labels.#{subj}") + ": " + r[:code]), method: :patch}) if @editMe %>
+                  <%= link_to(fa_icon("edit"), edit_tree_path(@tree.id, tree: { edit_type: 'treetree', attr_id: r[:ttid]}), {:remote => true, :class => "fa-lg pull-right", 'data-toggle' =>  "modal", 'data-target' => '#modal_popup'}) if @editMe %>
+                <% end %>
+              </div>
+            <% end %>
+          <% end %>
+        </div>
+      </div>

--- a/app/views/trees/show/_detail_area.html.erb
+++ b/app/views/trees/show/_detail_area.html.erb
@@ -1,0 +1,66 @@
+<div class='related-items-table'>
+  <div class='row center-label-bold top-label'>
+    <div class='col col-lg-12'>
+      <%= detail_title %>
+      <%= link_to(fa_icon("plus-square"), edit_tree_path(@tree.id, tree: { edit_type: 'sector', attr_id: 'new'}), {:remote => true, :class => "fa-lg pull-right", 'data-toggle' =>  "modal", 'data-target' => '#modal_popup'}) if @editMe && sector %>
+    </div>
+    <div class='col col-lg-6 rel-reason-col center-label'>
+              <%= detail_title.singularize %>
+    </div>
+    <div class='col col-lg-6 rel-reason-col center-label'>
+      <%= expl_header %>
+    </div>
+  </div>
+  <% details.each do |dt| %>
+  <!-- Dimensions Table (e.g., misconceptions, etc) -->
+  <%
+  if dim
+    d = dt.dimension
+    if d.dim_type == @treeTypeRec.big_ideas_dim_type
+    %>
+    <div class='row'>
+      <div class='col col-lg-6 rel-sectors'>
+        <%= @translations[d.dim_name_key] %>
+      </div>
+      <div class='col col-lg-6 ind-col last-col'>
+        <%= @translations[dt.dim_explanation_key] %>
+        <% if @editMe %>
+        <%= link_to(fa_icon("times"), tree_path(@tree.id, tree: { edit_type: 'dimtree', attr_id: dt[:id], active: false}, sector_tree: {active: false}), {:class => "fa-lg pull-right", 'data-confirm' => I18n.t('app.labels.confirm_deactivate', item: @translations[d.dim_name_key]), method: :patch}) if @editMe %>
+        <%= link_to(fa_icon("edit"), edit_tree_path(@tree.id, tree: { edit_type: 'dimtree', attr_id: dt[:id]}), {:remote => true, :class => "fa-lg pull-right", 'data-toggle' =>  "modal", 'data-target' => '#modal_popup'}) if @editMe %>
+        <% end #if @editMe %>
+      </div>
+    </div>
+  <%
+    end #if d.dim_type == @treeTypeRec.big_ideas_dim_type
+  elsif sector
+    st = dt
+  %>
+    <div class='row'>
+    <div class='col col-lg-6 rel-sectors'>
+      <%= link_to(
+        "#{@translations[st.sector.name_key]}",
+        sectors_path(
+          controller: 'sector',
+          action: 'index',
+          tree: {
+            sector_id: "#{st.sector.id}",
+            grade_band_id: "#{@tree.grade_band_id}",
+            subject_id: "#{@tree.subject_id}"
+          }
+        ),
+        html_options = {data: { :sector => st.sector.id }}
+      ) %>
+    </div>
+    <div class='col col-lg-6 rel-reason-col val'>
+      <%= @translations["#{st.explanation_key}"] %>
+      <% if @editMe %>
+        <%= link_to(fa_icon("times"), tree_path(@tree.id, tree: { edit_type: 'sector', attr_id: st[:id], active: false}, sector_tree: {active: false}), {:class => "fa-lg pull-right", 'data-confirm' => I18n.t('app.labels.confirm_deactivate', item: @translations[st.sector.name_key]), method: :patch}) if @editMe %>
+        <%= link_to(fa_icon("edit"), edit_tree_path(@tree.id, tree: { edit_type: 'sector', attr_id: st[:id]}), {:remote => true, :class => "fa-lg pull-right", 'data-toggle' =>  "modal", 'data-target' => '#modal_popup'}) if @editMe %>
+      <% end %>
+    </div>
+  </div>
+
+<% end #if dim, elsif sector
+end #details.each do |dt|
+%>
+</div>

--- a/app/views/trees/show/_tree_detail_area.html.erb
+++ b/app/views/trees/show/_tree_detail_area.html.erb
@@ -1,0 +1,27 @@
+ <% if @hierarchies.count > @treeTypeRec[:outcome_depth] + 1 && indicator %>
+      <div class='related-indicators'>
+        <div class='row center-label-bold top-label'>
+          <div class='col col-lg-12'>
+            <%= @indicator_name %>
+          </div>
+        </div>
+        <% tree.getAllChildren.each do |c| %>
+        <div class='row'>
+          <div class='col col-lg-2 ind-col'>
+            <%= c.code %>
+          </div>
+          <div class='col col-lg-10 ind-col last-col'>
+            <%= @translations[c.buildNameKey] %>
+            <%= link_to(fa_icon("edit"), edit_tree_path(@tree.id, tree: { edit_type: 'indicator', attr_id: c.id}), {:remote => true, 'data-toggle' =>  "modal", 'data-target' => '#modal_popup'}) if @editMe %>
+          </div>
+        </div>
+        <% end %>
+        <%
+          ind_codes = JSON.load(tree.matching_codes)
+          ind_codes.each do |ia|
+            code = "#{tree.buildRootKey}.#{ia}.name"
+        %>
+          <p><%= "#{I18n.translate('app.labels.indicator')} #{ia}: #{@translations[code]}" %></p>
+        <% end %>
+      </div>
+      <% end %>

--- a/app/views/trees/show/_tree_detail_area.html.erb
+++ b/app/views/trees/show/_tree_detail_area.html.erb
@@ -29,6 +29,7 @@
     <div class='row center-label-bold top-label'>
       <div class='col col-lg-12'>
         <%= I18n.translate('app.labels.comments') %>
+        <%= link_to(fa_icon("edit"), edit_tree_path(@tree.id, tree: { edit_type: 'comment'}), {:class => "fa-lg pull-right", :remote => true, 'data-toggle' =>  "modal", 'data-target' => '#modal_popup'}) if @editMe %>
       </div>
     </div>
     <div class='row'>

--- a/app/views/trees/show/_tree_detail_area.html.erb
+++ b/app/views/trees/show/_tree_detail_area.html.erb
@@ -1,27 +1,40 @@
  <% if @hierarchies.count > @treeTypeRec[:outcome_depth] + 1 && indicator %>
-      <div class='related-indicators'>
-        <div class='row center-label-bold top-label'>
-          <div class='col col-lg-12'>
-            <%= @indicator_name %>
-          </div>
-        </div>
-        <% tree.getAllChildren.each do |c| %>
-        <div class='row'>
-          <div class='col col-lg-2 ind-col'>
-            <%= c.code %>
-          </div>
-          <div class='col col-lg-10 ind-col last-col'>
-            <%= @translations[c.buildNameKey] %>
-            <%= link_to(fa_icon("edit"), edit_tree_path(@tree.id, tree: { edit_type: 'indicator', attr_id: c.id}), {:remote => true, 'data-toggle' =>  "modal", 'data-target' => '#modal_popup'}) if @editMe %>
-          </div>
-        </div>
-        <% end %>
-        <%
-          ind_codes = JSON.load(tree.matching_codes)
-          ind_codes.each do |ia|
-            code = "#{tree.buildRootKey}.#{ia}.name"
-        %>
-          <p><%= "#{I18n.translate('app.labels.indicator')} #{ia}: #{@translations[code]}" %></p>
-        <% end %>
+  <div class='related-indicators'>
+    <div class='row center-label-bold top-label'>
+      <div class='col col-lg-12'>
+        <%= @indicator_name %>
       </div>
-      <% end %>
+    </div>
+    <% tree.getAllChildren.each do |c| %>
+    <div class='row'>
+      <div class='col col-lg-2 ind-col'>
+        <%= c.code %>
+      </div>
+      <div class='col col-lg-10 ind-col last-col'>
+        <%= @translations[c.buildNameKey] %>
+        <%= link_to(fa_icon("edit"), edit_tree_path(@tree.id, tree: { edit_type: 'indicator', attr_id: c.id}), {:remote => true, 'data-toggle' =>  "modal", 'data-target' => '#modal_popup'}) if @editMe %>
+      </div>
+    </div>
+    <% end %>
+    <%
+      ind_codes = JSON.load(tree.matching_codes)
+      ind_codes.each do |ia|
+        code = "#{tree.buildRootKey}.#{ia}.name"
+    %>
+      <p><%= "#{I18n.translate('app.labels.indicator')} #{ia}: #{@translations[code]}" %></p>
+    <% end %>
+  </div>
+<% elsif comment %>
+  <div class='comments'>
+    <div class='row center-label-bold top-label'>
+      <div class='col col-lg-12'>
+        <%= I18n.translate('app.labels.comments') %>
+      </div>
+    </div>
+    <div class='row'>
+      <div class='col col-lg-12 ind-col'>
+        <%= Translation.find_translation_name(@locale_code,tree.outcome.get_explain_key, "") %>
+      </div>
+    </div>
+  </div>
+<% end %>

--- a/config/locales/pages.en.yml
+++ b/config/locales/pages.en.yml
@@ -36,6 +36,7 @@ en:
       outcomes: "Attainments"
       indicator: "Explanation"
       indicators: "Explanations"
+      comments: "Explanatory Comment"
       code: "Code"
       description: 'Description'
       message: "Message"

--- a/lib/tasks/seed_turkey.rake
+++ b/lib/tasks/seed_turkey.rake
@@ -27,8 +27,8 @@ namespace :seed_turkey do
       big_ideas_dim_type: 'bigidea',
       ess_q_dim_type: 'essq',
       tree_code_format: 'grade,unit,sub_unit,comp',
-      detail_headers: 'grade,unit,chapt,attain,[subj_big_idea],[ess_q],{explain},[miscon],[sector],[connect],[refs]',
-      grid_headers: 'grade,unit,chapt,attain,[subj_big_idea],[ess_q],explain,[miscon],[connect],[refs]'
+      detail_headers: 'grade,unit,chapt,attain,[bigidea],[ess_q],{explain},[miscon],[sector],[connect],[refs]',
+      grid_headers: 'grade,unit,chapt,attain,[bigidea],[ess_q],explain,[miscon],[connect],[refs]'
 
     }
     if myTreeType.count < 1

--- a/lib/tasks/seed_turkey.rake
+++ b/lib/tasks/seed_turkey.rake
@@ -27,7 +27,7 @@ namespace :seed_turkey do
       big_ideas_dim_type: 'bigidea',
       ess_q_dim_type: 'essq',
       tree_code_format: 'grade,unit,sub_unit,comp',
-      detail_headers: 'grade,unit,chapt,attain,[bigidea],[ess_q],{explain},[miscon],[sector],[connect],[refs]',
+      detail_headers: 'grade,unit,chapt,attain,[explanation],[bigidea],[ess_q],{explain},[miscon],[sector],[connect],[refs]',
       grid_headers: 'grade,unit,chapt,attain,[bigidea],[ess_q],explain,[miscon],[connect],[refs]'
 
     }

--- a/lib/tasks/seed_turkey_v02.rake
+++ b/lib/tasks/seed_turkey_v02.rake
@@ -34,8 +34,8 @@ namespace :seed_turkey_v02 do
       big_ideas_dim_type: 'bigidea',
       ess_q_dim_type: 'essq',
       tree_code_format: 'grade,unit,sub_unit,comp',
-      detail_headers: 'grade,unit,(sub_unit),comp,[subj_big_idea],[ess_q],{explain},[miscon],[sector],[connect],[refs]',
-      grid_headers: 'grade,unit,(sub_unit),comp,[subj_big_idea],[ess_q],explain,[miscon],[connect],[refs]'
+      detail_headers: 'grade,unit,(sub_unit),comp,[bigidea],[ess_q],{explain},[miscon],[sector],[connect],[refs]',
+      grid_headers: 'grade,unit,(sub_unit),comp,[bigidea],[ess_q],explain,[miscon],[connect],[refs]'
     }
     if myTreeType.count < 1
       TreeType.create(myTreeTypeValues)

--- a/lib/tasks/seed_turkey_v02a.rake
+++ b/lib/tasks/seed_turkey_v02a.rake
@@ -24,7 +24,7 @@ namespace :seed_turkey_v02a do
       sector_set_code: 'future,hide',
       sector_set_name_key: 'sector.set.future.name',
       curriculum_title_key: 'curriculum.tfv.title', # 'Turkey STEM Curriculum'
-      outcome_depth: 2,
+      outcome_depth: 3,
       version_id: @v02.id,
       working_status: true,
       miscon_dim_type: 'miscon',
@@ -71,8 +71,6 @@ namespace :seed_turkey_v02a do
       end
     end
     STDOUT.puts 'Done: Outcome records for all tree records at the outcome level have been created.'
-
-    myTreeType.update(:outcome_depth => 3)
 
     # Tree.joins(:outcome).where(:tree_type_id => 2).each do |t|
     #   old_name_key = t.buildNameKey

--- a/lib/tasks/seed_turkey_v02a.rake
+++ b/lib/tasks/seed_turkey_v02a.rake
@@ -31,9 +31,8 @@ namespace :seed_turkey_v02a do
       big_ideas_dim_type: 'bigidea',
       ess_q_dim_type: 'essq',
       tree_code_format: 'grade,unit,sub_unit,comp',
-      detail_headers: 'grade,unit,(sub_unit),comp,[subj_big_idea],[ess_q],{explain},[miscon],[sector],[connect],[refs]',
-      grid_headers: 'grade,unit,(sub_unit),comp,[subj_big_idea],[ess_q],explain,[miscon],[connect],[refs]'
-
+      detail_headers: 'grade,unit,(sub_unit),comp,[bigidea],[ess_q],{explain},[miscon],[sector],[connect],[refs]',
+      grid_headers: 'grade,unit,(sub_unit),comp,[bigidea],[ess_q],explain,[miscon],[connect],[refs]'
     }
     if myTreeType.count < 1
       raise 'Missing Tree Type record for tfv v02'


### PR DESCRIPTION
- Partially implemented dynamic order on tree detail page, using the treetype's details_header string. Still need to implement this for the header section of the page, but tables (dimensions, connections, indicators, and sectors) are covered.
   - follow the detail headers string to output the detail page, using partials to organize html
- Render the link to Sectors as a navbar button OR as a dropdown option depending on whether a flag is used in TreeType's sector_set_code
  - add TreeType#get_sector_set_code to separate the sector_set_code from the flag
  - add TreeType#hide_sectors to look at the flag in the sector_set_code and return boolean indicating whether or not to put the Sectors button in the default location (as a navbar button) 
