### PR TITLE
Resolve data and display issues with detail Page

### DIFF
--- a/app/controllers/trees_controller.rb
+++ b/app/controllers/trees_controller.rb
@@ -1329,7 +1329,7 @@ class TreesController < ApplicationController
         is_miscon = dt_dim.dim_type == @treeTypeRec.miscon_dim_type
         # If the dimension will not be captured by the dimension
         # columns displayed on the page.
-        if (is_bigidea && @dim_subjs['bigidea']  && @dim_subjs['bigidea'] != dt_dim.subject_code) || (is_miscon && @dim_subjs['miscon']  && @dim_subjs['miscon'] != dt_dim.subject_code) || (is_ess_q && @dim_subjs[@treeTypeRec.ess_q_dim_type]  && @dim_subjs[@treeTypeRec.ess_q_dim_type] != dt_dim.subject_code)
+        if (is_bigidea && @dim_subjs['bigidea'] && @dim_subjs['bigidea'] != dt_dim.subject_code) || (is_miscon && @dim_subjs['miscon']  && @dim_subjs['miscon'] != dt_dim.subject_code) || (is_ess_q && @dim_subjs[@treeTypeRec.ess_q_dim_type] && @dim_subjs[@treeTypeRec.ess_q_dim_type] != dt_dim.subject_code)
         #@trees.first.present? && dt_dim.subject_id != @trees.first.subject_id
             dimKeys << dt_dim.dim_name_key
             dt_dim_subj = "subject.base.#{dt_dim.subject_code}.name"

--- a/app/controllers/trees_controller.rb
+++ b/app/controllers/trees_controller.rb
@@ -16,7 +16,7 @@ class TreesController < ApplicationController
     componentHash = {}
     newHash = {}
     hierarchiesInTrees = []
-
+    puts "TREES: #{@trees.pluck('code')}"
     # create ruby hash from tree records, to easily build tree from record codes
     @trees.each do |tree|
       translation = @translations[tree.buildNameKey]
@@ -773,6 +773,7 @@ class TreesController < ApplicationController
       detail_areas = @treeTypeRec.detail_headers.split(",")
       @detail_headers = []
       @detail_areas = []
+      hierarchy_codes = @treeTypeRec.hierarchy_codes.split(",").map { |h| h.split("_").join("") }
       detail_areas.each do |a|
         detail_type = 'header'
         detail = a
@@ -782,9 +783,12 @@ class TreesController < ApplicationController
         elsif a.first == "[" && a.last == "]"
           detail_type = 'multi'
           detail = a[1..a.length - 2]
+        elsif a.first == "(" && a.last == ")"
+          detail_type = 'header'
+          detail = a[1..a.length - 2]
         end
         detail = detail.split("_").join("")
-        @detail_headers << {type: detail_type, name: detail} if detail_type == 'header'
+        @detail_headers << {type: detail_type, name: detail, depth: hierarchy_codes.index(detail) } if detail_type == 'header'
         @detail_areas << {type: detail_type, name: detail} if detail_type != 'header'
       end
     else

--- a/app/controllers/uploads_controller.rb
+++ b/app/controllers/uploads_controller.rb
@@ -272,6 +272,9 @@ class UploadsController < ApplicationController
         @rptRecs <<  rptRec if rptRec.present?
         recordOrder += 1
 
+        @subjectRec.update(min_grade: gradeBandRec.min_grade) if @subjectRec.min_grade > gradeBandRec.min_grade
+        @subjectRec.update(max_grade: gradeBandRec.max_grade) if @subjectRec.max_grade < gradeBandRec.max_grade
+
         ######################################################
         # Write the Unit level tree record (create or update)
         unitName = rowH['Unit']

--- a/app/controllers/uploads_controller.rb
+++ b/app/controllers/uploads_controller.rb
@@ -214,7 +214,7 @@ class UploadsController < ApplicationController
     end
 
     #   - Create a hash (at beginning of upload process) of the Dimensions for this subject, and dimension type (not by Tree Type - to prevent dups)
