### PR TITLE
Format Tree Codes

### DIFF
--- a/app/controllers/tree_trees_controller.rb
+++ b/app/controllers/tree_trees_controller.rb
@@ -10,7 +10,7 @@ class TreeTreesController < ApplicationController
 
     #Check whether a tree_tree for this relationship already exists.
     tree_tree_matches = TreeTree.where(
-      :tree_referencer_id => tree_tree_params[:tree_referencer_id], 
+      :tree_referencer_id => tree_tree_params[:tree_referencer_id],
       :tree_referencee_id => tree_tree_params[:tree_referencee_id])
 
     if errors.length == 0 && tree_tree_matches.length == 0
@@ -32,7 +32,7 @@ class TreeTreesController < ApplicationController
     end
     if errors.length == 0 && tree_tree_matches.length == 0
       respond_to do |format|
-        format.json {render json: { 
+        format.json {render json: {
           :tree_tree => @tree_tree,
           :referencer_code => referencer_subject_translation + " " + @referencer.code,
           :referencee_code => referencee_subject_translation + " " + @referencee.code,
@@ -52,7 +52,7 @@ class TreeTreesController < ApplicationController
         }}
       end
     #If a tree_tree for this relationship already exists,
-    #redirect to the edit path for that record. 
+    #redirect to the edit path for that record.
     elsif tree_tree_matches.length > 0
       redirect_to edit_tree_tree_path(tree_tree_matches.first)
     else
@@ -62,7 +62,7 @@ class TreeTreesController < ApplicationController
     end
   end
 
-  def edit 
+  def edit
     @referencer = @tree_tree.tree_referencer
     @referencee = @tree_tree.tree_referencee
     referencer_subject_translation = Translation.where(
@@ -75,12 +75,12 @@ class TreeTreesController < ApplicationController
       ).first.value
     explanation = @explanation_translation.value if @explanation_translation
     respond_to do |format|
-        format.json {render json: { 
+        format.json {render json: {
         :tree_tree => @tree_tree,
         :referencer_code => referencer_subject_translation + " " + @referencer.code,
         :referencee_code => referencee_subject_translation + " " + @referencee.code,
         :translations => {
-          :modal_title => translate('trees.labels.outcome_connections'),            
+          :modal_title => translate('trees.labels.outcome_connections'),
           :explanation_label => translate('tree_trees.labels.explanation'),
           :explanation => explanation || '',
           :relationship => I18n.translate('trees.labels.relation'),
@@ -96,17 +96,17 @@ class TreeTreesController < ApplicationController
       }}
     end
   end
- 
+
 
   def create
     errors = []
     if TreeTree.where(
-      :tree_referencer_id => tree_tree_params[:tree_referencer_id], 
+      :tree_referencer_id => tree_tree_params[:tree_referencer_id],
       :tree_referencee_id => tree_tree_params[:tree_referencee_id]).length > 0
       errors << "Relationship already exits."
     end
     if errors.length == 0 && TreeTree.where(
-      :tree_referencee_id => tree_tree_params[:tree_referencer_id], 
+      :tree_referencee_id => tree_tree_params[:tree_referencer_id],
       :tree_referencer_id => tree_tree_params[:tree_referencee_id]).length > 0
       errors << "Relationship already exits."
     end
@@ -118,23 +118,23 @@ class TreeTreesController < ApplicationController
       @explanation = tree_tree_params[:explanation]
       explanation_key = @treeTypeRec.code + "." + @versionRec.code + "." + @referencer.subject.code + "." + @referencer.code + ".tree." + @referencee.id.to_s
       @tree_tree = TreeTree.new(
-        :tree_referencer_id => tree_tree_params[:tree_referencer_id], 
+        :tree_referencer_id => tree_tree_params[:tree_referencer_id],
         :tree_referencee_id => tree_tree_params[:tree_referencee_id],
         :relationship => tree_tree_params[:relationship],
         :explanation_key => explanation_key
         )
-       
+
        #reciprocal_explanation_key = @treeTypeRec.code + "." + @versionRec.code + "." + @referencee.subject.code + "." + @referencee.code + ".tree." + @referencer.id.to_s
       @reciprocal_tree_tree = TreeTree.new(
-        :tree_referencer_id => tree_tree_params[:tree_referencee_id], 
+        :tree_referencer_id => tree_tree_params[:tree_referencee_id],
         :tree_referencee_id => tree_tree_params[:tree_referencer_id],
         :relationship => TreeTree.reciprocal_relationship(:"#{tree_tree_params[:relationship]}"),
         :explanation_key => explanation_key
         )
 
-      @explanation_translation = Translation.where(:locale => @locale_code, 
+      @explanation_translation = Translation.where(:locale => @locale_code,
         :key => explanation_key)
-      # @reciprocal_explanation_translation = Translation.where(:locale => @locale_code, 
+      # @reciprocal_explanation_translation = Translation.where(:locale => @locale_code,
       #   :key => reciprocal_explanation_key)
 
       if @explanation_translation.empty?
@@ -175,20 +175,20 @@ class TreeTreesController < ApplicationController
     puts "params: #{params}"
     errors = []
     notices = []
-    if @tree_tree.active.to_s != tree_tree_params[:active] 
-      n = (tree_tree_params[:active] == 'true' ? "Activated" : "Deactivated") 
-      n += " " + @tree_tree.tree_referencer.subject.code + "." + 
-      @tree_tree.tree_referencer.code + " to " + 
-      @tree_tree.tree_referencee.subject.code + "." + 
+    if @tree_tree.active.to_s != tree_tree_params[:active]
+      n = (tree_tree_params[:active] == 'true' ? "Activated" : "Deactivated")
+      n += " " + @tree_tree.tree_referencer.subject.code + "." +
+      @tree_tree.tree_referencer.code + " to " +
+      @tree_tree.tree_referencee.subject.code + "." +
       @tree_tree.tree_referencee.code + " connection."
       notices << n
-    end  
-    #TreeTree records should be created with an explanation_key, but since this 
-    #column is not currently reqired, if @tree_tree is lacking an explanation_key for 
+    end
+    #TreeTree records should be created with an explanation_key, but since this
+    #column is not currently reqired, if @tree_tree is lacking an explanation_key for
     #some reason, build it:
-    explanation_key = @treeTypeRec.code + "." + @versionRec.code 
-      + "." + @tree_tree.tree_referencer.subject.code + "." 
-      + @tree_tree.tree_referencer.code + ".tree." 
+    explanation_key = @treeTypeRec.code + "." + @versionRec.code
+      + "." + @tree_tree.tree_referencer.subject.code + "."
+      + @tree_tree.tree_referencer.code + ".tree."
       + @tree_tree.tree_referencee.id.to_s if !@tree_tree[:explanation_key]
     #Otherwise use the explanation_key saved in @tree_tree.
     #note: @tree_tree and @reciprocal_tree_tree should share an explanation_key
@@ -196,25 +196,25 @@ class TreeTreesController < ApplicationController
 
   ###################################
   # Set Values to Update in @tree_tree,
-  # @reciprocal_tree_tree, and 
+  # @reciprocal_tree_tree, and
   # @explanation_translation
   ###################################
-    
+
     @tree_tree.relationship = tree_tree_params[:relationship] if tree_tree_params[:relationship]
 
-    #active status must be set to @reciprocal_tree_tree as well, 
+    #active status must be set to @reciprocal_tree_tree as well,
     #once it's existence is ensured
-    @tree_tree.active = tree_tree_params[:active] if (tree_tree_params[:active] != nil) 
-    puts "+++++++++Should update active" if (tree_tree_params[:active] != nil) 
-    #find and edit reciprocal TreeTree, if found, 
+    @tree_tree.active = tree_tree_params[:active] if (tree_tree_params[:active] != nil)
+    puts "+++++++++Should update active" if (tree_tree_params[:active] != nil)
+    #find and edit reciprocal TreeTree, if found,
     #or create and edit if not found.
-    #Expect reciprocal TreeTree to exist, and flash a notificaiton if 
+    #Expect reciprocal TreeTree to exist, and flash a notificaiton if
     #it does not.
     if @reciprocal_tree_tree
       @reciprocal_tree_tree.relationship = TreeTree.reciprocal_relationship(:"#{tree_tree_params[:relationship]}") if tree_tree_params[:relationship]
     else
       @reciprocal_tree_tree = TreeTree.new(
-        :tree_referencer_id => @tree_tree[:tree_referencee_id], 
+        :tree_referencer_id => @tree_tree[:tree_referencee_id],
         :tree_referencee_id => @tree_tree[:tree_referencer_id],
         :relationship => TreeTree.reciprocal_relationship(:"#{tree_tree_params[:relationship]}"),
         :explanation_key => explanation_key
@@ -226,11 +226,11 @@ class TreeTreesController < ApplicationController
     @reciprocal_tree_tree.active = tree_tree_params[:active] if (tree_tree_params[:active] != nil)
 
     #Find and set explanation translations in the controller,
-    #or create and set a new explanation translation if one is 
+    #or create and set a new explanation translation if one is
     #not found.
-    #Expect explanation translations not to exist for some 
-    #existing TreeTree connections: 
-    #e.g., if the locale for this update does not match 
+    #Expect explanation translations not to exist for some
+    #existing TreeTree connections:
+    #e.g., if the locale for this update does not match
     #the locale in which the TreeTree was originally created.
     if @explanation_translation
       @explanation_translation.value = tree_tree_params[:explanation] if tree_tree_params[:explanation]
@@ -251,7 +251,7 @@ class TreeTreesController < ApplicationController
         errors << e
       end
     end
-    
+
     if errors.length > 0
       flash[:alert] = "Errors prevented the connection from being updated: #{errors.to_s}"
     else
@@ -288,14 +288,14 @@ class TreeTreesController < ApplicationController
     if @tree_tree
       @reciprocal_tree_tree = TreeTree.where(
         :tree_referencer_id => @tree_tree[:tree_referencee_id],
-        :tree_referencee_id => @tree_tree[:tree_referencer_id]).first 
+        :tree_referencee_id => @tree_tree[:tree_referencer_id]).first
     else
       @reciprocal_tree_tree = nil
     end
   end
 
   # Sets @explanation_translation to a string or nil
-  def set_explanation_translation 
+  def set_explanation_translation
     if @tree_tree
       @explanation_translation = Translation.where(
         :locale => @locale_code,

--- a/app/controllers/trees_controller.rb
+++ b/app/controllers/trees_controller.rb
@@ -234,10 +234,10 @@ class TreesController < ApplicationController
         subj_code: tree.subject.code,
         gb_code: tree.grade_band.code,
         code: tree.code,
-        last_code: tree.codeArrayAt(tree.depth-1),
+        formatted_code: tree.outcome ? tree.format_code(@locale_code) : tree.codeArray.last,
         selectors_by_parent: tree.parentCodes.map { |pc| "child-of-#{pc.split(".").join("-")}" if pc != "" }.join(" "),
         depth_name: @hierarchies[tree.depth-1],
-        text: "#{tree.code}: #{translation}",
+        text: "#{translation}",
         dimtrees: @dimtrees_by_tree_id[tree.id]
         #connections: @relations[tree.id]
       }
@@ -266,7 +266,7 @@ class TreesController < ApplicationController
       # display a success notice about an action performed
       # on a different version of the curriculum.
     end
-    flash[:notice] = I18n.translate("app.notice.saved_relationship", item_type_1: @hierarchies[@treeTypeRec.outcome_depth], item_desc_1: saved_dim_tree.tree.code, item_type_2: translate('nav_bar.'+saved_dim_tree.dimension.dim_type+'.name').singularize, item_desc_2: "\"#{@translations[saved_dim_tree.dimension.dim_name_key]}\"") if saved_dim_tree
+    flash[:notice] = I18n.translate("app.notice.saved_relationship", item_type_1: @hierarchies[@treeTypeRec.outcome_depth], item_desc_1: saved_dim_tree.tree.format_code(@locale_code), item_type_2: translate('nav_bar.'+saved_dim_tree.dimension.dim_type+'.name').singularize, item_desc_2: "\"#{@translations[saved_dim_tree.dimension.dim_name_key]}\"") if saved_dim_tree
 
     respond_to do |format|
       format.html { render 'maint'}
@@ -365,7 +365,7 @@ class TreesController < ApplicationController
         tcode = tree.subject.code + tree.code.split('.').join('')
         newHash = {
           code: tcode,
-          text: "#{tree.code}: #{translation}",
+          text: "#{tree.format_code(@locale_code)}: #{translation}",
           id: "#{tree.id}",
           gb_code: tree.grade_band.code,
           connections: @relations[tree.id]
@@ -618,7 +618,7 @@ class TreesController < ApplicationController
           tcode = tree.subject.code + tree.code.split('.').join('')
           newHash = {
             code: tcode,
-            text: "#{tree.code}: #{translation}",
+            text: "#{tree.format_code(@locale_code)}: #{translation}",
             id: "#{tree.id}",
             gb_code: tree.grade_band.code,
             rel: @relations["tree_id_#{tree.id}"]
@@ -819,7 +819,7 @@ class TreesController < ApplicationController
           treeKeys << r.explanation_key
           subCode = @subjById[rTree.subject_id]
           @relatedBySubj[subCode] << {
-            code: rTree.code,
+            code: rTree.format_code(@locale_code),
             relationship: I18n.translate("trees.labels.relation_types.#{r.relationship}"),
             tkey: rTree.buildNameKey,
             subj: rTree.subject.get_name(@locale_code),

--- a/app/models/subject.rb
+++ b/app/models/subject.rb
@@ -10,9 +10,22 @@ class Subject < BaseRec
     return "subject.#{treeTypeRec.code}.#{code}.name"
   end
 
+  # The TreeType-specific Translation key for a Subject
+  def versioned_abbr_key
+    treeTypeRec = TreeType.find(tree_type_id)
+    return "subject.#{treeTypeRec.code}.#{code}.abbr"
+  end
+
   # The default Translation key for BaseRec subjects
+  # To Do: migrate to use subject.default.#{code}.name
   def self.name_translation_key(code)
     return "subject.base.#{code}.name"
+  end
+
+  # The default Translation key for BaseRec subjects
+  # To Do: migrate to use subject.default.#{code}.name
+  def self.default_abbr_key(code)
+    return "subject.base.#{code}.abbr"
   end
 
   def get_name(locale_code)
@@ -27,6 +40,17 @@ class Subject < BaseRec
       )
   end
 
+  def get_abbr(locale_code)
+    return Translation.find_translation_name(
+        locale_code,
+        versioned_abbr_key,
+        nil
+      ) || Translation.find_translation_name(
+        locale_code,
+        Subject.default_abbr_key(code),
+        ""
+      )
+  end
   ########################################
 
   def abbr(loc)

--- a/app/models/tree.rb
+++ b/app/models/tree.rb
@@ -55,6 +55,8 @@ class Tree < BaseRec
   scope :not_blank, -> { where.not(:base_key => ["", nil]) }
   scope :active, -> { not_blank.where(:active => true) }
 
+
+###################################################
   # Field Translations
 
   # overrides of deprecated name_key field
@@ -84,6 +86,27 @@ class Tree < BaseRec
     return "#{self.tree_type.code}.#{self.version.code}.#{self.subject.code}.#{self.grade_band.code}"
   end
   ####################################################
+  def format_code(localeCode)
+    hierarchies = tree_type.hierarchy_codes.split(",")
+    if tree_type.tree_code_format != ""
+      format_str = tree_type.tree_code_format
+    else
+      format_str = "subject,#{tree_type.hierarchy_codes}"
+    end
+    format_arr = []
+    hierarchic_arr = code.split('.').map {|c| c == "" ? 0 : c }
+    format_str.split(",").each do |c|
+      if c == "subject"
+        format_arr << subject.get_abbr(localeCode).downcase
+      else
+        c_index = hierarchies.index(c)
+        format_arr << hierarchic_arr[c_index] if hierarchic_arr[c_index]
+      end
+    end
+
+    return format_arr.join(".")
+  end
+
   def code_by_ix(ix)
     if depth == 3
       if self.matching_codes.length > ix

--- a/app/views/trees/_edit_dimensions.html.erb
+++ b/app/views/trees/_edit_dimensions.html.erb
@@ -31,7 +31,7 @@
 
   <fieldset>
     <div>
-    <div><strong><%= @hierarchies[ @tree.depth - 1] + ": " %></strong><%= @tree_subject_translation + " " + @tree.code %></div>
+    <div><strong><%= @hierarchies[ @tree.depth - 1] + ": " %></strong><%= @tree.format_code(@locale_code) %></div>
     <div><strong> - <%= translate('trees.bigidea.relates_to') %> - </strong></div>
     <div><strong><%= Dimension.get_dim_type_name(@dim.dim_type, @treeTypeRec.code, @versionRec.code, @locale_code) + ": " %></strong><%= @dimension_translation %></div>
     </div>

--- a/app/views/trees/maint.html.erb
+++ b/app/views/trees/maint.html.erb
@@ -56,7 +56,9 @@
              misc_found = 0
            %>
           <li id="<%= h[:subj_code] %>_lo_<%= h[:id] %>" class="maint-item indent-3 <%= h[:selectors_by_parent] %> list-group-item" data-loid="<%= h[:id] %>">
-            <a href="<%= tree_path(h[:id])%>" title="<%= h[:text] %>"><%= h[:depth_name] %>: <%= h[:last_code] %></a>
+            <a href="<%= tree_path(h[:id])%>" title="<%= h[:text] %>"><%= h[:depth_name] %>:
+            <strong><em><%= h[:formatted_code] %></strong>
+            </a>
             <%= h[:text] %>
             <% if h[:dimtrees].length > 0 %>
             <% h[:dimtrees].each do |dt|
@@ -109,7 +111,7 @@
               <a class="" onclick="toggle_visibility('.child-of-<%= code.split(".").join("-") %>', '#trigger-<%= code.split(".").join("-") %>')">
                 <i id="trigger-<%= code.split(".").join("-") %>" class="fa fa-compress pull-left option-selected link-blue accordion" title="collapse"></i>
               </a>
-              <%= h[:depth_name] %>: <%= h[:text] %>
+              <%= "#{h[:depth_name]} #{h[:formatted_code]}#{": #{h[:text]}" if h[:depth] > 1}" %>
             </li>
           <% end %>
         <% end %>

--- a/app/views/trees/maint.html.erb
+++ b/app/views/trees/maint.html.erb
@@ -57,7 +57,7 @@
            %>
           <li id="<%= h[:subj_code] %>_lo_<%= h[:id] %>" class="maint-item indent-3 <%= h[:selectors_by_parent] %> list-group-item" data-loid="<%= h[:id] %>">
             <a href="<%= tree_path(h[:id])%>" title="<%= h[:text] %>"><%= h[:depth_name] %>:
-            <strong><em><%= h[:formatted_code] %></strong>
+            <strong><em><%= h[:formatted_code] %></em></strong>
             </a>
             <%= h[:text] %>
             <% if h[:dimtrees].length > 0 %>

--- a/app/views/trees/sequence.html.erb
+++ b/app/views/trees/sequence.html.erb
@@ -102,8 +102,8 @@
                       </a>
                       <% end %>
                       <div class="relationship-color-key spotlight-<%= c.relationship %>"></div>
-                      <strong><%= translate('trees.labels.relation_types.' + c.relationship) %></strong>
-                      <% ref = c.tree_referencee.subject.code + '.' + c.tree_referencee[:code] %>
+                      <strong><%= translate("trees.labels.relation_types.#{c.relationship}") %></strong>
+                      <% ref = c.tree_referencee.format_code(@locale_code) %>
                       <a href="<%= tree_path(c.tree_referencee_id)%>"
                       title= "<%= @translations[c.explanation_key] %>"><%= ref %></a>
                     </div>

--- a/lib/tasks/seed_turkey_v02a.rake
+++ b/lib/tasks/seed_turkey_v02a.rake
@@ -30,7 +30,7 @@ namespace :seed_turkey_v02a do
       miscon_dim_type: 'miscon',
       big_ideas_dim_type: 'bigidea',
       ess_q_dim_type: 'essq',
-      tree_code_format: 'grade,unit,sub_unit,comp',
+      tree_code_format: 'subject,grade,unit,sub_unit,comp',
       detail_headers: 'grade,unit,(sub_unit),comp,[ess_q],[bigidea],{explain},[miscon],[sector],[connect],[refs]',
       grid_headers: 'grade,unit,(sub_unit),comp,[ess_q],[bigidea],explain,[miscon],[connect],[refs]'
     }


### PR DESCRIPTION
- adds a new method, `format_code(localeCode)` to the Trees model. 
  - uses TreeType field, 'tree_code_format', to format display of tree code.  
- In the Competencies, Relations, and Show/Detail pages, use `tree.format_code(localeCode)` instead of `tree.code` when displaying tree codes