### PR TITLE
Competencies Grids

### DIFF
--- a/app/assets/javascripts/common.js
+++ b/app/assets/javascripts/common.js
@@ -127,6 +127,24 @@ $(function() {
       });
   };
 
+
+  show_hide_selection = function(selection, show) {
+    if (show) {
+      $(".top-selector" + " i.accordion").addClass("option-selected");
+      $(".top-selector" + " i.accordion").removeClass("fa-expand");
+      $(".top-selector" + " i.accordion").addClass("fa-compress");
+      $(selection).removeClass("hidden");
+      $(selection + " i.accordion").removeClass("fa-expand");
+      $(selection + " i.accordion").addClass("fa-compress");
+    } else {
+      $(".top-selector" + " i.accordion").removeClass("option-selected");
+      $(".top-selector" + " i.accordion").removeClass("fa-compress");
+      $(".top-selector" + " i.accordion").addClass("fa-expand");
+      $(selection).addClass("hidden");
+      $(selection + " i.accordion").removeClass("fa-compress");
+      $(selection + " i.accordion").addClass("fa-expand");
+    }
+  };
   //###################################
   //# ADD EVENT BINDINGS
 

--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -85,6 +85,10 @@ body {
   .left-justify {
     text-align: left;
   }
+
+  .right-margin {
+    margin-right: 5px;
+  }
 }
 
 // use font awesome fonts for glyphicon classes (for bootstrap 3 treeview library)

--- a/app/assets/stylesheets/trees.scss
+++ b/app/assets/stylesheets/trees.scss
@@ -257,6 +257,7 @@
       border-bottom: 0px solid black;
       border-left: 1px solid black;
     }
+
     .center-label-bold {
       background-color: #ddd;
       text-align: center !important;
@@ -275,6 +276,7 @@
       border: 0px;
       text-align: left;
     }
+
     .ind-col {
       text-align: left;
       border-left: 1px solid black;
@@ -346,6 +348,31 @@
 
   .related-items-table {
     word-wrap: break-word;
+  }
+
+  .maint-column {
+    .top-label {
+      margin-top: 10px;
+      text-decoration: underline;
+      font-weight: bold;
+    }
+
+    .related-items-table {
+      border: none;
+      text-align: left;
+      padding-left: 10px;
+      margin-bottom: 5px;
+      .col {
+        border-radius: 10px;
+        background-color: #eeeeee;
+        margin-left: 5px;
+        margin-top: 5px;
+        hr {
+          border-top: 1px solid black;
+          margin: 2px;
+        }
+      }
+    }
   }
 
   @media only screen and (max-width: 767px) {

--- a/app/assets/stylesheets/trees.scss
+++ b/app/assets/stylesheets/trees.scss
@@ -372,6 +372,9 @@
           margin: 2px;
         }
       }
+      .comp-col.col {
+        background-color: white;
+      }
     }
   }
 