-    @currentDims = Hash.new{ |h, k| h[k] = {} }
+    @currentDims = Hash.new{ |h, k| h[k] = Hash.new{ |h, k| h[k] = {} } }
     currentDims = Dimension.where(subject_code: @subjectRec.code, active: true)
     currentDims.each do |rec|
       transl_names = Translation.where(locale: @locale_code, key: rec.get_dim_name_key)
@@ -226,7 +226,7 @@ class UploadsController < ApplicationController
         transl_id = nil
       end
       if transl_name.present?
-        @currentDims[transl_name] = {updated: false, rec: rec, transl_name: transl_name, transl_id: transl_id}
+        @currentDims[rec.dim_type][transl_name] = {updated: false, rec: rec, transl_name: transl_name, transl_id: transl_id}
       else
         # Ignoring this condition for now
       end
@@ -853,7 +853,7 @@ class UploadsController < ApplicationController
     #   - if the dim_name exists already we are going to use that dimension (ignoring dim_desc)
     #   - otherwise we will create a new dimension
 
-    currentRecH = @currentDims[dim_name]
+    currentRecH = @currentDims[dim_type][dim_name]
     if !currentRecH.present?
       Rails.logger.debug("$$$ Did NOT find current dimension: #{dim_name}")
       currentRec = Dimension.create(
@@ -883,7 +883,7 @@ class UploadsController < ApplicationController
         dimExplKey,
         dim_tree_expl
       )
-      @currentDims[dim_name] = {updated: true, rec: currentRec, transl_name: dim_name, transl_id: transl_rec.id}
+      @currentDims[dim_type][dim_name] = {updated: true, rec: currentRec, transl_name: dim_name, transl_id: transl_rec.id}
     else #existing Dimension record
       Rails.logger.debug("$$$ Found current dimension: #{dim_name}")
       currentRec = currentRecH[:rec]
@@ -904,7 +904,7 @@ class UploadsController < ApplicationController
           dimExplKey,
           dim_tree_expl
         )
-        @currentDims[dim_name][:updated] = true
+        @currentDims[dim_type][dim_name][:updated] = true
       end
 
     end

--- a/app/models/dim_tree.rb
+++ b/app/models/dim_tree.rb
@@ -13,8 +13,8 @@ class DimTree < BaseRec
 
   # Standard for dim_explanation_key
   # e.g. TFV.v01.bio.9.1.1.1.miscon.3.expl
-  def self.getDimExplanationKey(treeNameKey, dimType, dimId)
-    return "#{treeNameKey}.#{dimType}.#{dimId}.expl"
+  def self.getDimExplanationKey(treeBaseKey, dimType, dimId)
+    return "#{treeBaseKey}.#{dimType}.#{dimId}.expl"
   end
 
 

--- a/app/models/grade_band.rb
+++ b/app/models/grade_band.rb
@@ -1,4 +1,19 @@
 class GradeBand < BaseRec
-	MIN_GRADE = 0
+  MIN_GRADE = 0
   MAX_GRADE = 20
+
+  # Translation Field
+  #
+  # In the existing data, gradeband translations are associated with a
+  # specific TreeType, but do not have a version code. It would probably
+  # be a good idea to migrate the current Translations to use a version
+  # code in addition to the TreeType code.
+  def self.build_name_key(treeTypeCode, gbCode)
+    return 'grades.'+treeTypeCode+'.'+gbCode+'.name'
+  end
+
+	def get_name_key
+	  return 'grades.'+TreeType.find(tree_type_id).code+'.'+code+'.name'
+	end
+  ######################################################
 end

--- a/app/models/sector.rb
+++ b/app/models/sector.rb
@@ -3,6 +3,13 @@ class Sector < BaseRec
   has_many :sector_trees
   has_many :trees, through: :sector_trees
 
+# Translation Field
+  def get_name_key
+    return "sector.#{sector_set_code}.#{code}.name"
+  end
+
+#####################################
+#Not Used, & no longer accurate- Should be deprecated?
   def self.sectorCodeFromTranslationCode(sectorCode)
     matches = sectorCode.split('.')
     if matches.length == 3 && matches[0] == 'sector' && matches[2] == 'name'
