### PR TITLE
Small Update To seed_turkey_v02b Rake Task

### DIFF
--- a/lib/tasks/seed_turkey_v02b.rake
+++ b/lib/tasks/seed_turkey_v02b.rake
@@ -55,7 +55,8 @@ namespace :seed_turkey_v02b do
         max_grade: 12
       )
     end
-    Translation.find_or_update_translation(@loc_en.code, 'subject.tfv.tech', 'Tech Engineering')
+    Translation.find_or_update_translation(@loc_en.code, 'subject.tfv.tech.name', 'Tech Engineering')
+    Translation.find_or_update_translation(@loc_en.code, 'subject.tfv.tech.abbr', 'tech')
     Translation.find_or_update_translation(@loc_en.code, 'subject.base.tech.name', 'Tech Engineering')
     Translation.find_or_update_translation(@loc_en.code, 'subject.base.tech.abbr', 'tech')
 


### PR DESCRIPTION
Add translations the sequence/relations page needs for Tech subject in tfv.v02 curriculum. Fixes an exception on the Sequence page, once the Tech curriculum is added.

Note: We are essentially expecting two different versions of the name/abbr translation keys for a subject, depending on the page being accessed. These should be standardized, and the obsolete keys removed from the code. 