### PR TITLE
Detail page no longer shows the "reason for" field

### DIFF
--- a/app/assets/javascripts/sequence.js
+++ b/app/assets/javascripts/sequence.js
@@ -247,12 +247,12 @@ add_edit_form = function(res) {
   edit_mode = res.tree_tree.id != null;
   if (edit_mode) {
     submit_button =
-      '<button type="button" \
+      '<button class="btn btn-primary" type="button" \
         onclick="patch_from_tree_tree_form(' +
       res.tree_tree.id +
       ')">SAVE</button>';
   } else {
-    submit_button = '<button type="submit">SAVE</button>';
+    submit_button = '<button class="btn btn-primary" type="submit">SAVE</button>';
   }
   return (
     '<div class="modal-header"> \
@@ -273,6 +273,9 @@ add_edit_form = function(res) {
           <input type="hidden" name="tree_tree[tree_referencee_id]" value=' +
     res.tree_tree.tree_referencee_id +
     '> \
+    <input type="hidden" name="tree[active]" value=' +
+    true +
+    '> \
           </div> \
           <fieldset> \
           <label for="relationship">' +
@@ -282,6 +285,11 @@ add_edit_form = function(res) {
     '<br> \
           <select id="relationship" name="tree_tree[relationship]"> \
           <option value="' +
+    res.relation_values.akin +
+    (res.tree_tree.relationship == "akin" ? '" selected>' : '">') +
+    res.translations.akin +
+    "</option> \
+          <option value=" +
     res.relation_values.applies +
     (res.tree_tree.relationship == "applies" ? '" selected>' : '">') +
     res.translations.applies +
@@ -291,32 +299,13 @@ add_edit_form = function(res) {
     (res.tree_tree.relationship == "depends" ? '" selected>' : '">') +
     res.translations.depends +
     '</option> \
-          <option value="' +
-    res.relation_values.akin +
-    (res.tree_tree.relationship == "akin" ? '" selected>' : '">') +
-    res.translations.akin +
-    "</option> \
           </select> \
-          <div>" +
+          <div>' +
     res.referencee_code +
     '</div><br> \
-          </fieldset> \
-          <fieldset> \
-            <label for="explanation">' +
-    res.translations.explanation_label +
-    '<br> \
-            <textarea type="text" name="tree_tree[explanation]">' +
-    (res.translations.explanation != undefined
-      ? res.translations.explanation
-      : "") +
-    '</textarea> \
-          </fieldset> \
-          <fieldset><label for="tree_tree[active]">Active?</label>\
-          <input name="tree_tree[active]" type="checkbox"' +
-    (res.tree_tree.active ? " checked" : "") +
-    "></input></fieldset>" +
+          </fieldset>' +
     submit_button +
-    '<button type="button" type="button" data-dismiss="modal" \
+    '<button type="button" class="btn" type="button" data-dismiss="modal" \
           aria-hidden="true">CANCEL</button> \
           </div> \
           </form>'

--- a/app/assets/stylesheets/trees.scss
+++ b/app/assets/stylesheets/trees.scss
@@ -318,7 +318,7 @@
     }
     .connections-grid {
       display: grid;
-      grid-template-columns: 10% 10% 8% 36% 36%;
+      grid-template-columns: 10% 15% 8% 67%;
       margin-left: -15px;
       margin-right: -15px;
       border-top: 1px solid black;

--- a/app/controllers/trees_controller.rb
+++ b/app/controllers/trees_controller.rb
@@ -1329,7 +1329,7 @@ class TreesController < ApplicationController
         is_miscon = dt_dim.dim_type == @treeTypeRec.miscon_dim_type
         # If the dimension will not be captured by the dimension
         # columns displayed on the page.
-        if (is_bigidea && @dim_subjs['bigidea']  && @dim_subjs['bigidea'] != dt_dim.subject_code) || (is_miscon && @dim_subjs['miscon']  && @dim_subjs['miscon'] != dt_dim.subject_code) || (is_ess_q && @dim_subjs[@treeTypeRec.ess_q_dim_type]  && @dim_subjs[@treeTypeRec.ess_q_dim_type] != dt_dim.subject_code)
+        if (is_bigidea && @dim_subjs['bigidea'] && @dim_subjs['bigidea'] != dt_dim.subject_code) || (is_miscon && @dim_subjs['miscon']  && @dim_subjs['miscon'] != dt_dim.subject_code) || (is_ess_q && @dim_subjs[@treeTypeRec.ess_q_dim_type] && @dim_subjs[@treeTypeRec.ess_q_dim_type] != dt_dim.subject_code)
         #@trees.first.present? && dt_dim.subject_id != @trees.first.subject_id
             dimKeys << dt_dim.dim_name_key
             dt_dim_subj = "subject.base.#{dt_dim.subject_code}.name"

--- a/app/controllers/trees_controller.rb
+++ b/app/controllers/trees_controller.rb
@@ -16,7 +16,7 @@ class TreesController < ApplicationController
     componentHash = {}
     newHash = {}
     hierarchiesInTrees = []
-
+    puts "TREES: #{@trees.pluck('code')}"
     # create ruby hash from tree records, to easily build tree from record codes
     @trees.each do |tree|
       translation = @translations[tree.buildNameKey]
@@ -773,6 +773,7 @@ class TreesController < ApplicationController
       detail_areas = @treeTypeRec.detail_headers.split(",")
       @detail_headers = []
       @detail_areas = []
+      hierarchy_codes = @treeTypeRec.hierarchy_codes.split(",").map { |h| h.split("_").join("") }
       detail_areas.each do |a|
         detail_type = 'header'
         detail = a
@@ -782,9 +783,12 @@ class TreesController < ApplicationController
         elsif a.first == "[" && a.last == "]"
           detail_type = 'multi'
           detail = a[1..a.length - 2]
+        elsif a.first == "(" && a.last == ")"
+          detail_type = 'header'
+          detail = a[1..a.length - 2]
         end
         detail = detail.split("_").join("")
-        @detail_headers << {type: detail_type, name: detail} if detail_type == 'header'
+        @detail_headers << {type: detail_type, name: detail, depth: hierarchy_codes.index(detail) } if detail_type == 'header'
         @detail_areas << {type: detail_type, name: detail} if detail_type != 'header'
       end
     else

--- a/app/controllers/uploads_controller.rb
+++ b/app/controllers/uploads_controller.rb
@@ -272,6 +272,9 @@ class UploadsController < ApplicationController
         @rptRecs <<  rptRec if rptRec.present?
         recordOrder += 1
 
+        @subjectRec.update(min_grade: gradeBandRec.min_grade) if @subjectRec.min_grade > gradeBandRec.min_grade
+        @subjectRec.update(max_grade: gradeBandRec.max_grade) if @subjectRec.max_grade < gradeBandRec.max_grade
+
         ######################################################
         # Write the Unit level tree record (create or update)
         unitName = rowH['Unit']

--- a/app/controllers/uploads_controller.rb
+++ b/app/controllers/uploads_controller.rb
@@ -214,7 +214,7 @@ class UploadsController < ApplicationController
     end
 
     #   - Create a hash (at beginning of upload process) of the Dimensions for this subject, and dimension type (not by Tree Type - to prevent dups)
-    @currentDims = Hash.new{ |h, k| h[k] = {} }
+    @currentDims = Hash.new{ |h, k| h[k] = Hash.new{ |h, k| h[k] = {} } }
     currentDims = Dimension.where(subject_code: @subjectRec.code, active: true)
     currentDims.each do |rec|
       transl_names = Translation.where(locale: @locale_code, key: rec.get_dim_name_key)
@@ -226,7 +226,7 @@ class UploadsController < ApplicationController
         transl_id = nil
       end
       if transl_name.present?
-        @currentDims[transl_name] = {updated: false, rec: rec, transl_name: transl_name, transl_id: transl_id}
+        @currentDims[rec.dim_type][transl_name] = {updated: false, rec: rec, transl_name: transl_name, transl_id: transl_id}
       else
         # Ignoring this condition for now
       end
@@ -853,7 +853,7 @@ class UploadsController < ApplicationController
     #   - if the dim_name exists already we are going to use that dimension (ignoring dim_desc)
     #   - otherwise we will create a new dimension
 
-    currentRecH = @currentDims[dim_name]
+    currentRecH = @currentDims[dim_type][dim_name]
     if !currentRecH.present?
       Rails.logger.debug("$$$ Did NOT find current dimension: #{dim_name}")
       currentRec = Dimension.create(
@@ -883,7 +883,7 @@ class UploadsController < ApplicationController
         dimExplKey,
         dim_tree_expl
       )
-      @currentDims[dim_name] = {updated: true, rec: currentRec, transl_name: dim_name, transl_id: transl_rec.id}
+      @currentDims[dim_type][dim_name] = {updated: true, rec: currentRec, transl_name: dim_name, transl_id: transl_rec.id}
     else #existing Dimension record
       Rails.logger.debug("$$$ Found current dimension: #{dim_name}")
       currentRec = currentRecH[:rec]
@@ -904,7 +904,7 @@ class UploadsController < ApplicationController
           dimExplKey,
           dim_tree_expl
         )
-        @currentDims[dim_name][:updated] = true
+        @currentDims[dim_type][dim_name][:updated] = true
       end
 
     end

--- a/app/models/dim_tree.rb
+++ b/app/models/dim_tree.rb
@@ -13,8 +13,8 @@ class DimTree < BaseRec
 
   # Standard for dim_explanation_key
   # e.g. TFV.v01.bio.9.1.1.1.miscon.3.expl
-  def self.getDimExplanationKey(treeNameKey, dimType, dimId)
-    return "#{treeNameKey}.#{dimType}.#{dimId}.expl"
+  def self.getDimExplanationKey(treeBaseKey, dimType, dimId)
+    return "#{treeBaseKey}.#{dimType}.#{dimId}.expl"
   end
 
 

--- a/app/models/grade_band.rb
+++ b/app/models/grade_band.rb
@@ -1,4 +1,19 @@
 class GradeBand < BaseRec
-	MIN_GRADE = 0
+  MIN_GRADE = 0
   MAX_GRADE = 20
+
+  # Translation Field
+  #
+  # In the existing data, gradeband translations are associated with a
+  # specific TreeType, but do not have a version code. It would probably
+  # be a good idea to migrate the current Translations to use a version
+  # code in addition to the TreeType code.
+  def self.build_name_key(treeTypeCode, gbCode)
+    return 'grades.'+treeTypeCode+'.'+gbCode+'.name'
+  end
+
+	def get_name_key
+	  return 'grades.'+TreeType.find(tree_type_id).code+'.'+code+'.name'
+	end
+  ######################################################
 end

--- a/app/models/sector.rb
+++ b/app/models/sector.rb
@@ -3,6 +3,13 @@ class Sector < BaseRec
   has_many :sector_trees
   has_many :trees, through: :sector_trees
 
+# Translation Field
+  def get_name_key
+    return "sector.#{sector_set_code}.#{code}.name"
+  end
+
+#####################################
+#Not Used, & no longer accurate- Should be deprecated?
   def self.sectorCodeFromTranslationCode(sectorCode)
     matches = sectorCode.split('.')
     if matches.length == 3 && matches[0] == 'sector' && matches[2] == 'name'
@@ -11,7 +18,7 @@ class Sector < BaseRec
       return ''
     end
   end
-
+  #Not Used, & no longer accurate- Should be deprecated?
   def self.TranslationCodeFromsectorCode(sectorCode)
     if ALL_SECTORS.include?(sectorCode)
       return "sector.#{sectorCode}.name"

--- a/app/models/sector_tree.rb
+++ b/app/models/sector_tree.rb
@@ -4,6 +4,7 @@ class SectorTree < BaseRec
 
   scope :active, -> { where(:active => true) }
 
+  # Translation Field
   def self.explanationKey(tree_type_code, version_code, tree_id, sector_id)
     "#{tree_type_code}.#{version_code}.tree.#{tree_id}.sector.#{sector_id}"
   end
@@ -11,5 +12,5 @@ class SectorTree < BaseRec
   def explanationKey(tree_type_code, version_code, tree_id, sector_id)
     "#{tree_type_code}.#{version_code}.tree.#{tree_id}.sector.#{sector_id}"
   end
-
+  #########################################
 end

--- a/app/models/subject.rb
+++ b/app/models/subject.rb
@@ -15,6 +15,18 @@ class Subject < BaseRec
     return "subject.base.#{code}.name"
   end
 
+  def get_name(locale_code)
+    return Translation.find_translation_name(
+        locale_code,
+        versioned_name_key,
+        nil
+      ) || Translation.find_translation_name(
+        locale_code,
+        Subject.name_translation_key(code),
+        ""
+      )
+  end
+
   ########################################
 
   def abbr(loc)

--- a/app/models/subject.rb
+++ b/app/models/subject.rb
@@ -2,9 +2,20 @@ class Subject < BaseRec
 
   has_and_belongs_to_many :trees
 
-  def self.name_translation_key(code)
-    "subject.base.#{code}.name"
+  # Translation Field
+
+  # The TreeType-specific Translation key for a Subject
+  def versioned_name_key
+    treeTypeRec = TreeType.find(tree_type_id)
+    return "subject.#{treeTypeRec.code}.#{code}.name"
   end
+
+  # The default Translation key for BaseRec subjects
+  def self.name_translation_key(code)
+    return "subject.base.#{code}.name"
+  end
+
+  ########################################
 
   def abbr(loc)
     Rails.logger.debug("loc: #{loc.inspect}")

--- a/app/models/tree.rb
+++ b/app/models/tree.rb
@@ -104,6 +104,19 @@ class Tree < BaseRec
     end
   end
 
+  def parentCode
+    arr = self.codeArray
+    if arr && arr.length > 0
+      arr.pop(1)
+      while arr && arr.length > 0 && arr.last == ""
+        arr.pop(1)
+      end
+      return arr.join('.')
+    else
+      return ''
+    end
+  end
+
   def parentCodes
     arr = self.codeArray
     ret = []

--- a/app/models/tree.rb
+++ b/app/models/tree.rb
@@ -57,6 +57,32 @@ class Tree < BaseRec
 
   # Field Translations
 
+  # overrides of deprecated name_key field
+  def name_key
+    return base_key + ".name"
+  end
+
+  def self.buildNameKey(treeTypeRec, versionRec, subjectRec, gradeBandRec, fullCode)
+    # return "#{treeTypeRec.code}.#{versionRec.code}.#{subjectRec.code}.#{gradeBandRec.code}.#{fullCode}.name"
+    return "#{treeTypeRec.code}.#{versionRec.code}.#{subjectRec.code}.#{fullCode}.name"
+  end
+  def buildNameKey
+    # return "#{self.tree_type.code}.#{self.version.code}.#{self.subject.code}.#{self.grade_band.code}.#{self.code}.name"
+    return "#{self.tree_type.code}.#{self.version.code}.#{self.subject.code}.#{self.code}.name"
+  end
+
+  def self.buildBaseKey(treeTypeRec, versionRec, subjectRec, gradeBandRec, fullCode)
+    # return "#{treeTypeRec.code}.#{versionRec.code}.#{subjectRec.code}.#{gradeBandRec.code}.#{fullCode}"
+    return "#{treeTypeRec.code}.#{versionRec.code}.#{subjectRec.code}.#{fullCode}"
+  end
+  def buildBaseKey
+    # return "#{self.tree_type.code}.#{self.version.code}.#{self.subject.code}.#{self.grade_band.code}.#{self.code}"
+    return "#{self.tree_type.code}.#{self.version.code}.#{self.subject.code}.#{self.code}"
+  end
+
+  def buildRootKey
+    return "#{self.tree_type.code}.#{self.version.code}.#{self.subject.code}.#{self.grade_band.code}"
+  end
   ####################################################
   def code_by_ix(ix)
     if depth == 3
@@ -132,10 +158,7 @@ class Tree < BaseRec
     return codeArray.length
   end
 
-  # overrides of deprecated name_key field
-  def name_key
-    return base_key + ".name"
-  end
+
 
   # def area
   #   return self.codeArray[0]
@@ -223,28 +246,6 @@ class Tree < BaseRec
     else
       return retCode
     end
-  end
-
-  def self.buildNameKey(treeTypeRec, versionRec, subjectRec, gradeBandRec, fullCode)
-    # return "#{treeTypeRec.code}.#{versionRec.code}.#{subjectRec.code}.#{gradeBandRec.code}.#{fullCode}.name"
-    return "#{treeTypeRec.code}.#{versionRec.code}.#{subjectRec.code}.#{fullCode}.name"
-  end
-  def buildNameKey
-    # return "#{self.tree_type.code}.#{self.version.code}.#{self.subject.code}.#{self.grade_band.code}.#{self.code}.name"
-    return "#{self.tree_type.code}.#{self.version.code}.#{self.subject.code}.#{self.code}.name"
-  end
-
-  def self.buildBaseKey(treeTypeRec, versionRec, subjectRec, gradeBandRec, fullCode)
-    # return "#{treeTypeRec.code}.#{versionRec.code}.#{subjectRec.code}.#{gradeBandRec.code}.#{fullCode}"
-    return "#{treeTypeRec.code}.#{versionRec.code}.#{subjectRec.code}.#{fullCode}"
-  end
-  def buildBaseKey
-    # return "#{self.tree_type.code}.#{self.version.code}.#{self.subject.code}.#{self.grade_band.code}.#{self.code}"
-    return "#{self.tree_type.code}.#{self.version.code}.#{self.subject.code}.#{self.code}"
-  end
-
-  def buildRootKey
-    return "#{self.tree_type.code}.#{self.version.code}.#{self.subject.code}.#{self.grade_band.code}"
   end
 
   # get parent record for this item (by hierarchy code as appropriate)

--- a/app/models/tree_type.rb
+++ b/app/models/tree_type.rb
@@ -1,7 +1,24 @@
 class TreeType < BaseRec
 
+  # Translation Field
+  def hierarchy_name_key(hierarchy_code)
+    return "curriculum.#{code}.hierarchy.#{hierarchy_code}"
+  end
+
+  def sector_set_name_key
+    return "sector.set.#{get_sector_set_code}.name"
+  end
+
+  def title_key
+    return "curriculum.#{code}.title"
+  end
+  #######################################
   def self.get_sector_set_code(code)
     return code.split(",")[0]
+  end
+
+  def get_sector_set_code
+    return sector_set_code.split(",")[0]
   end
 
   def self.versions_hash()

--- a/app/views/trees/_edit.html.erb
+++ b/app/views/trees/_edit.html.erb
@@ -5,6 +5,7 @@
 
 <%= form_for(@tree) do |f| %>
   <div class="hidden_fields">
+    <%= f.hidden_field :code, name: 'tree[active]', value: true %>
     <%= f.hidden_field :code, name: 'tree[edit_type]', value: @edit_type %>
     <%= f.hidden_field :code, name: 'tree[attr_id]', value: @attr_id  if (@edit_type != 'outcome') %>
   </div>
@@ -24,7 +25,7 @@
   <fieldset>
     <label for='relationship'><%= translate('trees.labels.relation') %></label>
     <div>
-    <span class="stack"><%= I18n.t("trees.labels.#{@tree.subject.code}") + " " + @tree.code %></span>
+    <span class="stack"><%= "#{@tree.subject.get_name(@locale_code)} #{@tree.code}" %></span>
     <% if @edit_type == 'treetree' %>
 	    <select id="relationship" name="tree_tree[relationship]" class="stack">
 	      <option value="<%= TreeTree::APPLIES_KEY %>"
@@ -55,19 +56,6 @@
     </span>
     </div>
   </fieldset>
-  <fieldset>
-    <label for='explanation'><%= translate('app.labels.explanation') %></label>
-    <div>
-    <%= f.text_area :explanation, name: 'tree[name_translation]', id: 'explanation', value: @explanation %>
-    </div>
-  </fieldset>
-
-  <fieldset>
-    <label for="<%= @edit_type == 'treetree' ? 'tree' : 'sector' %>_tree[active]">Active?</label>
-      <input name="tree[active]" type="checkbox"
-        <%= @rel.active ? ' checked' : '' %>></input>
-  </fieldset>
-
 
 	<% end #build fieldsets by @edit_type %>
 

--- a/app/views/trees/_edit_dimensions.html.erb
+++ b/app/views/trees/_edit_dimensions.html.erb
@@ -1,5 +1,5 @@
 <div class="modal-header">
-   <h3 id="myModalLabel"><%= translate('trees.' + @dim.dim_type + '.title') %> Connection</h3>
+   <h3 id="myModalLabel"><%= translate('app.labels.connect_form_title') %> </h3>
  </div>
  <div class="modal-body">
 
@@ -23,6 +23,7 @@
   	<input type="hidden" name="dim_tree[dimension_id]" value='<%= @dim_tree.dimension_id %>'>
     <input type="hidden" name="dim_tree[dim_explanation_key]" value='<%= @dim_tree.dim_explanation_key %>'>
     <input type="hidden" name="dim_tree[dim_type]" value='<%= @dim.dim_type %>'>
+    <input type="hidden" name="dim_tree[active]" value='<%= true %>'>
     <% if @dim_tree.id %>
       <input type="hidden" name="dim_tree[id]" value='<%= @dim_tree.id %>'>
     <% end %>
@@ -30,28 +31,16 @@
 
   <fieldset>
     <div>
-    <div><strong><%= translate('app.labels.outcome') + ": " %></strong><%= @tree_subject_translation + " " + @tree.code %></div>
+    <div><strong><%= @hierarchies[ @tree.depth - 1] + ": " %></strong><%= @tree_subject_translation + " " + @tree.code %></div>
     <div><strong> - <%= translate('trees.bigidea.relates_to') %> - </strong></div>
-    <div><strong><%= translate('trees.' + @dim.dim_type + '.singular') + ": " %></strong><%= @dimension_translation %></div>
+    <div><strong><%= Dimension.get_dim_type_name(@dim.dim_type, @treeTypeRec.code, @versionRec.code, @locale_code) + ": " %></strong><%= @dimension_translation %></div>
     </div>
   </fieldset>
   <br>
-  <fieldset>
 
-    <div>
-    <div><label for='explanation'><%= translate('app.labels.explanation') %></label></div>
-    <%= f.text_area :explanation, name: 'dim_tree[explanation]', id: 'explanation', value: @explanation %>
-    </div>
-  </fieldset>
-
-  <fieldset>
-    <label for="dim_tree[active]">Active?</label>
-      <input name="dim_tree[active]" type="checkbox"
-        <%= @dim_tree.active ? ' checked' : '' %>></input>
-  </fieldset>
 
  <div class="modal-footer">
-   <button class="btn" data-dismiss="modal" aria-hidden="true">Close</button>
-   <button type="submit" class="btn btn-primary">Save changes</button>
+   <button class="btn" data-dismiss="modal" aria-hidden="true"><%= translate('app.labels.cancel') %></button>
+   <button type="submit" class="btn btn-primary"><%= translate('app.labels.save') %></button>
  </div>
 <% end %>

--- a/app/views/trees/show.html.erb
+++ b/app/views/trees/show.html.erb
@@ -12,23 +12,33 @@
   <!--  loop through all tree items to display (to display multimle LOs when asked to display detail for higher Level tree item) -->
   <% @tree_items_to_display.each do |tree| %>
     <div class='detail-page'>
-      <% tree_parents = tree.getAllParents %>
+      <% parents_by_depth = {}
+        tree.getAllParents.map { |t| parents_by_depth[t.depth - 1] = t if t }
+        parents_by_depth[@treeTypeRec[:outcome_depth]] = tree
+      %>
 
       <!-- Display the translated descriptions of all parents for this item (Grade, Unit, Chapter, Outcome)  -->
-      <% @hierarchies.each_with_index do |e, i|
-         if i <= @treeTypeRec[:outcome_depth]
-           rec = (i == @treeTypeRec[:outcome_depth] ? tree : tree_parents[tree_parents.length - 1 - i])
-           if rec
-             label_text = @translations[rec.buildNameKey]
-           %>
-             <div class='row subject-<%= e.downcase %>-row'><div class='col col-lg-6 text-left'><%= "#{"#{@subjectByCode[tree.subject.code][:name]} " if i == 0 && rec}#{e} #{rec.codeArrayAt(i) if i > 0 && rec}" %>: <%= label_text %>
-               <% if i == @treeTypeRec[:outcome_depth] %>
-                 <%= link_to(fa_icon("edit"), edit_tree_path(@tree.id, tree: { edit_type: 'outcome'}), {:remote => true, 'data-toggle' =>  "modal", 'data-target' => '#modal_popup'}) if @editMe %>
-               <% end %>
-             </div></div>
-      <%  end
-        end
-      end %>
+      <% @detail_headers.each do |h| %>
+        <% rec = parents_by_depth[h[:depth]] %>
+        <% if rec %>
+          <div class='row subject-<%= h[:name] %>-row'>
+            <div class='col col-lg-6 text-left'>
+              <strong>
+              <%= "#{@subjectByCode[tree.subject.code][:name] if h[:depth] == 0 }#{" #{@hierarchies[h[:depth]]} #{rec.codeArray.last}:" if h[:depth] > 0}" %>
+              <% if h[:depth] > 0 %>
+                </strong>
+              <% end %>
+              <%= @translations[rec.buildNameKey] %>
+              <% if h[:depth] == 0 %>
+                </strong>
+              <% end %>
+              <% if h[:depth] == @treeTypeRec[:outcome_depth] %>
+                <%= link_to(fa_icon("edit"), edit_tree_path(@tree.id, tree: { edit_type: 'outcome'}), {:remote => true, 'data-toggle' =>  "modal", 'data-target' => '#modal_popup'}) if @editMe %>
+              <% end %>
+            </div>
+          </div>
+        <% end #if rec %>
+      <% end #@detail_headers.each_with_index do |h, i| %>
 
       <div class='col col-lg-12 text-right'>
           <% if @editMe %>

--- a/app/views/trees/show/_connect_detail.html.erb
+++ b/app/views/trees/show/_connect_detail.html.erb
@@ -31,12 +31,6 @@
               <%= I18n.t('app.labels.description') %>
             </div>
           </div>
-          <div class='connections-header'>
-            <div class='center-label sub-header-margin'>
-              <%= I18n.t('trees.labels.how_outcome_related') %>
-            </div>
-          </div>
-
         </div>
         <div class='connections-grid'>
           <% @relatedBySubj.each do |subj, rel|%>
@@ -45,7 +39,7 @@
                 <%= r[:relationship] %>
               </div>
               <div class='connections-item'>
-                <%= I18n.t("trees.labels.#{subj}") %>
+                <%= r[:subj] %>
               </div>
               <div class='connections-item'>
                 <%= r[:code] %>
@@ -56,9 +50,6 @@
                 <% else %>
                   <a href='/<%= @locale_code %>/trees/<%= r[:tid] %>'><%= @translations[r[:tkey]] %></a>
                 <% end %>
-              </div>
-              <div class='connections-item'>
-                <%= @translations[r[:explanation]] %>
                 <% if @editMe %>
                   <%= link_to(fa_icon("times"), tree_path(@tree.id, tree: { edit_type: 'treetree', attr_id: r[:ttid], active: false}, tree_tree: {active: false}), {:class => "fa-lg pull-right", 'data-confirm' => I18n.t('app.labels.confirm_deactivate', item: I18n.t("trees.labels.#{subj}") + ": " + r[:code]), method: :patch}) if @editMe %>
                   <%= link_to(fa_icon("edit"), edit_tree_path(@tree.id, tree: { edit_type: 'treetree', attr_id: r[:ttid]}), {:remote => true, :class => "fa-lg pull-right", 'data-toggle' =>  "modal", 'data-target' => '#modal_popup'}) if @editMe %>

--- a/app/views/trees/show/_detail_area.html.erb
+++ b/app/views/trees/show/_detail_area.html.erb
@@ -4,12 +4,6 @@
       <%= detail_title %>
       <%= link_to(fa_icon("plus-square"), edit_tree_path(@tree.id, tree: { edit_type: 'sector', attr_id: 'new'}), {:remote => true, :class => "fa-lg pull-right", 'data-toggle' =>  "modal", 'data-target' => '#modal_popup'}) if @editMe && sector %>
     </div>
-    <div class='col col-lg-6 rel-reason-col center-label'>
-              <%= detail_title.singularize %>
-    </div>
-    <div class='col col-lg-6 rel-reason-col center-label'>
-      <%= expl_header %>
-    </div>
   </div>
   <% details.each do |dt| %>
   <!-- Dimensions Table (e.g., misconceptions, etc) -->
@@ -19,14 +13,10 @@
     if d.dim_type == dim_type
     %>
     <div class='row'>
-      <div class='col col-lg-6 rel-sectors'>
+      <div class='col col-lg-12 rel-sectors'>
         <%= @translations[d.dim_name_key] %>
-      </div>
-      <div class='col col-lg-6 ind-col last-col'>
-        <%= @translations[dt.dim_explanation_key] %>
         <% if @editMe %>
         <%= link_to(fa_icon("times"), tree_path(@tree.id, tree: { edit_type: 'dimtree', attr_id: dt[:id], active: false}, sector_tree: {active: false}), {:class => "fa-lg pull-right", 'data-confirm' => I18n.t('app.labels.confirm_deactivate', item: @translations[d.dim_name_key]), method: :patch}) if @editMe %>
-        <%= link_to(fa_icon("edit"), edit_tree_path(@tree.id, tree: { edit_type: 'dimtree', attr_id: dt[:id]}), {:remote => true, :class => "fa-lg pull-right", 'data-toggle' =>  "modal", 'data-target' => '#modal_popup'}) if @editMe %>
         <% end #if @editMe %>
       </div>
     </div>
@@ -36,7 +26,7 @@
     st = dt
   %>
     <div class='row'>
-    <div class='col col-lg-6 rel-sectors'>
+    <div class='col col-lg-12 rel-sectors'>
       <%= link_to(
         "#{@translations[st.sector.name_key]}",
         sectors_path(
@@ -50,12 +40,8 @@
         ),
         html_options = {data: { :sector => st.sector.id }}
       ) %>
-    </div>
-    <div class='col col-lg-6 rel-reason-col val'>
-      <%= @translations["#{st.explanation_key}"] %>
       <% if @editMe %>
         <%= link_to(fa_icon("times"), tree_path(@tree.id, tree: { edit_type: 'sector', attr_id: st[:id], active: false}, sector_tree: {active: false}), {:class => "fa-lg pull-right", 'data-confirm' => I18n.t('app.labels.confirm_deactivate', item: @translations[st.sector.name_key]), method: :patch}) if @editMe %>
-        <%= link_to(fa_icon("edit"), edit_tree_path(@tree.id, tree: { edit_type: 'sector', attr_id: st[:id]}), {:remote => true, :class => "fa-lg pull-right", 'data-toggle' =>  "modal", 'data-target' => '#modal_popup'}) if @editMe %>
       <% end %>
     </div>
   </div>

--- a/config/locales/pages.en.yml
+++ b/config/locales/pages.en.yml
@@ -55,6 +55,7 @@ en:
       show: "Show"
       working_version: "Working"
       final_version: "Final"
+      connect_form_title: "Save Connection?"
     roles:
       name: 'Roles'
       admin:
@@ -201,12 +202,12 @@ en:
       how_sectors_related: 'How Sector is Related'
       indicator_connections: 'Connections to Other Explanations:'
       outcome_connections: 'Connections to Other %{outcome}:'
-      relation: 'Relation'
+      relation: 'Connection'
       how_outcome_related: 'How Attainment is Related'
       relation_types:
         applies: 'Applies to:'
         depends: 'Depends on:'
-        akin: 'Akin to:'
+        akin: 'Connects to:'
       current_subject: "This Subject"
       bio: "Biology"
       che: "Chemistry"

--- a/lib/tasks/dimensions.rake
+++ b/lib/tasks/dimensions.rake
@@ -37,4 +37,28 @@ namespace :dimensions do
 
   end #task set_subject_codes: :environment do
 
+
+  desc "Delete all Dimensions, DimTrees, and their associated Translations"
+  task destroy_all: :environment do
+    dim_trees = DimTree.all
+    dims = Dimension.all
+    dim_trees.each do |dt|
+      t = dt.tree.base_key
+      d = dt.dimension
+      key = DimTree.getDimExplanationKey(t, d.dim_type, d.id)
+      puts "Deleting DimTree Translation: #{key}"
+      Translation.where(:key => key).delete_all
+    end
+    dims.each do |d|
+      puts "Deleting Dim Name Translation: #{d.get_dim_name_key}"
+      Translation.where(:key => d.get_dim_name_key).delete_all
+      puts "Deleting Dim Desc Translation: #{d.get_dim_desc_key}"
+      Translation.where(:key => d.get_dim_desc_key).delete_all
+    end
+     puts "Deleting all DimTree records"
+     dim_trees.delete_all
+     puts "Deleting all Dimension records"
+     dims.delete_all
+  end # task destroy_all
+
 end

--- a/lib/tasks/seed_turkey_v02a.rake
+++ b/lib/tasks/seed_turkey_v02a.rake
@@ -31,8 +31,8 @@ namespace :seed_turkey_v02a do
       big_ideas_dim_type: 'bigidea',
       ess_q_dim_type: 'essq',
       tree_code_format: 'grade,unit,sub_unit,comp',
-      detail_headers: 'grade,unit,(sub_unit),comp,[bigidea],[ess_q],{explain},[miscon],[sector],[connect],[refs]',
-      grid_headers: 'grade,unit,(sub_unit),comp,[bigidea],[ess_q],explain,[miscon],[connect],[refs]'
+      detail_headers: 'grade,unit,(sub_unit),comp,[ess_q],[bigidea],{explain},[miscon],[sector],[connect],[refs]',
+      grid_headers: 'grade,unit,(sub_unit),comp,[ess_q],[bigidea],explain,[miscon],[connect],[refs]'
     }
     if myTreeType.count < 1
       raise 'Missing Tree Type record for tfv v02'

--- a/lib/tasks/seed_turkey_v02a.rake
+++ b/lib/tasks/seed_turkey_v02a.rake
@@ -58,23 +58,23 @@ namespace :seed_turkey_v02a do
     throw "ERROR updating sector translation: #{message}" if status == BaseRec::REC_ERROR
     STDOUT.puts 'Create translation record for Sub-Unit.'
 
-    STDOUT.puts 'Create all Outcome records for all tree records at the outcome level.'
-    Tree.all.each do |t|
-      tt = t.tree_type
-      if tt.outcome_depth > 0
-        # Tree model overrides the depth field. Returns the length of the code.
-        if t.depth == tt.outcome_depth + 1 && !t.outcome_id.present?
-          puts "try to save outcome for #{t.code}"
-          out = Outcome.new()
-          out.base_key = out.get_base_key(t.base_key)
-          out.save
-          t.outcome_id = out.id
-          t.save
-          puts "saved outcome for #{t.code}"
-        end
-      end
-    end
-    STDOUT.puts 'Done: Outcome records for all tree records at the outcome level have been created.'
+    # STDOUT.puts 'Create all Outcome records for all tree records at the outcome level.'
+    # Tree.all.each do |t|
+    #   tt = t.tree_type
+    #   if tt.outcome_depth > 0
+    #     # Tree model overrides the depth field. Returns the length of the code.
+    #     if t.depth == tt.outcome_depth + 1 && !t.outcome_id.present?
+    #       puts "try to save outcome for #{t.code}"
+    #       out = Outcome.new()
+    #       out.base_key = out.get_base_key(t.base_key)
+    #       out.save
+    #       t.outcome_id = out.id
+    #       t.save
+    #       puts "saved outcome for #{t.code}"
+    #     end
+    #   end
+    # end
+    # STDOUT.puts 'Done: Outcome records for all tree records at the outcome level have been created.'
 
     # Tree.joins(:outcome).where(:tree_type_id => 2).each do |t|
     #   old_name_key = t.buildNameKey

--- a/lib/tasks/seed_turkey_v02b.rake
+++ b/lib/tasks/seed_turkey_v02b.rake
@@ -55,7 +55,8 @@ namespace :seed_turkey_v02b do
         max_grade: 12
       )
     end
-    Translation.find_or_update_translation(@loc_en.code, 'subject.tfv.tech', 'Tech Engineering')
+    Translation.find_or_update_translation(@loc_en.code, 'subject.tfv.tech.name', 'Tech Engineering')
+    Translation.find_or_update_translation(@loc_en.code, 'subject.tfv.tech.abbr', 'Tech')
     Translation.find_or_update_translation(@loc_en.code, 'subject.base.tech.name', 'Tech Engineering')
     Translation.find_or_update_translation(@loc_en.code, 'subject.base.tech.abbr', 'tech')
 


### PR DESCRIPTION
- Remove references to "reason for"/explanations of connections from the app. 
- On the tree detail page, show K-12 Big Ideas before Specific Big Ideas
- implement dynamic ordering for header fields on Tree detail page (using the detail_headers string stored in the TreeType record)
- Prepared a rake task, `dimensions:destroy_all`, to clear Dimensions, dim trees and their translations from the db. 
- In uploads_controller, update @currentDims hash to list dimension data by dimtype, then translation
- The upload process now updates the Subject min_grade and max_grade.
- document translation keys associated with gradeband, sector, sector_tree, subject, tree, and tree_type in their respective models