@@ -11,7 +18,7 @@ class Sector < BaseRec
       return ''
     end
   end
-
+  #Not Used, & no longer accurate- Should be deprecated?
   def self.TranslationCodeFromsectorCode(sectorCode)
     if ALL_SECTORS.include?(sectorCode)
       return "sector.#{sectorCode}.name"

--- a/app/models/sector_tree.rb
+++ b/app/models/sector_tree.rb
@@ -4,6 +4,7 @@ class SectorTree < BaseRec
 
   scope :active, -> { where(:active => true) }
 
+  # Translation Field
   def self.explanationKey(tree_type_code, version_code, tree_id, sector_id)
     "#{tree_type_code}.#{version_code}.tree.#{tree_id}.sector.#{sector_id}"
   end
@@ -11,5 +12,5 @@ class SectorTree < BaseRec
   def explanationKey(tree_type_code, version_code, tree_id, sector_id)
     "#{tree_type_code}.#{version_code}.tree.#{tree_id}.sector.#{sector_id}"
   end
-
+  #########################################
 end

--- a/app/models/subject.rb
+++ b/app/models/subject.rb
@@ -2,9 +2,20 @@ class Subject < BaseRec
 
   has_and_belongs_to_many :trees
 
-  def self.name_translation_key(code)
-    "subject.base.#{code}.name"
+  # Translation Field
+
+  # The TreeType-specific Translation key for a Subject
+  def versioned_name_key
+    treeTypeRec = TreeType.find(tree_type_id)
+    return "subject.#{treeTypeRec.code}.#{code}.name"
   end
+
+  # The default Translation key for BaseRec subjects
+  def self.name_translation_key(code)
+    return "subject.base.#{code}.name"
+  end
+
+  ########################################
 
   def abbr(loc)
     Rails.logger.debug("loc: #{loc.inspect}")

--- a/app/models/tree.rb
+++ b/app/models/tree.rb
@@ -104,6 +104,19 @@ class Tree < BaseRec
     end
   end
 
+  def parentCode
+    arr = self.codeArray
+    if arr && arr.length > 0
+      arr.pop(1)
+      while arr && arr.length > 0 && arr.last == ""
+        arr.pop(1)
+      end
+      return arr.join('.')
+    else
+      return ''
+    end
+  end
+
   def parentCodes
     arr = self.codeArray
     ret = []

--- a/app/models/tree.rb
+++ b/app/models/tree.rb
@@ -57,6 +57,32 @@ class Tree < BaseRec
 
   # Field Translations
 
+  # overrides of deprecated name_key field
+  def name_key
+    return base_key + ".name"
+  end
+
+  def self.buildNameKey(treeTypeRec, versionRec, subjectRec, gradeBandRec, fullCode)
+    # return "#{treeTypeRec.code}.#{versionRec.code}.#{subjectRec.code}.#{gradeBandRec.code}.#{fullCode}.name"
+    return "#{treeTypeRec.code}.#{versionRec.code}.#{subjectRec.code}.#{fullCode}.name"
+  end
+  def buildNameKey
+    # return "#{self.tree_type.code}.#{self.version.code}.#{self.subject.code}.#{self.grade_band.code}.#{self.code}.name"
+    return "#{self.tree_type.code}.#{self.version.code}.#{self.subject.code}.#{self.code}.name"
+  end
+
+  def self.buildBaseKey(treeTypeRec, versionRec, subjectRec, gradeBandRec, fullCode)
+    # return "#{treeTypeRec.code}.#{versionRec.code}.#{subjectRec.code}.#{gradeBandRec.code}.#{fullCode}"
+    return "#{treeTypeRec.code}.#{versionRec.code}.#{subjectRec.code}.#{fullCode}"
+  end
+  def buildBaseKey
+    # return "#{self.tree_type.code}.#{self.version.code}.#{self.subject.code}.#{self.grade_band.code}.#{self.code}"
+    return "#{self.tree_type.code}.#{self.version.code}.#{self.subject.code}.#{self.code}"
+  end
+
+  def buildRootKey
+    return "#{self.tree_type.code}.#{self.version.code}.#{self.subject.code}.#{self.grade_band.code}"
+  end
   ####################################################
   def code_by_ix(ix)
     if depth == 3
