### PR TITLE
Show/Hide Buttons on Competencies Page

### DIFF
--- a/app/assets/javascripts/common.js
+++ b/app/assets/javascripts/common.js
@@ -155,6 +155,21 @@ $(function() {
     }
   };
 
+  show_hierarchy_level = function (level, maxLevel) {
+    $(".level-" + level).removeClass("hidden");
+    $(".level-" + level + " i.accordion").removeClass("option-selected fa-compress");
+    $(".level-" + level + " i.accordion").addClass("fa-expand");
+    level = parseInt(level);
+    for (var i = 0; i < level; i++ ) {
+      $(".level-" + i).removeClass("hidden");
+      $(".level-" + i + " i.accordion").removeClass("fa-compress option-selected");
+      $(".level-" + i + " i.accordion").addClass("fa-expand");
+    }
+    for (var i = level + 1; i <= maxLevel; i++ ) {
+      $(".level-" + i).addClass("hidden");
+    }
+  }
+
   show_maint_details = function () {
     var showing_details = $("#show-details-btn #show-text").hasClass('hidden');
     $("#show-details-btn #show-text").toggleClass('hidden');

--- a/app/assets/javascripts/common.js
+++ b/app/assets/javascripts/common.js
@@ -144,6 +144,28 @@ $(function() {
       $(selection + " i.accordion").removeClass("fa-compress");
       $(selection + " i.accordion").addClass("fa-expand");
     }
+    var showing_details = $("#show-details-btn #show-text").hasClass('hidden');
+    if (showing_details) {
+      $(".comp-col").addClass("col-lg-2 col-md-4 col-sm-11");
+      $(".related-items-table .row").removeClass('hide-children');
+    }
+    else {
+      $(".comp-col").removeClass("col-lg-2 col-md-4 col-sm-11");
+      $(".related-items-table .row").addClass('hide-children');
+    }
+  };
+
+  show_maint_details = function () {
+    var showing_details = $("#show-details-btn #show-text").hasClass('hidden');
+    $("#show-details-btn #show-text").toggleClass('hidden');
+    $("#show-details-btn #hide-text").toggleClass('hidden');
+    $(".related-items-table .row").toggleClass('hide-children');
+    if (showing_details) {
+      $(".comp-col").removeClass("col-lg-2 col-md-4 col-sm-11");
+    }
+    else {
+      $(".comp-col").addClass("col-lg-2 col-md-4 col-sm-11");
+    }
   };
   //###################################
   //# ADD EVENT BINDINGS

--- a/app/assets/javascripts/common.js
+++ b/app/assets/javascripts/common.js
@@ -136,13 +136,12 @@ $(function() {
       $(selection).removeClass("hidden");
       $(selection + " i.accordion").removeClass("fa-expand");
       $(selection + " i.accordion").addClass("fa-compress");
+      $(selection + " i.accordion").addClass("option-selected");
     } else {
       $(".top-selector" + " i.accordion").removeClass("option-selected");
       $(".top-selector" + " i.accordion").removeClass("fa-compress");
       $(".top-selector" + " i.accordion").addClass("fa-expand");
       $(selection).addClass("hidden");
-      $(selection + " i.accordion").removeClass("fa-compress");
-      $(selection + " i.accordion").addClass("fa-expand");
     }
     var showing_details = $("#show-details-btn #show-text").hasClass('hidden');
     if (showing_details) {
@@ -157,13 +156,15 @@ $(function() {
 
   show_hierarchy_level = function (level, maxLevel) {
     $(".level-" + level).removeClass("hidden");
-    $(".level-" + level + " i.accordion").removeClass("option-selected fa-compress");
-    $(".level-" + level + " i.accordion").addClass("fa-expand");
+    var removeClass = (level == maxLevel ? "fa-expand" : "option-selected fa-compress");
+    var addClass = (level == maxLevel ? "option-selected fa-compress" : "fa-expand")
+    $(".level-" + level + " i.accordion").removeClass(removeClass);
+    $(".level-" + level + " i.accordion").addClass(addClass);
     level = parseInt(level);
     for (var i = 0; i < level; i++ ) {
       $(".level-" + i).removeClass("hidden");
-      $(".level-" + i + " i.accordion").removeClass("fa-compress option-selected");
-      $(".level-" + i + " i.accordion").addClass("fa-expand");
+      $(".level-" + i + " i.accordion").removeClass(removeClass);
+      $(".level-" + i + " i.accordion").addClass(addClass);
     }
     for (var i = level + 1; i <= maxLevel; i++ ) {
       $(".level-" + i).addClass("hidden");

--- a/app/assets/javascripts/dimensions.js
+++ b/app/assets/javascripts/dimensions.js
@@ -33,6 +33,7 @@ $(function() {
     num_cols = num_cols < 2 ? 2 : num_cols;
     $(".sequence-grid").addClass("cols-" + num_cols);
   };
+
   /**
    * Show a subject's dimension and lo column when the corresponding
    * radio button is checked.

--- a/app/assets/javascripts/sequence.js
+++ b/app/assets/javascripts/sequence.js
@@ -104,6 +104,7 @@ $(function() {
       }
       $(selector + " i.accordion").removeClass("fa-expand");
       $(selector + " i.accordion").addClass("fa-compress");
+      $(selector + " i.accordion").addClass("option-selected");
     } else {
       $(selector).addClass("hidden");
       if ($(trigger).hasClass("accordion")) {

--- a/app/assets/stylesheets/trees.scss
+++ b/app/assets/stylesheets/trees.scss
@@ -361,7 +361,8 @@
       border: none;
       text-align: left;
       padding-left: 10px;
-      margin-bottom: 5px;
+      margin-bottom: 15px;
+      .hide-children .parent-can-hide {display: none;}
       .parent-can-hide {
        padding-left: 5px;
        padding-right: 5px;

--- a/app/assets/stylesheets/trees.scss
+++ b/app/assets/stylesheets/trees.scss
@@ -362,17 +362,22 @@
       text-align: left;
       padding-left: 10px;
       margin-bottom: 5px;
+      .parent-can-hide {
+       padding-left: 5px;
+       padding-right: 5px;
+      }
+      .parent-can-hide:last-child {padding-right: 15px;}
       .col {
         border-radius: 10px;
         background-color: #eeeeee;
-        margin-left: 5px;
-        margin-top: 5px;
+        height: 96%;
         hr {
           border-top: 1px solid black;
           margin: 2px;
         }
       }
-      .comp-col.col {
+      .comp-col.col, .spacer {
+        border: none;
         background-color: white;
       }
     }
@@ -434,6 +439,12 @@
     // }
     .teacher-grid {
       grid-template-columns: auto auto;
+    }
+  }
+
+  @media only screen and (min-width: 992px) {
+    .spacer {
+      display: none;
     }
   }
 

--- a/app/controllers/trees_controller.rb
+++ b/app/controllers/trees_controller.rb
@@ -129,8 +129,8 @@ class TreesController < ApplicationController
     # convert array of areas into json to put into bootstrap treeview
     @otcJson = otcArrHash.to_json
 
-    @hierarchiesInTrees = []
-    @hierarchies[0 .. 3].each { |h| @hierarchiesInTrees << h if hierarchiesInTrees.include?(h) }
+   # @hierarchiesInTrees = []
+   # @hierarchies[0 .. 3].each { |h| @hierarchiesInTrees << h if hierarchiesInTrees.include?(h) }
 
     respond_to do |format|
       format.html { render 'index'}
@@ -210,7 +210,7 @@ class TreesController < ApplicationController
 
     @miscon_title = Translation.find_translation_name(@locale_code, Dimension.get_dim_type_key(@treeTypeRec.miscon_dim_type, @treeTypeRec.code, @versionRec.code), nil) || translate('nav_bar.miscon.name')
 
-    @ess_q_title = Translation.find_translation_name(@locale_code, Dimension.get_dim_type_key(@treeTypeRec.ess_q_dim_type, @treeTypeRec.code, @versionRec.code), nil) || translate('nav_bar.ess_q.name')
+    @ess_q_title = Translation.find_translation_name(@locale_code, Dimension.get_dim_type_key(@treeTypeRec.ess_q_dim_type, @treeTypeRec.code, @versionRec.code), nil) || translate('nav_bar.essq.name')
 
     puts "ESSENTIAL QUESTION TRANSLATION #{@ess_q_title}"
 
@@ -1209,6 +1209,11 @@ class TreesController < ApplicationController
     # Consider having Translations belong_to trees and sectors.
     # Current solution: get translation from hash of pre-cached translations.
     base_keys= @trees.map { |t| t.buildNameKey }
+
+    hierarchiesInTrees = @trees.pluck('depth').uniq.map {|d| @hierarchies[d] if d <= @treeTypeRec[:outcome_depth] }
+    @hierarchiesInTrees = []
+    @hierarchies[0 .. 3].each { |h| @hierarchiesInTrees << h if hierarchiesInTrees.include?(h) }
+
     tempArray = []
     @subjects.each { |k, v| tempArray << "#{v.base_key}.name" }
     @subjects.each { |s, v| tempArray << "#{v.base_key}.abbr" }

--- a/app/views/trees/_alt_competency_grids_column.html.erb
+++ b/app/views/trees/_alt_competency_grids_column.html.erb
@@ -16,7 +16,11 @@
          misc_found = 0
        %>
       <li id="<%= h[:subj_code] %>_lo_<%= h[:id] %>" class="maint-item indent-3 <%= h[:selectors_by_parent] %> list-group-item" data-loid="<%= h[:id] %>">
-        <% if true %>
+        <a href="<%= tree_path(h[:id])%>" title="<%= h[:text] %>"><%= h[:depth_name] %>:
+        <strong><em><%= h[:formatted_code] %></em></strong>
+        </a>
+        <%= h[:text] %>
+        <% if h[:dimtrees].length > 0 %>
           <% h[:dimtrees].each do |dt|
              dim = dt.dimension
              if dim.dim_type == @treeTypeRec.ess_q_dim_type
@@ -37,13 +41,7 @@
           %>
           <div class="related-items-table">
             <div class="row">
-              <div class="col col-<%= types_found + 1 %> comp-col">
-                <a href="<%= tree_path(h[:id])%>" title="<%= h[:text] %>"><%= h[:depth_name] %>:
-                <strong><em><%= h[:formatted_code] %></em></strong>
-                </a>
-                <%= h[:text] %>
-              </div>
-              <% if ess_q_found > 0 %>
+                <!-- Build essential questions column -->
                 <div class="col col-<%= types_found %>">
                   <div class="top-label">
                     <%= ess_q_found > 1 ? @ess_q_title : @ess_q_title.singularize %>
@@ -54,8 +52,7 @@
                     </div>
                   <% end #ess_q_arr.each do |dim| %>
                 </div>
-              <% end
-              if ideas_found > 0 %>
+                <!-- Build big ideas column -->
                 <div class="col col-<%= types_found %>">
                   <div class="top-label">
                     <%= ideas_found > 1 ? @ideas_title : @ideas_title.singularize %>
@@ -67,8 +64,7 @@
                     </div>
                   <% end #ess_q_arr.each do |dim| %>
                 </div>
-              <% end
-              if h[:explanation] %>
+                <!-- Build explanatory comments column -->
                <div class="col col-<%= types_found %>">
                   <div class="top-label">
                     <%= I18n.translate('app.labels.comments') %>
@@ -77,8 +73,7 @@
                     <%= h[:explanation] %>
                   </div>
                 </div>
-              <% end #if h[:explanation]
-              if misc_found > 0 %>
+                <!-- Build misconceptions column -->
                 <div class="col col-<%= types_found %>">
                   <div class="top-label">
                     <%= misc_found > 1 ? @miscon_title : @miscon_title.singularize %>
@@ -89,10 +84,9 @@
                     </div>
                   <% end #ess_q_arr.each do |dim| %>
                 </div>
-              <% end %>
-            </div>
-          </div>
-        <% end #if true %>
+            </div> <!-- end row -->
+          </div> <!-- end related items table -->
+        <% end #if h[:dimtrees].length > 0 %>
       </li>
       <!-- TO DO: Find a different workaround for hiding indicator-level items -->
       <% elsif h[:depth] > @treeTypeRec.outcome_depth+1 %>

--- a/app/views/trees/_competencies_column.html.erb
+++ b/app/views/trees/_competencies_column.html.erb
@@ -15,7 +15,7 @@
          ideas_found = 0
          misc_found = 0
        %>
-      <li id="<%= h[:subj_code] %>_lo_<%= h[:id] %>" class="maint-item indent-3 <%= h[:selectors_by_parent] %> list-group-item" data-loid="<%= h[:id] %>">
+      <li id="<%= h[:subj_code] %>_lo_<%= h[:id] %>" class="maint-item indent-3 <%= h[:selectors_by_parent] %> list-group-item level-<%= h[:depth] - 1 %>" data-loid="<%= h[:id] %>">
         <a href="<%= tree_path(h[:id])%>" title="<%= h[:text] %>"><%= h[:depth_name] %>:
         <strong><em><%= h[:formatted_code] %></em></strong>
         </a>
@@ -67,7 +67,7 @@
       <!-- TO DO: Find a different workaround for hiding indicator-level items -->
       <% elsif h[:depth] > @treeTypeRec.outcome_depth+1 %>
       <% else %>
-        <li class="maint-sub-header indent-<%= h[:depth]-1 %> <%= h[:selectors_by_parent] %>">
+        <li class="maint-sub-header indent-<%= h[:depth]-1 %> <%= h[:selectors_by_parent] %> level-<%= h[:depth] - 1 %>">
           <a class="" onclick="toggle_visibility('.child-of-<%= code.split(".").join("-") %>', '#trigger-<%= code.split(".").join("-") %>')">
             <i id="trigger-<%= code.split(".").join("-") %>" class="fa fa-compress pull-left option-selected link-blue accordion" title="collapse"></i>
           </a>

--- a/app/views/trees/_competency_grids_column.html.erb
+++ b/app/views/trees/_competency_grids_column.html.erb
@@ -38,7 +38,7 @@
           <div class="related-items-table">
             <div class="row">
               <!-- Build competency column -->
-              <div class="col col-lg-2 col-md-4 col-11 col-sm-11 comp-col">
+              <div class="col-lg-2 col-md-4 col-11 col-sm-11 comp-col">
                 <a href="<%= tree_path(h[:id])%>" title="<%= h[:text] %>"><%= h[:depth_name] %>:
                 <strong><em><%= h[:formatted_code] %></em></strong>
                 </a>

--- a/app/views/trees/_competency_grids_column.html.erb
+++ b/app/views/trees/_competency_grids_column.html.erb
@@ -15,7 +15,7 @@
          ideas_found = 0
          misc_found = 0
        %>
-      <li id="<%= h[:subj_code] %>_lo_<%= h[:id] %>" class="maint-item indent-3 <%= h[:selectors_by_parent] %> list-group-item" data-loid="<%= h[:id] %>">
+      <li id="<%= h[:subj_code] %>_lo_<%= h[:id] %>" class="maint-item indent-3 <%= h[:selectors_by_parent] %> list-group-item level-<%= h[:depth] - 1 %>" data-loid="<%= h[:id] %>">
         <% if true %>
           <% h[:dimtrees].each do |dt|
              dim = dt.dimension
@@ -125,7 +125,7 @@
       <!-- TO DO: Find a different workaround for hiding indicator-level items -->
       <% elsif h[:depth] > @treeTypeRec.outcome_depth+1 %>
       <% else %>
-        <li class="maint-sub-header indent-<%= h[:depth]-1 %> <%= h[:selectors_by_parent] %>">
+        <li class="maint-sub-header indent-<%= h[:depth]-1 %> <%= h[:selectors_by_parent] %> level-<%= h[:depth] - 1 %>">
           <a class="" onclick="toggle_visibility('.child-of-<%= code.split(".").join("-") %>', '#trigger-<%= code.split(".").join("-") %>')">
             <i id="trigger-<%= code.split(".").join("-") %>" class="fa fa-compress pull-left option-selected link-blue accordion" title="collapse"></i>
           </a>

--- a/app/views/trees/_competency_grids_column.html.erb
+++ b/app/views/trees/_competency_grids_column.html.erb
@@ -16,11 +16,7 @@
          misc_found = 0
        %>
       <li id="<%= h[:subj_code] %>_lo_<%= h[:id] %>" class="maint-item indent-3 <%= h[:selectors_by_parent] %> list-group-item" data-loid="<%= h[:id] %>">
-        <a href="<%= tree_path(h[:id])%>" title="<%= h[:text] %>"><%= h[:depth_name] %>:
-        <strong><em><%= h[:formatted_code] %></em></strong>
-        </a>
-        <%= h[:text] %>
-        <% if h[:dimtrees].length > 0 %>
+        <% if true %>
           <% h[:dimtrees].each do |dt|
              dim = dt.dimension
              if dim.dim_type == @treeTypeRec.ess_q_dim_type
@@ -37,12 +33,20 @@
                 misc_arr << "[#{@translations[miscSubjKey]}] #{@translations[dim.dim_name_key]}"
              end
           end # h[:dimtrees].each do |dt|
-          types_found = 5 - (ess_q_found ? 1 : 0) - (ideas_found ? 1 : 0) - (misc_found ? 1 : 0)
+          #types_found = 5 - (ess_q_found ? 1 : 0) - (ideas_found ? 1 : 0) - (misc_found ? 1 : 0)
           %>
           <div class="related-items-table">
             <div class="row">
-              <% if ess_q_found > 0 %>
-                <div class="col col-<%= types_found %>">
+              <!-- Build competency column -->
+              <div class="col col-lg-2 col-md-4 col-11 col-sm-11 comp-col">
+                <a href="<%= tree_path(h[:id])%>" title="<%= h[:text] %>"><%= h[:depth_name] %>:
+                <strong><em><%= h[:formatted_code] %></em></strong>
+                </a>
+                <%= h[:text] %>
+              </div>
+              <!-- Build essential questions column -->
+              <div class="col-lg-2 col-md-3 col-11 col-sm-11 parent-can-hide">
+                <div class="col">
                   <div class="top-label">
                     <%= ess_q_found > 1 ? @ess_q_title : @ess_q_title.singularize %>
                   </div>
@@ -52,9 +56,10 @@
                     </div>
                   <% end #ess_q_arr.each do |dim| %>
                 </div>
-              <% end
-              if ideas_found > 0 %>
-                <div class="col col-<%= types_found %>">
+              </div>
+              <!-- Build big ideas column -->
+              <div class="col-lg-2 col-md-3 col-11 col-sm-11 parent-can-hide">
+                <div class="col">
                   <div class="top-label">
                     <%= ideas_found > 1 ? @ideas_title : @ideas_title.singularize %>
                   </div>
@@ -65,9 +70,31 @@
                     </div>
                   <% end #ess_q_arr.each do |dim| %>
                 </div>
-              <% end
-              if h[:explanation] %>
-               <div class="col col-<%= types_found %>">
+              </div>
+              <!-- Spacer column -->
+              <div class="col-md-4 spacer hidden-lg parent-can-hide"></div>
+              <!-- Build practices column -->
+              <!-- To Do: fill in -->
+              <div class="col-lg-2 col-md-3 col-11 col-sm-11 parent-can-hide">
+                <div class="col">
+                  <div class="top-label">
+                    <%= "practices_found > 1" ? "Associated Practices" : "@practices_title.singularize" %>
+                  </div>
+                  <% if @practices_arr
+                   practices_arr.each_with_index do |dim, i| %>
+                    <div class="dim-item">
+                      <% if i > 0 %><hr><% end %>
+                      <%= dim %>
+                    </div>
+                  <% end #ess_q_arr.each do |dim|
+                    end #if practices_arr
+                  %>
+                </div>
+              </div>
+
+              <!-- Build explanatory comments column -->
+              <div class="col-lg-2 col-md-3 col-11 col-sm-11 parent-can-hide">
+                <div class="col">
                   <div class="top-label">
                     <%= I18n.translate('app.labels.comments') %>
                   </div>
@@ -75,9 +102,12 @@
                     <%= h[:explanation] %>
                   </div>
                 </div>
-              <% end #if h[:explanation]
-              if misc_found > 0 %>
-                <div class="col col-<%= types_found %>">
+              </div>
+              <!-- Spacer column -->
+              <div class="col-md-4 spacer col-lg-0 parent-can-hide"></div>
+              <!-- Build misconceptions column -->
+              <div class="col-lg-2 col-md-3 col-11 col-sm-11 parent-can-hide">
+                <div class="col">
                   <div class="top-label">
                     <%= misc_found > 1 ? @miscon_title : @miscon_title.singularize %>
                   </div>
@@ -87,10 +117,10 @@
                     </div>
                   <% end #ess_q_arr.each do |dim| %>
                 </div>
-              <% end %>
+              </div> <!-- end of misconceptions column -->
             </div>
           </div>
-        <% end #if h[:dimtrees].length > 0 %>
+        <% end #if true %>
       </li>
       <!-- TO DO: Find a different workaround for hiding indicator-level items -->
       <% elsif h[:depth] > @treeTypeRec.outcome_depth+1 %>

--- a/app/views/trees/_maint_filter.html.erb
+++ b/app/views/trees/_maint_filter.html.erb
@@ -114,5 +114,11 @@
   <div>
     <button class="btn btn-link btn-sm pull-left right-margin" onclick="show_hide_selection('.collapsable', true)"><%= I18n.translate("app.labels.expand_all") %></button>
     <button class="btn btn-link btn-sm pull-left" onclick="show_hide_selection('.collapsable', false)"><%= I18n.translate("app.labels.collapse_all") %></button>
+    <% if !@editing %>
+      <button id="show-details-btn" class="btn btn-info btn-sm pull-left" onclick="show_maint_details()">
+        <span id="show-text" class="hidden">Show Details</span>
+        <span id="hide-text">Hide Details</span>
+      </button>
+    <% end %>
   </div>
 <% end %>

--- a/app/views/trees/_maint_filter.html.erb
+++ b/app/views/trees/_maint_filter.html.erb
@@ -114,8 +114,17 @@
   <div>
     <button class="btn btn-link btn-sm pull-left right-margin" onclick="show_hide_selection('.collapsable', true)"><%= I18n.translate("app.labels.expand_all") %></button>
     <button class="btn btn-link btn-sm pull-left" onclick="show_hide_selection('.collapsable', false)"><%= I18n.translate("app.labels.collapse_all") %></button>
+    <%
+    @hierarchiesInTrees.each_with_index do |h, ix|
+      if ix > 0 && ix <= @treeTypeRec.outcome_depth
+    %>
+        <button class='btn btn-info btn-sm pull-left right-margin' onclick="show_hierarchy_level('<%= ix %>', '<%= @treeTypeRec[:outcome_depth] %>')"><%= I18n.t('app.labels.show') %> <%= @hierarchiesInTrees[ix].pluralize if @hierarchiesInTrees.length > ix %></button>
+    <%
+      end
+    end
+    %>
     <% if !@editing %>
-      <button id="show-details-btn" class="btn btn-info btn-sm pull-left" onclick="show_maint_details()">
+      <button id="show-details-btn" class="btn btn-link btn-sm pull-left right-margin" onclick="show_maint_details()">
         <span id="show-text" class="hidden">Show Details</span>
         <span id="hide-text">Hide Details</span>
       </button>

--- a/app/views/trees/_maint_filter.html.erb
+++ b/app/views/trees/_maint_filter.html.erb
@@ -117,8 +117,9 @@
     <%
     @hierarchiesInTrees.each_with_index do |h, ix|
       if ix > 0 && ix <= @treeTypeRec.outcome_depth
+      hierarchy_depth = @hierarchies.index(@hierarchiesInTrees[ix])
     %>
-        <button class='btn btn-info btn-sm pull-left right-margin' onclick="show_hierarchy_level('<%= ix %>', '<%= @treeTypeRec[:outcome_depth] %>')"><%= I18n.t('app.labels.show') %> <%= @hierarchiesInTrees[ix].pluralize if @hierarchiesInTrees.length > ix %></button>
+        <button class='btn btn-info btn-sm pull-left right-margin' onclick="show_hierarchy_level('<%= hierarchy_depth %>', '<%= @treeTypeRec[:outcome_depth] %>')"><%= I18n.t('app.labels.show') %> <%= @hierarchiesInTrees[ix].pluralize if @hierarchiesInTrees.length > ix %></button>
     <%
       end
     end

--- a/config/locales/pages.en.yml
+++ b/config/locales/pages.en.yml
@@ -36,7 +36,7 @@ en:
       outcomes: "Attainments"
       indicator: "Explanation"
       indicators: "Explanations"
-      comments: "Explanatory Comment"
+      comments: "Teacher Support"
       code: "Code"
       description: 'Description'
       message: "Message"


### PR DESCRIPTION
- Grid Layout of competencies page has competencies in the left side of the grid, not on top.
- Responsive column widths for competency grids.
- Update translation for "explanatory comments" to "Teacher Support."
- A new (single) column has been added for ‘Associated Practices’, which will be part of the upload spreadsheet (in column 4 before ’Teacher Support.' Currently a placeholder with no data.
- Competencies page has a Show/Hide Detail button will hide detail grid (and expand competency to fill the row).
- Competencies page has Show/Hide Competencies Button, Show/Hide Sub-Units Button, Show/hide Units button.