--- a/app/assets/stylesheets/trees.scss
+++ b/app/assets/stylesheets/trees.scss
@@ -320,7 +320,7 @@
     }
     .connections-grid {
       display: grid;
-      grid-template-columns: 10% 15% 8% 67%;
+      grid-template-columns: 10% 10% 13% 67%;
       margin-left: -15px;
       margin-right: -15px;
       border-top: 1px solid black;

--- a/app/controllers/trees_controller.rb
+++ b/app/controllers/trees_controller.rb
@@ -231,6 +231,11 @@ class TreesController < ApplicationController
       @translations[tkey] = tkeyTrans
       selectors_by_parent = tree.parentCodes.map { |pc| "child-of-#{pc.split(".").join("-")}" if pc != "" }
       selectors_by_parent = selectors_by_parent.length > 1 ? "collapsable " + selectors_by_parent.join(" ") : "top-selector" + selectors_by_parent.join(" ")
+      explanation = tree.outcome ? Translation.find_translation_name(
+          @locale_code,
+          tree.outcome.get_explain_key,
+          nil
+        ) : nil
       newHash = {
         id: tree.id,
         depth: tree.depth,
@@ -242,6 +247,7 @@ class TreesController < ApplicationController
         selectors_by_parent: selectors_by_parent,
         depth_name: @hierarchies[tree.depth-1],
         text: "#{translation}",
+        explanation: explanation,
         dimtrees: @dimtrees_by_tree_id[tree.id]
         #connections: @relations[tree.id]
       }

--- a/app/controllers/trees_controller.rb
+++ b/app/controllers/trees_controller.rb
@@ -229,6 +229,8 @@ class TreesController < ApplicationController
       end
       tkeyTrans += Translation.find_translation_name(@locale_code, 'subject.'+tree.tree_type.code+'.'+ tree.subject.code+ '.name', 'Missing Subject Name') + ' - ' + Translation.find_translation_name(@locale_code, 'grades.'+tree.tree_type.code+'.'+ tree.grade_band.code+ '.name', 'Missing Grade Name')
       @translations[tkey] = tkeyTrans
+      selectors_by_parent = tree.parentCodes.map { |pc| "child-of-#{pc.split(".").join("-")}" if pc != "" }
+      selectors_by_parent = selectors_by_parent.length > 1 ? "collapsable " + selectors_by_parent.join(" ") : "top-selector" + selectors_by_parent.join(" ")
       newHash = {
         id: tree.id,
         depth: tree.depth,
@@ -237,7 +239,7 @@ class TreesController < ApplicationController
         gb_code: tree.grade_band.code,
         code: tree.code,
         formatted_code: tree.outcome ? tree.format_code(@locale_code) : tree.codeArray.last,
-        selectors_by_parent: tree.parentCodes.map { |pc| "child-of-#{pc.split(".").join("-")}" if pc != "" }.join(" "),
+        selectors_by_parent: selectors_by_parent,
         depth_name: @hierarchies[tree.depth-1],
         text: "#{translation}",
         dimtrees: @dimtrees_by_tree_id[tree.id]

--- a/app/controllers/trees_controller.rb
+++ b/app/controllers/trees_controller.rb
@@ -197,6 +197,8 @@ class TreesController < ApplicationController
 
     treePrep
     dimPrep
+    #To Do: Remove Alt Flag when design is finalized
+    @use_alt_partial = params[:alt]
     @editing = params[:editme] && current_user.present? && current_user.is_admin?
     @dim_type = dim_tree_params && dim_tree_params[:dim_type] ? dim_tree_params[:dim_type] : nil
     @page_title = @editing ? translate('trees.maint.title') : (@dim_type ? (Translation.find_translation_name(@locale_code, Dimension.get_dim_type_key(@dim_type, @treeTypeRec.code, @versionRec.code), nil) || translate('nav_bar.'+@dim_type+'.name')) : @hierarchies[@treeTypeRec.outcome_depth].pluralize )

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -90,24 +90,6 @@
       </li>
     <%
     end
-        if controller.controller_name == 'trees'  && action_name == 'dimensions' && params[:dim_type] == @treeTypeRec.big_ideas_dim_type && @treeTypeRec.big_ideas_dim_type %>
-      <li class="nav-item active" aria-selected='true'>
-        <a class="nav-link btn btn-primary" href=<%= maint_trees_path(show_bigidea: true, dim_tree: {dim_type: @treeTypeRec.big_ideas_dim_type}) %>><%= @bigIdeasTitle %></a>
-      </li>
-    <% elsif @treeTypeRec.big_ideas_dim_type %>
-      <li class="nav-item" role='menuitem'>
-        <a class="nav-link btn btn-primary" href=<%= maint_trees_path(show_bigidea: true, dim_tree: {dim_type: @treeTypeRec.big_ideas_dim_type}) %>><%= @bigIdeasTitle %></a>
-      </li>
-    <% end
-    if controller.controller_name == 'trees'  && action_name == 'dimensions' && params[:dim_type] == @treeTypeRec.miscon_dim_type && @treeTypeRec.miscon_dim_type %>
-      <li class="nav-item active" aria-selected='true'>
-        <a class="nav-link btn btn-primary" href=<%= maint_trees_path(show_miscon: true, dim_tree: {dim_type: @treeTypeRec.micon_dim_type}) %>><%= translate('nav_bar.'+@treeTypeRec.miscon_dim_type+'.name') %></a>
-      </li>
-    <% elsif @treeTypeRec.miscon_dim_type %>
-      <li class="nav-item" role='menuitem'>
-        <a class="nav-link btn btn-primary" href=<%= maint_trees_path(show_miscon: true, dim_tree: {dim_type: @treeTypeRec.miscon_dim_type}) %>><%= translate('nav_bar.'+@treeTypeRec.miscon_dim_type+'.name') %></a>
-      </li>
-    <% end
     if controller.controller_name == 'sectors' && action_name == 'index' && !@treeTypeRec.hide_sectors %>
       <li class="nav-item active" aria-selected='true'>
         <a class="nav-link btn btn-primary" href=<%= sectors_path %>><%= @sectorName %></a>
@@ -145,7 +127,13 @@
       </button>
       <ul class="dropdown-menu">
         <li class="nav-item" role='menuitem'>
-        <a class="nav-link btn btn-primary" href="<%= maint_trees_path(show_ess_q: true, dim_tree: {dim_type: @treeTypeRec.ess_q_dim_type}) %>" ><%= essq_name %></a>
+          <a class="nav-link btn btn-primary" href="<%= maint_trees_path(show_ess_q: true, dim_tree: {dim_type: @treeTypeRec.ess_q_dim_type}) %>" ><%= essq_name %></a>
+        </li>
+        <li class="nav-item" role='menuitem'>
+          <a class="nav-link btn btn-primary" href="<%= maint_trees_path(show_bigidea: true, dim_tree: {dim_type: @treeTypeRec.big_ideas_dim_type}) %>" ><%= @bigIdeasTitle %></a>
+        </li>
+        <li class="nav-item" role='menuitem'>
+          <a class="nav-link btn btn-primary" href="<%= maint_trees_path(show_miscon: true, dim_tree: {dim_type: @treeTypeRec.miscon_dim_type}) %>" ><%= translate('nav_bar.'+@treeTypeRec.miscon_dim_type+'.name') %></a>
         </li>
         <li class="nav-item" role='menuitem'>
           <a class="nav-link btn btn-primary" href=<%= sectors_path %>><%= @sectorName %></a>

--- a/app/views/trees/_alt_competency_grids_column.html.erb
+++ b/app/views/trees/_alt_competency_grids_column.html.erb
@@ -16,11 +16,7 @@
          misc_found = 0
        %>
       <li id="<%= h[:subj_code] %>_lo_<%= h[:id] %>" class="maint-item indent-3 <%= h[:selectors_by_parent] %> list-group-item" data-loid="<%= h[:id] %>">
-        <a href="<%= tree_path(h[:id])%>" title="<%= h[:text] %>"><%= h[:depth_name] %>:
-        <strong><em><%= h[:formatted_code] %></em></strong>
-        </a>
-        <%= h[:text] %>
-        <% if h[:dimtrees].length > 0 %>
+        <% if true %>
           <% h[:dimtrees].each do |dt|
              dim = dt.dimension
              if dim.dim_type == @treeTypeRec.ess_q_dim_type
@@ -37,10 +33,16 @@
                 misc_arr << "[#{@translations[miscSubjKey]}] #{@translations[dim.dim_name_key]}"
              end
           end # h[:dimtrees].each do |dt|
-          types_found = 6 - (ess_q_found ? 1 : 0) - (ideas_found ? 1 : 0) - (misc_found ? 1 : 0)
+          types_found = 5 - (ess_q_found ? 1 : 0) - (ideas_found ? 1 : 0) - (misc_found ? 1 : 0)
           %>
           <div class="related-items-table">
             <div class="row">
+              <div class="col col-lg-<%= types_found + 1 %> comp-col">
+                <a href="<%= tree_path(h[:id])%>" title="<%= h[:text] %>"><%= h[:depth_name] %>:
+                <strong><em><%= h[:formatted_code] %></em></strong>
+                </a>
+                <%= h[:text] %>
+              </div>
               <% if ess_q_found > 0 %>
                 <div class="col col-lg-<%= types_found %>">
                   <div class="top-label">
@@ -80,7 +82,7 @@
               <% end %>
             </div>
           </div>
-        <% end #if h[:dimtrees].length > 0 %>
+        <% end #if true %>
       </li>
       <!-- TO DO: Find a different workaround for hiding indicator-level items -->
       <% elsif h[:depth] > @treeTypeRec.outcome_depth+1 %>

--- a/app/views/trees/_alt_competency_grids_column.html.erb
+++ b/app/views/trees/_alt_competency_grids_column.html.erb
@@ -68,6 +68,16 @@
                   <% end #ess_q_arr.each do |dim| %>
                 </div>
               <% end
+              if h[:explanation] %>
+               <div class="col col-<%= types_found %>">
+                  <div class="top-label">
+                    Explanatory Comment
+                  </div>
+                  <div class="dim-item">
+                    <%= h[:explanation] %>
+                  </div>
+                </div>
+              <% end #if h[:explanation]
               if misc_found > 0 %>
                 <div class="col col-<%= types_found %>">
                   <div class="top-label">

--- a/app/views/trees/_alt_competency_grids_column.html.erb
+++ b/app/views/trees/_alt_competency_grids_column.html.erb
@@ -37,14 +37,14 @@
           %>
           <div class="related-items-table">
             <div class="row">
-              <div class="col col-lg-<%= types_found + 1 %> comp-col">
+              <div class="col col-<%= types_found + 1 %> comp-col">
                 <a href="<%= tree_path(h[:id])%>" title="<%= h[:text] %>"><%= h[:depth_name] %>:
                 <strong><em><%= h[:formatted_code] %></em></strong>
                 </a>
                 <%= h[:text] %>
               </div>
               <% if ess_q_found > 0 %>
-                <div class="col col-lg-<%= types_found %>">
+                <div class="col col-<%= types_found %>">
                   <div class="top-label">
                     <%= ess_q_found > 1 ? @ess_q_title : @ess_q_title.singularize %>
                   </div>
@@ -56,7 +56,7 @@
                 </div>
               <% end
               if ideas_found > 0 %>
-                <div class="col col-lg-<%= types_found %>">
+                <div class="col col-<%= types_found %>">
                   <div class="top-label">
                     <%= ideas_found > 1 ? @ideas_title : @ideas_title.singularize %>
                   </div>
@@ -69,7 +69,7 @@
                 </div>
               <% end
               if misc_found > 0 %>
-                <div class="col col-lg-<%= types_found %>">
+                <div class="col col-<%= types_found %>">
                   <div class="top-label">
                     <%= misc_found > 1 ? @miscon_title : @miscon_title.singularize %>
                   </div>

--- a/app/views/trees/_alt_competency_grids_column.html.erb
+++ b/app/views/trees/_alt_competency_grids_column.html.erb
@@ -71,7 +71,7 @@
               if h[:explanation] %>
                <div class="col col-<%= types_found %>">
                   <div class="top-label">
-                    Explanatory Comment
+                    <%= I18n.translate('app.labels.comments') %>
                   </div>
                   <div class="dim-item">
                     <%= h[:explanation] %>

--- a/app/views/trees/_competencies_column.html.erb
+++ b/app/views/trees/_competencies_column.html.erb
@@ -1,0 +1,79 @@
+<ul class="list-group maint-column">
+  <li>
+    <%= render partial: "maint_filter", locals: {col: "tree"} %>
+  </li>
+  <%
+   @treeByParents.each do |tkey, codeh| %>
+    <li class="maint-header indent-0"><%= @translations[tkey] %></li>
+    <% codeh.each do |code, h| %>
+      <% if h[:outcome] %>
+      <%
+         ess_q_str = ''
+         ideas_str = '' #@ideas_title
+         misc_str = '' #@misc_title
+         ess_q_found = 0
+         ideas_found = 0
+         misc_found = 0
+       %>
+      <li id="<%= h[:subj_code] %>_lo_<%= h[:id] %>" class="maint-item indent-3 <%= h[:selectors_by_parent] %> list-group-item" data-loid="<%= h[:id] %>">
+        <a href="<%= tree_path(h[:id])%>" title="<%= h[:text] %>"><%= h[:depth_name] %>:
+        <strong><em><%= h[:formatted_code] %></em></strong>
+        </a>
+        <%= h[:text] %>
+        <% if h[:dimtrees].length > 0 %>
+        <% h[:dimtrees].each do |dt|
+             dim = dt.dimension
+             if dim.dim_type == @treeTypeRec.ess_q_dim_type
+                ess_q_found += 1
+                essqSubjKey = @subj_key_by_dt_id[dt.id] || @ess_q_subj_base_key
+                ess_q_str += "<br/>______________<br/>"
+                ess_q_str += "[#{@translations[essqSubjKey]}] #{@translations[dim.dim_name_key]}"
+             elsif dim.dim_type == "bigidea"
+                ideas_found += 1
+                ideaSubjKey = @subj_key_by_dt_id[dt.id] || @idea_subj_base_key
+                ideas_str += "<br/>______________<br/>"
+                ideas_str += "[#{@translations[ideaSubjKey]}] #{@translations[dim.dim_name_key]}"
+             else
+                misc_found += 1
+                miscSubjKey = @subj_key_by_dt_id[dt.id] || @misc_subj_base_key
+                misc_str += "<br/>______________<br/>"
+                misc_str += "[#{@translations[miscSubjKey]}] #{@translations[dim.dim_name_key]}"
+             end
+           end
+           ess_q_str = "<strong>#{(ess_q_found > 1 ? @ess_q_title : @ess_q_title.singularize)}:</strong>#{ess_q_str}"
+           ideas_str = "<strong>#{(ideas_found > 1 ? @ideas_title : @ideas_title.singularize)}:</strong>#{ideas_str}"
+           misc_str = "<strong>#{(misc_found > 1 ? @misc_title : @miscon_title.singularize)}:</strong>#{misc_str}"
+        %>
+        <% if ess_q_found > 0 %>
+            <i class="fa fa-question" data-toggle="tooltip" title="<%= ess_q_str %>"></i>
+        <% end
+           if ideas_found > 0 %>
+            <i class="fa fa-lightbulb-o" data-toggle="tooltip" title="<%= ideas_str %>"></i>
+        <% end
+          if misc_found > 0
+        %>
+            <i class="fa fa-exclamation-triangle" data-toggle="tooltip" title="<%= misc_str %>"></i>
+        <% end %>
+        <% end %>
+        <% if @editing %>
+        <div class="pull-right">
+          <!-- TO DO: Implement working resequence button and deactivate button -->
+          <a class="" href="/<%= @locale_code %>/trees/<%= h[:id] %>?editme=<%= h[:id] %>">
+            <i class="fa fa-edit pull-right" title="edit this LO"></i>
+          </a>
+        </div>
+        <% end %>
+      </li>
+      <!-- TO DO: Find a different workaround for hiding indicator-level items -->
+      <% elsif h[:depth] > @treeTypeRec.outcome_depth+1 %>
+      <% else %>
+        <li class="maint-sub-header indent-<%= h[:depth]-1 %> <%= h[:selectors_by_parent] %>">
+          <a class="" onclick="toggle_visibility('.child-of-<%= code.split(".").join("-") %>', '#trigger-<%= code.split(".").join("-") %>')">
+            <i id="trigger-<%= code.split(".").join("-") %>" class="fa fa-compress pull-left option-selected link-blue accordion" title="collapse"></i>
+          </a>
+          <%= "#{h[:depth_name]} #{h[:formatted_code]}#{": #{h[:text]}" if h[:depth] > 1}" %>
+        </li>
+      <% end %>
+    <% end %>
+  <% end %>
+</ul>

--- a/app/views/trees/_competency_grids_column.html.erb
+++ b/app/views/trees/_competency_grids_column.html.erb
@@ -42,7 +42,7 @@
           <div class="related-items-table">
             <div class="row">
               <% if ess_q_found > 0 %>
-                <div class="col col-lg-<%= types_found %>">
+                <div class="col col-<%= types_found %>">
                   <div class="top-label">
                     <%= ess_q_found > 1 ? @ess_q_title : @ess_q_title.singularize %>
                   </div>
@@ -54,7 +54,7 @@
                 </div>
               <% end
               if ideas_found > 0 %>
-                <div class="col col-lg-<%= types_found %>">
+                <div class="col col-<%= types_found %>">
                   <div class="top-label">
                     <%= ideas_found > 1 ? @ideas_title : @ideas_title.singularize %>
                   </div>
@@ -67,7 +67,7 @@
                 </div>
               <% end
               if misc_found > 0 %>
-                <div class="col col-lg-<%= types_found %>">
+                <div class="col col-<%= types_found %>">
                   <div class="top-label">
                     <%= misc_found > 1 ? @miscon_title : @miscon_title.singularize %>
                   </div>

--- a/app/views/trees/_competency_grids_column.html.erb
+++ b/app/views/trees/_competency_grids_column.html.erb
@@ -69,7 +69,7 @@
               if h[:explanation] %>
                <div class="col col-<%= types_found %>">
                   <div class="top-label">
-                    Explanatory Comment
+                    <%= I18n.translate('app.labels.comments') %>
                   </div>
                   <div class="dim-item">
                     <%= h[:explanation] %>

--- a/app/views/trees/_competency_grids_column.html.erb
+++ b/app/views/trees/_competency_grids_column.html.erb
@@ -37,7 +37,7 @@
                 misc_arr << "[#{@translations[miscSubjKey]}] #{@translations[dim.dim_name_key]}"
              end
           end # h[:dimtrees].each do |dt|
-          types_found = 6 - (ess_q_found ? 1 : 0) - (ideas_found ? 1 : 0) - (misc_found ? 1 : 0)
+          types_found = 5 - (ess_q_found ? 1 : 0) - (ideas_found ? 1 : 0) - (misc_found ? 1 : 0)
           %>
           <div class="related-items-table">
             <div class="row">
@@ -66,6 +66,16 @@
                   <% end #ess_q_arr.each do |dim| %>
                 </div>
               <% end
+              if h[:explanation] %>
+               <div class="col col-<%= types_found %>">
+                  <div class="top-label">
+                    Explanatory Comment
+                  </div>
+                  <div class="dim-item">
+                    <%= h[:explanation] %>
+                  </div>
+                </div>
+              <% end #if h[:explanation]
               if misc_found > 0 %>
                 <div class="col col-<%= types_found %>">
                   <div class="top-label">

--- a/app/views/trees/_competency_grids_column.html.erb
+++ b/app/views/trees/_competency_grids_column.html.erb
@@ -1,0 +1,95 @@
+<ul class="list-group maint-column">
+  <li>
+    <%= render partial: "maint_filter", locals: {col: "tree"} %>
+  </li>
+  <%
+   @treeByParents.each do |tkey, codeh| %>
+    <li class="maint-header indent-0"><%= @translations[tkey] %></li>
+    <% codeh.each do |code, h| %>
+      <% if h[:outcome] %>
+      <%
+         ess_q_arr = []
+         ideas_arr = [] #@ideas_title
+         misc_arr = [] #@misc_title
+         ess_q_found = 0
+         ideas_found = 0
+         misc_found = 0
+       %>
+      <li id="<%= h[:subj_code] %>_lo_<%= h[:id] %>" class="maint-item indent-3 <%= h[:selectors_by_parent] %> list-group-item" data-loid="<%= h[:id] %>">
+        <a href="<%= tree_path(h[:id])%>" title="<%= h[:text] %>"><%= h[:depth_name] %>:
+        <strong><em><%= h[:formatted_code] %></em></strong>
+        </a>
+        <%= h[:text] %>
+        <% if h[:dimtrees].length > 0 %>
+          <% h[:dimtrees].each do |dt|
+             dim = dt.dimension
+             if dim.dim_type == @treeTypeRec.ess_q_dim_type
+                ess_q_found += 1
+                essqSubjKey = @subj_key_by_dt_id[dt.id] || @ess_q_subj_base_key
+                ess_q_arr << "[#{@translations[essqSubjKey]}] #{@translations[dim.dim_name_key]}"
+             elsif dim.dim_type == "bigidea"
+                ideas_found += 1
+                ideaSubjKey = @subj_key_by_dt_id[dt.id] || @idea_subj_base_key
+                ideas_arr << "[#{@translations[ideaSubjKey]}] #{@translations[dim.dim_name_key]}"
+             else
+                misc_found += 1
+                miscSubjKey = @subj_key_by_dt_id[dt.id] || @misc_subj_base_key
+                misc_arr << "[#{@translations[miscSubjKey]}] #{@translations[dim.dim_name_key]}"
+             end
+          end # h[:dimtrees].each do |dt| %>
+          <div class="related-items-table">
+            <div class="row">
+              <% if ess_q_found > 0 %>
+                <div class="col col-lg-3">
+                  <div class="top-label">
+                    <%= ess_q_found > 1 ? @ess_q_title : @ess_q_title.singularize %>
+                  </div>
+                  <% ess_q_arr.each_with_index do |dim, i| %>
+                    <div class="dim-item">
+                      <%= dim %>
+                    </div>
+                  <% end #ess_q_arr.each do |dim| %>
+                </div>
+              <% end
+              if ideas_found > 0 %>
+                <div class="col col-lg-3">
+                  <div class="top-label">
+                    <%= ideas_found > 1 ? @ideas_title : @ideas_title.singularize %>
+                  </div>
+                  <% ideas_arr.each_with_index do |dim, i| %>
+                    <div class="dim-item">
+                      <% if i > 0 %><hr><% end %>
+                      <%= dim %>
+                    </div>
+                  <% end #ess_q_arr.each do |dim| %>
+                </div>
+              <% end
+              if misc_found > 0 %>
+                <div class="col col-lg-3">
+                  <div class="top-label">
+                    <%= misc_found > 1 ? @miscon_title : @miscon_title.singularize %>
+                  </div>
+                  <% misc_arr.each_with_index do |dim, i| %>
+                    <div class="dim-item">
+                      <%= dim %>
+                    </div>
+                  <% end #ess_q_arr.each do |dim| %>
+                </div>
+              <% end %>
+            </div>
+          </div>
+        <% end #if h[:dimtrees].length > 0 %>
+      </li>
+      <!-- TO DO: Find a different workaround for hiding indicator-level items -->
+      <% elsif h[:depth] > @treeTypeRec.outcome_depth+1 %>
+      <% else %>
+        <li class="maint-sub-header indent-<%= h[:depth]-1 %> <%= h[:selectors_by_parent] %>">
+          <a class="" onclick="toggle_visibility('.child-of-<%= code.split(".").join("-") %>', '#trigger-<%= code.split(".").join("-") %>')">
+            <i id="trigger-<%= code.split(".").join("-") %>" class="fa fa-compress pull-left option-selected link-blue accordion" title="collapse"></i>
+          </a>
+          <%= "#{h[:depth_name]} #{h[:formatted_code]}#{": #{h[:text]}" if h[:depth] > 1}" %>
+        </li>
+      <% end %>
+    <% end %>
+  <% end %>
+</ul>

--- a/app/views/trees/_maint_filter.html.erb
+++ b/app/views/trees/_maint_filter.html.erb
@@ -64,13 +64,13 @@
     end %>
 
     <!-- Labels -->
-    <div class='col col-md-3'><label for='<%= param_name %>_subject'><%= translate('app.labels.subject') %></label></div>
-    <div class='col col-md-2'><label for='<%= param_name %>_grade_band'><%= translate('app.labels.grade_band') %></label></div>
+    <div class='col col-lg-1 col-md-<%= @editing ? 3 : 2 %>'><label for='<%= param_name %>_subject'><%= translate('app.labels.subject') %></label></div>
+    <div class='col col-lg-<%= @editing ? 5 : 1 %> col-md-<%= @editing ? 5 : 2 %>'><label for='<%= param_name %>_grade_band'><%= translate('app.labels.grade_band') %></label></div>
   </div>
 
   <!-- Form input options -->
   <div class='row'>
-    <div class='col col-md-2 subject-with-gb'><select id='<%= param_name %>_subject_id' name='<%= param_name %>[<%= param_name == "tree" ? "subject_id" : "#{col}_subj_code"%>]'>
+    <div class='col col-lg-1 col-md-2 subject-with-gb'><select id='<%= param_name %>_subject_id' name='<%= param_name %>[<%= param_name == "tree" ? "subject_id" : "#{col}_subj_code"%>]'>
         <% if col == "tree" %>
           <% @subjects.each do |k, s| %>
             <% sel_code = @subject_code %>
@@ -88,7 +88,7 @@
           <% end %>
         <% end # if col == "tree" %>
     </select></div>
-    <div id='<%= param_name %>-gb-container' class='col col-md-4'>
+    <div id='<%= param_name %>-gb-container' class='col col-lg-<%= @editing ? 5 : 1 %> col-md-<%= @editing ? 5 : 2 %>'>
       <span id='<%= param_name %>-all-gbs-select'>
       <!-- %= collection_select(:tree, :grade_band_id, @gbs, :id, :code, include_blank: I18n.t('app.labels.all') ) % -->
       <select id='<%= param_name %>_grade_band_id' name='<%= param_name %>[<%= param_name == "tree" ? "grade_band_id" : "#{col}_gb_id" %>]'>
@@ -107,6 +107,6 @@
       </span>
     </div>
 
-    <div class='col col-md-3 margin-bottom'><%= form.submit translate('app.labels.gen_list'), :class => 'btn-primary' %></div>
+    <div class='col col-lg-1 col-md-3 margin-bottom'><%= form.submit translate('app.labels.gen_list'), :class => 'btn-primary' %></div>
   </div>
 <% end #form %>

--- a/app/views/trees/_maint_filter.html.erb
+++ b/app/views/trees/_maint_filter.html.erb
@@ -110,3 +110,9 @@
     <div class='col col-lg-1 col-md-3 margin-bottom'><%= form.submit translate('app.labels.gen_list'), :class => 'btn-primary' %></div>
   </div>
 <% end #form %>
+<% if col == "tree" %>
+<div>
+<button class="btn btn-link btn-sm pull-left right-margin" onclick="show_hide_selection('.collapsable', true)"><%= I18n.translate("app.labels.expand_all") %></button>
+<button class="btn btn-link btn-sm pull-left" onclick="show_hide_selection('.collapsable', false)"><%= I18n.translate("app.labels.collapse_all") %></button>
+</div>
+<% end %>

--- a/app/views/trees/_maint_filter.html.erb
+++ b/app/views/trees/_maint_filter.html.erb
@@ -111,8 +111,8 @@
   </div>
 <% end #form %>
 <% if col == "tree" %>
-<div>
-<button class="btn btn-link btn-sm pull-left right-margin" onclick="show_hide_selection('.collapsable', true)"><%= I18n.translate("app.labels.expand_all") %></button>
-<button class="btn btn-link btn-sm pull-left" onclick="show_hide_selection('.collapsable', false)"><%= I18n.translate("app.labels.collapse_all") %></button>
-</div>
+  <div>
+    <button class="btn btn-link btn-sm pull-left right-margin" onclick="show_hide_selection('.collapsable', true)"><%= I18n.translate("app.labels.expand_all") %></button>
+    <button class="btn btn-link btn-sm pull-left" onclick="show_hide_selection('.collapsable', false)"><%= I18n.translate("app.labels.collapse_all") %></button>
+  </div>
 <% end %>

--- a/app/views/trees/maint.html.erb
+++ b/app/views/trees/maint.html.erb
@@ -39,7 +39,7 @@
 <div id="trees" class="dimension-page maint-page">
   <div class="sequence-grid cols-<%= num_cols %>">
 
-    <%= render partial: (@editing ? "competencies_column" : "competency_grids_column") %>
+    <%= render partial: (@editing ? "competencies_column" : "alt_competency_grids_column") %>
     <% if @editing || @dim_type %>
       <%= if @treeTypeRec.ess_q_dim_type != ""
             render partial: "dim_column", locals: {

--- a/app/views/trees/maint.html.erb
+++ b/app/views/trees/maint.html.erb
@@ -39,7 +39,8 @@
 <div id="trees" class="dimension-page maint-page">
   <div class="sequence-grid cols-<%= num_cols %>">
 
-    <%= render partial: (@editing ? "competencies_column" : "alt_competency_grids_column") %>
+    <% competencies_partial = @use_alt_partial ? "alt_competency_grids_column" : "competency_grids_column" %>
+    <%= render partial: (@editing ? "competencies_column" : competencies_partial) %>
     <% if @editing || @dim_type %>
       <%= if @treeTypeRec.ess_q_dim_type != ""
             render partial: "dim_column", locals: {

--- a/app/views/trees/maint.html.erb
+++ b/app/views/trees/maint.html.erb
@@ -2,13 +2,13 @@
 <% content_for(:page_class, 'trees') %>
 <%
    grades_str = translate('app.labels.grade_band').pluralize
-   num_cols = 1 + (@show_bigidea ? 1 : 0) + (@show_miscon ? 1 : 0) + (@show_ess_q ? 1 :0)
+   num_cols = 1 + (@show_bigidea && @editing ? 1 : 0) + (@show_miscon && @editing ? 1 : 0) + (@show_ess_q && @editing ? 1 :0)
 %>
 <br>
 <div class='text-center dimension-page'>
   <h2><%= @page_title %></h2>
 </div>
-<% if !@dim_type && @treeTypeRec.ess_q_dim_type != ""  %>
+<% if @editing && @treeTypeRec.ess_q_dim_type != ""  %>
   <%=
       render partial: "show_maint_col_buttons", locals: {
       dim_type: @treeTypeRec.ess_q_dim_type,
@@ -17,7 +17,7 @@
       }
   %>
 <% end %>
-<% if !@dim_type && @treeTypeRec.big_ideas_dim_type != "" %>
+<% if @editing && @treeTypeRec.big_ideas_dim_type != "" %>
   <%=
       render partial: "show_maint_col_buttons", locals: {
       dim_type: @treeTypeRec.big_ideas_dim_type,
@@ -26,7 +26,7 @@
       }
   %>
 <% end %>
-<% if !@dim_type && @treeTypeRec.miscon_dim_type != ""  %>
+<% if @editing && @treeTypeRec.miscon_dim_type != ""  %>
   <%=
       render partial: "show_maint_col_buttons", locals: {
       dim_type: @treeTypeRec.miscon_dim_type,
@@ -38,86 +38,9 @@
 <% subj_counter = 0 %>
 <div id="trees" class="dimension-page maint-page">
   <div class="sequence-grid cols-<%= num_cols %>">
-    <ul class="list-group maint-column">
-      <li>
-        <%= render partial: "maint_filter", locals: {col: "tree"} %>
-      </li>
-      <%
-       @treeByParents.each do |tkey, codeh| %>
-        <li class="maint-header indent-0"><%= @translations[tkey] %></li>
-        <% codeh.each do |code, h| %>
-          <% if h[:outcome] %>
-          <%
-             ess_q_str = ''
-             ideas_str = '' #@ideas_title
-             misc_str = '' #@misc_title
-             ess_q_found = 0
-             ideas_found = 0
-             misc_found = 0
-           %>
-          <li id="<%= h[:subj_code] %>_lo_<%= h[:id] %>" class="maint-item indent-3 <%= h[:selectors_by_parent] %> list-group-item" data-loid="<%= h[:id] %>">
-            <a href="<%= tree_path(h[:id])%>" title="<%= h[:text] %>"><%= h[:depth_name] %>:
-            <strong><em><%= h[:formatted_code] %></em></strong>
-            </a>
-            <%= h[:text] %>
-            <% if h[:dimtrees].length > 0 %>
-            <% h[:dimtrees].each do |dt|
-                 dim = dt.dimension
-                 if dim.dim_type == @treeTypeRec.ess_q_dim_type
-                    ess_q_found += 1
-                    essqSubjKey = @subj_key_by_dt_id[dt.id] || @ess_q_subj_base_key
-                    ess_q_str += "<br/>______________<br/>"
-                    ess_q_str += "[#{@translations[essqSubjKey]}] #{@translations[dim.dim_name_key]}"
-                 elsif dim.dim_type == "bigidea"
-                    ideas_found += 1
-                    ideaSubjKey = @subj_key_by_dt_id[dt.id] || @idea_subj_base_key
-                    ideas_str += "<br/>______________<br/>"
-                    ideas_str += "[#{@translations[ideaSubjKey]}] #{@translations[dim.dim_name_key]}"
-                 else
-                    misc_found += 1
-                    miscSubjKey = @subj_key_by_dt_id[dt.id] || @misc_subj_base_key
-                    misc_str += "<br/>______________<br/>"
-                    misc_str += "[#{@translations[miscSubjKey]}] #{@translations[dim.dim_name_key]}"
-                 end
-               end
-               ess_q_str = "<strong>#{(ess_q_found > 1 ? @ess_q_title : @ess_q_title.singularize)}:</strong>#{ess_q_str}"
-               ideas_str = "<strong>#{(ideas_found > 1 ? @ideas_title : @ideas_title.singularize)}:</strong>#{ideas_str}"
-               misc_str = "<strong>#{(misc_found > 1 ? @misc_title : @miscon_title.singularize)}:</strong>#{misc_str}"
-            %>
-            <% if ess_q_found > 0 %>
-                <i class="fa fa-question" data-toggle="tooltip" title="<%= ess_q_str %>"></i>
-            <% end
-               if ideas_found > 0 %>
-                <i class="fa fa-lightbulb-o" data-toggle="tooltip" title="<%= ideas_str %>"></i>
-            <% end
-              if misc_found > 0
-            %>
-                <i class="fa fa-exclamation-triangle" data-toggle="tooltip" title="<%= misc_str %>"></i>
-            <% end %>
-            <% end %>
-            <% if @editing %>
-            <div class="pull-right">
-              <!-- TO DO: Implement working resequence button and deactivate button -->
-              <a class="" href="/<%= @locale_code %>/trees/<%= h[:id] %>?editme=<%= h[:id] %>">
-                <i class="fa fa-edit pull-right" title="edit this LO"></i>
-              </a>
-            </div>
-            <% end %>
-          </li>
-          <!-- TO DO: Find a different workaround for hiding indicator-level items -->
-          <% elsif h[:depth] > @treeTypeRec.outcome_depth+1 %>
-          <% else %>
-            <li class="maint-sub-header indent-<%= h[:depth]-1 %> <%= h[:selectors_by_parent] %>">
-              <a class="" onclick="toggle_visibility('.child-of-<%= code.split(".").join("-") %>', '#trigger-<%= code.split(".").join("-") %>')">
-                <i id="trigger-<%= code.split(".").join("-") %>" class="fa fa-compress pull-left option-selected link-blue accordion" title="collapse"></i>
-              </a>
-              <%= "#{h[:depth_name]} #{h[:formatted_code]}#{": #{h[:text]}" if h[:depth] > 1}" %>
-            </li>
-          <% end %>
-        <% end %>
-      <% end %>
-      </ul>
 
+    <%= render partial: (@editing ? "competencies_column" : "competency_grids_column") %>
+    <% if @editing || @dim_type %>
       <%= if @treeTypeRec.ess_q_dim_type != ""
             render partial: "dim_column", locals: {
             dim_type: @treeTypeRec.ess_q_dim_type,
@@ -157,6 +80,7 @@
           end
       %>
 
+    <% end # if @editing || @dim_type %>
 
 
     </div>

--- a/app/views/trees/maint.html.erb
+++ b/app/views/trees/maint.html.erb
@@ -2,7 +2,7 @@
 <% content_for(:page_class, 'trees') %>
 <%
    grades_str = translate('app.labels.grade_band').pluralize
-   num_cols = 1 + (@show_bigidea && @editing ? 1 : 0) + (@show_miscon && @editing ? 1 : 0) + (@show_ess_q && @editing ? 1 :0)
+   num_cols = (@dim_type ? 2 : 1) + (@show_bigidea && @editing ? 1 : 0) + (@show_miscon && @editing ? 1 : 0) + (@show_ess_q && @editing ? 1 :0)
 %>
 <br>
 <div class='text-center dimension-page'>

--- a/config/locales/pages.en.yml
+++ b/config/locales/pages.en.yml
@@ -56,6 +56,8 @@ en:
       working_version: "Working"
       final_version: "Final"
       connect_form_title: "Save Connection?"
+      expand_all: "Expand All"
+      collapse_all: "Collapse All"
     roles:
       name: 'Roles'
       admin:


### PR DESCRIPTION
- remove all dimension columns and buttons, takes full page width
- Grid to show competency, then table below
- using `?alt=true` param at the end of the url, it is possible to see an alternate version of the maint/competencies page where the competency is on the same level as the rest of the grid. 