@@ -132,10 +158,7 @@ class Tree < BaseRec
     return codeArray.length
   end
 
-  # overrides of deprecated name_key field
-  def name_key
-    return base_key + ".name"
-  end
+
 
   # def area
   #   return self.codeArray[0]
@@ -223,28 +246,6 @@ class Tree < BaseRec
     else
       return retCode
     end
-  end
-
-  def self.buildNameKey(treeTypeRec, versionRec, subjectRec, gradeBandRec, fullCode)
-    # return "#{treeTypeRec.code}.#{versionRec.code}.#{subjectRec.code}.#{gradeBandRec.code}.#{fullCode}.name"
-    return "#{treeTypeRec.code}.#{versionRec.code}.#{subjectRec.code}.#{fullCode}.name"
-  end
-  def buildNameKey
-    # return "#{self.tree_type.code}.#{self.version.code}.#{self.subject.code}.#{self.grade_band.code}.#{self.code}.name"
-    return "#{self.tree_type.code}.#{self.version.code}.#{self.subject.code}.#{self.code}.name"
-  end
-
-  def self.buildBaseKey(treeTypeRec, versionRec, subjectRec, gradeBandRec, fullCode)
-    # return "#{treeTypeRec.code}.#{versionRec.code}.#{subjectRec.code}.#{gradeBandRec.code}.#{fullCode}"
-    return "#{treeTypeRec.code}.#{versionRec.code}.#{subjectRec.code}.#{fullCode}"
-  end
-  def buildBaseKey
-    # return "#{self.tree_type.code}.#{self.version.code}.#{self.subject.code}.#{self.grade_band.code}.#{self.code}"
-    return "#{self.tree_type.code}.#{self.version.code}.#{self.subject.code}.#{self.code}"
-  end
-
-  def buildRootKey
-    return "#{self.tree_type.code}.#{self.version.code}.#{self.subject.code}.#{self.grade_band.code}"
   end
 
   # get parent record for this item (by hierarchy code as appropriate)

--- a/app/models/tree_type.rb
+++ b/app/models/tree_type.rb
@@ -1,7 +1,24 @@
 class TreeType < BaseRec
 
+  # Translation Field
+  def hierarchy_name_key(hierarchy_code)
+    return "curriculum.#{code}.hierarchy.#{hierarchy_code}"
+  end
+
+  def sector_set_name_key
+    return "sector.set.#{get_sector_set_code}.name"
+  end
+
+  def title_key
+    return "curriculum.#{code}.title"
+  end
+  #######################################
   def self.get_sector_set_code(code)
     return code.split(",")[0]
+  end
+
+  def get_sector_set_code
+    return sector_set_code.split(",")[0]
   end
 
   def self.versions_hash()

--- a/app/views/trees/show.html.erb
+++ b/app/views/trees/show.html.erb
@@ -12,23 +12,33 @@
   <!--  loop through all tree items to display (to display multimle LOs when asked to display detail for higher Level tree item) -->
   <% @tree_items_to_display.each do |tree| %>
     <div class='detail-page'>
-      <% tree_parents = tree.getAllParents %>
+      <% parents_by_depth = {}
+        tree.getAllParents.map { |t| parents_by_depth[t.depth - 1] = t if t }
+        parents_by_depth[@treeTypeRec[:outcome_depth]] = tree
+      %>
 
       <!-- Display the translated descriptions of all parents for this item (Grade, Unit, Chapter, Outcome)  -->
-      <% @hierarchies.each_with_index do |e, i|
-         if i <= @treeTypeRec[:outcome_depth]
-           rec = (i == @treeTypeRec[:outcome_depth] ? tree : tree_parents[tree_parents.length - 1 - i])
-           if rec
-             label_text = @translations[rec.buildNameKey]
-           %>
-             <div class='row subject-<%= e.downcase %>-row'><div class='col col-lg-6 text-left'><%= "#{"#{@subjectByCode[tree.subject.code][:name]} " if i == 0 && rec}#{e} #{rec.codeArrayAt(i) if i > 0 && rec}" %>: <%= label_text %>
-               <% if i == @treeTypeRec[:outcome_depth] %>
-                 <%= link_to(fa_icon("edit"), edit_tree_path(@tree.id, tree: { edit_type: 'outcome'}), {:remote => true, 'data-toggle' =>  "modal", 'data-target' => '#modal_popup'}) if @editMe %>
-               <% end %>
-             </div></div>
-      <%  end
-        end
-      end %>
+      <% @detail_headers.each do |h| %>
+        <% rec = parents_by_depth[h[:depth]] %>
+        <% if rec %>
+          <div class='row subject-<%= h[:name] %>-row'>
+            <div class='col col-lg-6 text-left'>
+              <strong>
+              <%= "#{@subjectByCode[tree.subject.code][:name] if h[:depth] == 0 }#{" #{@hierarchies[h[:depth]]} #{rec.codeArray.last}:" if h[:depth] > 0}" %>
+              <% if h[:depth] > 0 %>
+                </strong>
+              <% end %>
+              <%= @translations[rec.buildNameKey] %>
+              <% if h[:depth] == 0 %>
+                </strong>
+              <% end %>
+              <% if h[:depth] == @treeTypeRec[:outcome_depth] %>
+                <%= link_to(fa_icon("edit"), edit_tree_path(@tree.id, tree: { edit_type: 'outcome'}), {:remote => true, 'data-toggle' =>  "modal", 'data-target' => '#modal_popup'}) if @editMe %>
+              <% end %>
+            </div>
+          </div>
+        <% end #if rec %>
+      <% end #@detail_headers.each_with_index do |h, i| %>
 
       <div class='col col-lg-12 text-right'>
           <% if @editMe %>

--- a/lib/tasks/dimensions.rake
+++ b/lib/tasks/dimensions.rake
@@ -37,4 +37,28 @@ namespace :dimensions do
 
   end #task set_subject_codes: :environment do
 
+
+  desc "Delete all Dimensions, DimTrees, and their associated Translations"
+  task destroy_all: :environment do
+    dim_trees = DimTree.all
+    dims = Dimension.all
+    dim_trees.each do |dt|
+      t = dt.tree.base_key
+      d = dt.dimension
+      key = DimTree.getDimExplanationKey(t, d.dim_type, d.id)
+      puts "Deleting DimTree Translation: #{key}"
+      Translation.where(:key => key).delete_all
+    end
+    dims.each do |d|
+      puts "Deleting Dim Name Translation: #{d.get_dim_name_key}"
+      Translation.where(:key => d.get_dim_name_key).delete_all
+      puts "Deleting Dim Desc Translation: #{d.get_dim_desc_key}"
+      Translation.where(:key => d.get_dim_desc_key).delete_all
+    end
+     puts "Deleting all DimTree records"
+     dim_trees.delete_all
+     puts "Deleting all Dimension records"
+     dims.delete_all
+  end # task destroy_all
+
 end

--- a/lib/tasks/seed_turkey_v02a.rake
+++ b/lib/tasks/seed_turkey_v02a.rake
@@ -31,8 +31,8 @@ namespace :seed_turkey_v02a do
       big_ideas_dim_type: 'bigidea',
       ess_q_dim_type: 'essq',
       tree_code_format: 'grade,unit,sub_unit,comp',
-      detail_headers: 'grade,unit,(sub_unit),comp,[bigidea],[ess_q],{explain},[miscon],[sector],[connect],[refs]',
-      grid_headers: 'grade,unit,(sub_unit),comp,[bigidea],[ess_q],explain,[miscon],[connect],[refs]'
+      detail_headers: 'grade,unit,(sub_unit),comp,[ess_q],[bigidea],{explain},[miscon],[sector],[connect],[refs]',
+      grid_headers: 'grade,unit,(sub_unit),comp,[ess_q],[bigidea],explain,[miscon],[connect],[refs]'
     }
     if myTreeType.count < 1
       raise 'Missing Tree Type record for tfv v02'

--- a/lib/tasks/seed_turkey_v02a.rake
+++ b/lib/tasks/seed_turkey_v02a.rake
@@ -58,23 +58,23 @@ namespace :seed_turkey_v02a do
     throw "ERROR updating sector translation: #{message}" if status == BaseRec::REC_ERROR
     STDOUT.puts 'Create translation record for Sub-Unit.'
 
-    STDOUT.puts 'Create all Outcome records for all tree records at the outcome level.'
-    Tree.all.each do |t|
-      tt = t.tree_type
-      if tt.outcome_depth > 0
-        # Tree model overrides the depth field. Returns the length of the code.
-        if t.depth == tt.outcome_depth + 1 && !t.outcome_id.present?
-          puts "try to save outcome for #{t.code}"
-          out = Outcome.new()
-          out.base_key = out.get_base_key(t.base_key)
-          out.save
-          t.outcome_id = out.id
-          t.save
-          puts "saved outcome for #{t.code}"
-        end
-      end
-    end
-    STDOUT.puts 'Done: Outcome records for all tree records at the outcome level have been created.'
+    # STDOUT.puts 'Create all Outcome records for all tree records at the outcome level.'
+    # Tree.all.each do |t|
+    #   tt = t.tree_type
+    #   if tt.outcome_depth > 0
+    #     # Tree model overrides the depth field. Returns the length of the code.
+    #     if t.depth == tt.outcome_depth + 1 && !t.outcome_id.present?
+    #       puts "try to save outcome for #{t.code}"
+    #       out = Outcome.new()
+    #       out.base_key = out.get_base_key(t.base_key)
+    #       out.save
+    #       t.outcome_id = out.id
+    #       t.save
+    #       puts "saved outcome for #{t.code}"
+    #     end
+    #   end
+    # end
+    # STDOUT.puts 'Done: Outcome records for all tree records at the outcome level have been created.'
 
     # Tree.joins(:outcome).where(:tree_type_id => 2).each do |t|
     #   old_name_key = t.buildNameKey

--- a/lib/tasks/seed_turkey_v02b.rake
+++ b/lib/tasks/seed_turkey_v02b.rake
@@ -55,7 +55,8 @@ namespace :seed_turkey_v02b do
         max_grade: 12
       )
     end
-    Translation.find_or_update_translation(@loc_en.code, 'subject.tfv.tech', 'Tech Engineering')
+    Translation.find_or_update_translation(@loc_en.code, 'subject.tfv.tech.name', 'Tech Engineering')
+    Translation.find_or_update_translation(@loc_en.code, 'subject.tfv.tech.abbr', 'Tech')
     Translation.find_or_update_translation(@loc_en.code, 'subject.base.tech.name', 'Tech Engineering')
     Translation.find_or_update_translation(@loc_en.code, 'subject.base.tech.abbr', 'tech')
 


### PR DESCRIPTION
- Fix headers on Tree detail page, and show according to the tree type detail_headers string
- In the csv upload process, distinguish between dim_types when finding matching dimensions.
  - add a dim_type hash above the dim_name hash
  - change @current_dims hash to have dim_type
  - when getting current dimension, look up by dim type
- Rake task (dimensions:destroy_all) to clean up the data (tested locally)
  - loops through all dimension trees
    - removes all explanations for dim trees
  - deletes dimension trees
  - loops through all dimensions
    - removes all translations for dimension
  - removes dimensions
- Updated tree_type.detail_headers in seed_turkey_v02a:populate so that the detail page will list K12 Big Ideas first.
- Updated tech subject translations in seed_turkey_v02b:populate


- document translation keys associated with gradeband, sector, sector_tree, subject, tree, and tree_type in their respective models

**Note:** Tested running uploads after clearing out dimension data. Checked that all dimensions were correct for Tech grades K and 1, and extensively spot-checked Bio. Dimensions seem to match the proper competencies and have the correct dim_type now.

When updating the server:
- RAILS_ENV=production bundle exec rake seed_turkey_v02a:populate
- RAILS_ENV=production bundle exec rake seed_turkey_v02b:populate
- RAILS_ENV=production bundle exec rake dimensions:destroy_all
- **** Redo the curriculum uploads for all v02 subjects
