### PR TITLE
Standard coding for looking up subject translations

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -211,8 +211,8 @@ class ApplicationController < ActionController::Base
         subjects.each do |subj|
           h = {
             rec: subj,
-            abbr: Translation.find_translation_name(@locale_code, "subject.#{@treeTypeRec.code}.#{subj.code}.abbr", ''),
-            name: Translation.find_translation_name(@locale_code, "subject.#{@treeTypeRec.code}.#{subj.code}.name", ''),
+            abbr: subj.get_abbr(@locale_code),
+            name: subj.get_name(@locale_code),
           }
           @subjectByCode[subj.code] = h
           @subjectById[subj.id] = h

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -211,7 +211,7 @@ class ApplicationController < ActionController::Base
         subjects.each do |subj|
           h = {
             rec: subj,
-            abbr: subj.get_abbr(@locale_code),
+            abbr: subj.get_abbr(@locale_code).downcase,
             name: subj.get_name(@locale_code),
           }
           @subjectByCode[subj.code] = h

--- a/app/controllers/sectors_controller.rb
+++ b/app/controllers/sectors_controller.rb
@@ -114,7 +114,7 @@ class SectorsController < ApplicationController
         if @grade_band_id.present? && st.tree.grade_band_id.to_s != @grade_band_id
         elsif @subject_id.present? && st.tree.subject_id.to_s != @subject_id
         else
-          rptRows << [ '', st.tree.codeByLocale(@locale_code), translations[st.tree.name_key], st.tree.id.to_s, translations[st.explanation_key] ]
+          rptRows << [ '', st.tree.format_code(@locale_code), translations[st.tree.name_key], st.tree.id.to_s, translations[st.explanation_key] ]
         end
       end #if st.tree
     end #sector.sector_trees.active.each do |st|

--- a/app/controllers/sectors_controller.rb
+++ b/app/controllers/sectors_controller.rb
@@ -82,8 +82,14 @@ class SectorsController < ApplicationController
     # To Do: filter out subjects and grades not diaplayed
     name_keys = [sector.name_key]
     sector.sector_trees.each do |st|
-      name_keys << st.explanation_key
-      name_keys << st.tree.name_key
+      if st.tree
+        name_keys << st.explanation_key
+        name_keys << st.tree.name_key
+      else
+        open(BaseRec::DATA_COMPLAINTS_PATH, "a") do |f|
+          f.puts "[#{DateTime.now}] tree record is nil in sector_tree with id: #{st.id}"
+        end
+      end
     end
     return name_keys
   end
@@ -104,12 +110,14 @@ class SectorsController < ApplicationController
     # filter out records when pulling from the join
     # To Do: put grade band and subject into sector_trees join record to efficiently filter out selected grade or subject
     sector.sector_trees.active.each do |st|
-      if @grade_band_id.present? && st.tree.grade_band_id.to_s != @grade_band_id
-      elsif @subject_id.present? && st.tree.subject_id.to_s != @subject_id
-      else
-        rptRows << [ '', st.tree.codeByLocale(@locale_code), translations[st.tree.name_key], st.tree.id.to_s, translations[st.explanation_key] ]
-      end
-    end
+      if st.tree
+        if @grade_band_id.present? && st.tree.grade_band_id.to_s != @grade_band_id
+        elsif @subject_id.present? && st.tree.subject_id.to_s != @subject_id
+        else
+          rptRows << [ '', st.tree.codeByLocale(@locale_code), translations[st.tree.name_key], st.tree.id.to_s, translations[st.explanation_key] ]
+        end
+      end #if st.tree
+    end #sector.sector_trees.active.each do |st|
     return  rptRows
   end
 

--- a/app/controllers/trees_controller.rb
+++ b/app/controllers/trees_controller.rb
@@ -483,7 +483,7 @@ class TreesController < ApplicationController
 
     changes += ", #{{'dimension': dimension.as_json, 'text': dim_translation.as_json}},,,[END OF LINE]"
 
-    open("#{Rails.root}/log/dimension_changes.out", "a") do |f|
+    open(BaseRec::DIM_CHANGE_LOG_PATH, "a") do |f|
       f.puts changes
     end
 
@@ -523,7 +523,7 @@ class TreesController < ApplicationController
         dimension.get_dim_name_key
       )
 
-    open("#{Rails.root}/log/dimension_changes.out", "a") do |f|
+    open(BaseRec::DIM_CHANGE_LOG_PATH, "a") do |f|
       f.puts changes
     end
 

--- a/app/controllers/trees_controller.rb
+++ b/app/controllers/trees_controller.rb
@@ -227,7 +227,7 @@ class TreesController < ApplicationController
       if (false) # when current curriculum and version are known, check if current column is not the current one
         tkeyTrans += Translation.find_translation_name(@locale_code, 'curriculum.'+tree.tree_type.code+'.title', 'Missing Curriculum Name') + ' - ' + tree.version.code + ' - '
       end
-      tkeyTrans += Translation.find_translation_name(@locale_code, 'subject.'+tree.tree_type.code+'.'+ tree.subject.code+ '.name', 'Missing Subject Name') + ' - ' + Translation.find_translation_name(@locale_code, 'grades.'+tree.tree_type.code+'.'+ tree.grade_band.code+ '.name', 'Missing Grade Name')
+      tkeyTrans += Translation.find_translation_name(@locale_code, tree.subject.get_versioned_name_key, 'Missing Subject Name') + ' - ' + Translation.find_translation_name(@locale_code, tree.grade_band.get_name_key, 'Missing Grade Name')
       @translations[tkey] = tkeyTrans
       selectors_by_parent = tree.parentCodes.map { |pc| "child-of-#{pc.split(".").join("-")}" if pc != "" }
       selectors_by_parent = selectors_by_parent.length > 1 ? "collapsable " + selectors_by_parent.join(" ") : "top-selector" + selectors_by_parent.join(" ")
@@ -437,14 +437,14 @@ class TreesController < ApplicationController
     subjects.each do |subj_code|
       @dimension_subject_opts << {code: subj_code, name: Translation.find_translation_name(
           @locale_code,
-          Subject.name_translation_key(subj_code),
+          Subject.get_default_name_key(subj_code),
           subj_code)
       }
     end
 
     @dimension_subject = Translation.find_translation_name(
       @locale_code,
-      Subject.name_translation_key(@dimension.subject_code),
+      Subject.get_default_name_key(@dimension.subject_code),
       @dimension.subject_code) if @dimension.subject_code
     @dimension_text = Translation.find_translation_name(
         @locale_code,
@@ -574,8 +574,8 @@ class TreesController < ApplicationController
       }
       @subj_gradebands[s.code] = listing.joins(:subject).where('subjects.code' => s.code).joins(:grade_band).pluck('grade_bands.code').uniq
       @subj_gradebands[s.code] << "All" if @subj_gradebands[s.code].length > 1
-      transl_keys << s.base_key+'.name'
-      transl_keys << s.base_key+'.abbr'
+      transl_keys << Subject.get_default_name_key(s.code)
+      transl_keys << Subject.get_default_abbr_key(s.code)
     end
 
     Rails.logger.debug("*** @subjects: #{@subjects.inspect}")
@@ -887,7 +887,7 @@ class TreesController < ApplicationController
         @attr_id = @rel.id
         expl_key = @rel.explanation_key
         @tree_referencee = @rel.tree_referencee
-        @tree_referencee_code = I18n.t("trees.labels.#{@tree_referencee.subject.code}") + " #{@tree_referencee.code}"
+        @tree_referencee_code = @tree_referencee.format_code(@locale_code)
         translation = Translation.translationsByKeys(
           @locale_code,
           expl_key
@@ -910,7 +910,7 @@ class TreesController < ApplicationController
           )
         @rel_name = (name_matches.length > 0 ? ": #{name_matches.first.value}" : '')
         @tree_referencee_code = "#{I18n.t('app.labels.sector_num', num: @rel.sector.code)}#{@rel_name}" if (@edit_type == "sector" && @rel.id)
-        @tree_referencee_code = "#{I18n.t("trees.#{@rel.dimension.dim_type}.singular")} #{@rel_name}" if @edit_type == "dimtree"
+        @tree_referencee_code = "#{Dimension.get_dim_type_name(@rel.dimension.dim_type, @treeTypeRec.code, @versionRec.code, @locale_code).singularize} #{@rel_name}" if @edit_type == "dimtree"
       end
     end
     respond_to do |format|
@@ -1305,9 +1305,9 @@ class TreesController < ApplicationController
       # Get dimensions and dimtrees for displayed curriculum
       @dimtrees = DimTree.active.joins(:dimension).where(:tree_id => @trees.pluck("id"))
       dimKeys = @dimtrees.pluck('dim_explanation_key')
-      @ess_q_subj_base_key = Subject.name_translation_key(@dim_subjs[@treeTypeRec.ess_q_dim_type]) if @dim_subjs[@treeTypeRec.ess_q_dim_type]
-      @idea_subj_base_key = Subject.name_translation_key(@dim_subjs['bigidea']) if @dim_subjs['bigidea']
-      @misc_subj_base_key = Subject.name_translation_key(@dim_subjs['miscon']) if @dim_subjs['miscon']
+      @ess_q_subj_base_key = Subject.get_default_name_key(@dim_subjs[@treeTypeRec.ess_q_dim_type]) if @dim_subjs[@treeTypeRec.ess_q_dim_type]
+      @idea_subj_base_key = Subject.get_default_name_key(@dim_subjs['bigidea']) if @dim_subjs['bigidea']
+      @misc_subj_base_key = Subject.get_default_name_key(@dim_subjs['miscon']) if @dim_subjs['miscon']
       dimKeys << @idea_subj_base_key if @idea_subj_base_key
       dimKeys << @ess_q_subj_base_key if @ess_q_subj_base_key
       dimKeys << @misc_subj_base_key if @misc_subj_base_key
@@ -1323,7 +1323,7 @@ class TreesController < ApplicationController
         if (translate?('bigidea', is_bigidea, dt_dim, bigidea_min_arr, bigidea_max_arr) || translate?('miscon', is_miscon, dt_dim, miscon_min_arr, miscon_max_arr) || translate?(@treeTypeRec.ess_q_dim_type, is_ess_q, dt_dim, ess_q_min_arr, ess_q_max_arr))
         #@trees.first.present? && dt_dim.subject_id != @trees.first.subject_id
             dimKeys << dt_dim.dim_name_key
-            dt_dim_subj = "subject.base.#{dt_dim.subject_code}.name"
+            dt_dim_subj = Subject.get_default_name_key(dt_dim.subject_code)
             dimKeys << dt_dim_subj if !dimKeys.include?(dt_dim_subj)
         end
         @subj_key_by_dt_id[dt.id] = dt_dim_subj
@@ -1355,9 +1355,10 @@ class TreesController < ApplicationController
     end
     if @translations
       BaseRec::BASE_SUBJECTS.each do |s|
-        subjKey = "subject.base.#{s}"
-        dimKeys << "#{subjKey}.name" if !dimKeys.include?("#{subjKey}.name")
-        dimKeys << "#{subjKey}.abbr" if !dimKeys.include?("#{subjKey}.abbr")
+        subjNameKey = Subject.get_default_name_key(s)
+        subjAbbrKey = Subject.get_default_abbr_key(s)
+        dimKeys << subjNameKey if !dimKeys.include?(subjNameKey)
+        dimKeys << subjAbbrKey if !dimKeys.include?(subjAbbrKey)
       end
       dim_translations = Translation.translationsByKeys(
         @locale_code,

--- a/app/models/base_rec.rb
+++ b/app/models/base_rec.rb
@@ -54,5 +54,9 @@ class BaseRec < ActiveRecord::Base
 
   # ALL_SECTORS = ['1','2','3','4','5','6','7','8','9','10']
 
+  #name of the log file where runtime issues with data are logged
+  DATA_COMPLAINTS_PATH = "#{Rails.root}/log/data_complaints.out"
+
+  DIM_CHANGE_LOG_PATH = "#{Rails.root}/log/dimension_changes.out"
 
 end

--- a/app/models/subject.rb
+++ b/app/models/subject.rb
@@ -4,38 +4,68 @@ class Subject < BaseRec
 
   # Translation Field
 
+  # Soon to be deprecated in favor of get_versioned_name_key
   # The TreeType-specific Translation key for a Subject
   def versioned_name_key
     treeTypeRec = TreeType.find(tree_type_id)
     return "subject.#{treeTypeRec.code}.#{code}.name"
   end
 
-  # The TreeType-specific Translation key for a Subject
-  def versioned_abbr_key
-    treeTypeRec = TreeType.find(tree_type_id)
-    return "subject.#{treeTypeRec.code}.#{code}.abbr"
-  end
-
+  # To be deprecated in favor of get_default_name_key
   # The default Translation key for BaseRec subjects
   # To Do: migrate to use subject.default.#{code}.name
   def self.name_translation_key(code)
     return "subject.base.#{code}.name"
   end
 
+  # To be deprecated
+  # The TreeType-specific Translation key for a Subject
+  def versioned_abbr_key
+    treeTypeRec = TreeType.find(tree_type_id)
+    return "subject.#{treeTypeRec.code}.#{code}.abbr"
+  end
+
+  # To be deprecated
   # The default Translation key for BaseRec subjects
   # To Do: migrate to use subject.default.#{code}.name
   def self.default_abbr_key(code)
     return "subject.base.#{code}.abbr"
   end
 
+  def build_base_key
+    treeTypeRec = TreeType.find(tree_type_id)
+    versionRec = Version.find(treeTypeRec.version_id)
+    return "subject.#{treeTypeRec.code}.#{versionRec.code}.#{code}"
+  end
+
+  # Returns curriculum-specific translation key for a subject name.
+  def get_versioned_name_key
+    return "#{build_base_key}.name"
+  end
+
+  # Returns curriculum-specific translation key for a subject abbreviation.
+  def get_versioned_abbr_key
+    return "#{build_base_key}.abbr"
+  end
+
+  # The default Translation key for BaseRec subject names
+  def self.get_default_name_key(code)
+    return "subject.default.#{code}.name"
+  end
+
+  # The default Translation key for BaseRec subject abbreviations
+  def self.get_default_abbr_key(code)
+    return "subject.default.#{code}.abbr"
+  end
+
   def get_name(locale_code)
     return Translation.find_translation_name(
         locale_code,
-        versioned_name_key,
+        get_versioned_name_key,
         nil
       ) || Translation.find_translation_name(
         locale_code,
-        Subject.name_translation_key(code),
+        Subject.get_default_name_key(code),
         ""
       )
   end
@@ -43,11 +73,11 @@ class Subject < BaseRec
   def get_abbr(locale_code)
     return Translation.find_translation_name(
         locale_code,
-        versioned_abbr_key,
+        get_versioned_abbr_key,
         nil
       ) || Translation.find_translation_name(
         locale_code,
-        Subject.default_abbr_key(code),
+        Subject.get_default_abbr_key(code),
         ""
       )
   end

--- a/app/models/subject.rb
+++ b/app/models/subject.rb
@@ -18,19 +18,21 @@ class Subject < BaseRec
     return "subject.base.#{code}.name"
   end
 
-  # To be deprecated
+  # To be deprecated in favor of get_versioned_abbr_key
   # The TreeType-specific Translation key for a Subject
   def versioned_abbr_key
     treeTypeRec = TreeType.find(tree_type_id)
     return "subject.#{treeTypeRec.code}.#{code}.abbr"
   end
 
-  # To be deprecated
+  # To be deprecated in favor of get_default_abbr_key
   # The default Translation key for BaseRec subjects
   # To Do: migrate to use subject.default.#{code}.name
   def self.default_abbr_key(code)
     return "subject.base.#{code}.abbr"
   end
+  # End of deprecated methods
+  ##################
 
   def build_base_key
     treeTypeRec = TreeType.find(tree_type_id)

--- a/app/models/subject.rb
+++ b/app/models/subject.rb
@@ -55,6 +55,7 @@ class Subject < BaseRec
   end
   ########################################
 
+  # Deprecated. Use get_abbr(locale_code) instead
   def abbr(loc)
     Rails.logger.debug("loc: #{loc.inspect}")
     Rails.logger.debug("self.base_key: #{self.base_key.inspect}")

--- a/app/models/subject.rb
+++ b/app/models/subject.rb
@@ -4,36 +4,6 @@ class Subject < BaseRec
 
   # Translation Field
 
-  # Soon to be deprecated in favor of get_versioned_name_key
-  # The TreeType-specific Translation key for a Subject
-  def versioned_name_key
-    treeTypeRec = TreeType.find(tree_type_id)
-    return "subject.#{treeTypeRec.code}.#{code}.name"
-  end
-
-  # To be deprecated in favor of get_default_name_key
-  # The default Translation key for BaseRec subjects
-  # To Do: migrate to use subject.default.#{code}.name
-  def self.name_translation_key(code)
-    return "subject.base.#{code}.name"
-  end
-
-  # To be deprecated in favor of get_versioned_abbr_key
-  # The TreeType-specific Translation key for a Subject
-  def versioned_abbr_key
-    treeTypeRec = TreeType.find(tree_type_id)
-    return "subject.#{treeTypeRec.code}.#{code}.abbr"
-  end
-
-  # To be deprecated in favor of get_default_abbr_key
-  # The default Translation key for BaseRec subjects
-  # To Do: migrate to use subject.default.#{code}.name
-  def self.default_abbr_key(code)
-    return "subject.base.#{code}.abbr"
-  end
-  # End of deprecated methods
-  ##################
-
   def build_base_key
     treeTypeRec = TreeType.find(tree_type_id)
     versionRec = Version.find(treeTypeRec.version_id)

--- a/app/views/trees/_maint_filter.html.erb
+++ b/app/views/trees/_maint_filter.html.erb
@@ -76,12 +76,12 @@
             <% sel_code = @subject_code %>
             <%- selectedStr = (s.code == sel_code) ? ' selected = "selected"' : '' %>
             <%= Rails.logger.debug(" +++ index match output: #{selectedStr}") %>
-            <option value=<%= s.id %><%= selectedStr %>><%= @translations["subject.base.#{s.code}.abbr"] %></option>
+            <option value=<%= s.id %><%= selectedStr %>><%= @translations[Subject.get_default_abbr_key(s.code)] %></option>
           <% end %>
         <% else # if col != "tree" %>
           <% BaseRec::BASE_SUBJECTS.each do |s| %>
             <% sel_code = @dim_subjs[dim_key] if @dim_subjs[dim_key]
-               opt_name = @translations["subject.base.#{s}.abbr"]
+               opt_name = @translations[Subject.get_default_abbr_key(s)]
             %>
             <%- selectedStr = (s == sel_code) ? ' selected = "selected"' : '' %>
             <option value=<%= s %><%= selectedStr %>><%= opt_name %></option>

--- a/app/views/trees/_select_form.html.erb
+++ b/app/views/trees/_select_form.html.erb
@@ -14,7 +14,7 @@
           <% @subjects.each do |k, s| %>
             <%- selectedStr = (s.code == @subject_code) ? ' selected = "selected"' : '' %>
             <%= Rails.logger.debug(" +++ index match output: #{selectedStr}") %>
-            <option value=<%= s.id%><%= selectedStr %>><%=s.abbr( @locale_code )%></option>
+            <option value=<%= s.id%><%= selectedStr %>><%=s.get_abbr( @locale_code ).downcase %></option>
           <% end %>
         </select></div>
         <div id='gb-container' class='col col-md-4 border-left border-bottom'>

--- a/app/views/trees/dimensions.html.erb
+++ b/app/views/trees/dimensions.html.erb
@@ -25,7 +25,7 @@
 	<% @s_o_hash.each do |i, j| %>
     <div id="<%=i%>-dim-column" class="dimension-item subject-column <%= 'hidden' if i != subject_visible %>">
       <ul class="list-group">
-        <li class="dimension-header"><%= @translations["subject.#{i}.name"] %> - <%= @page_title %></li>
+        <li class="dimension-header"><%= @translations[Subject.get_default_name_key(i)] %> - <%= @page_title %></li>
         <% j[:dimensions].each do |k| %>
           <li id="<%= i %>_dim_<%= k[:id] %>" class="dim-item dim-item--collapsable list-group-item" data-dimid="<%= k[:id] %>">
             <span class="truncate-if-collapsed"><%= @translations[k[:dim_name_key]] %></span>
@@ -35,7 +35,7 @@
                 <div>
                   <a class="hide-unless-condition" href='<%= dtree[:tree_id] %>'
                     title='<%= @translations[dtree[:dim_explanation_key]] %>'>
-                    <%= "#{@translations[dtree.tree.subject.base_key + ".abbr"].downcase}.#{dtree.tree[:code]}" %>
+                    <%= "#{@translations[Subject.get_default_abbr_key(dtree.tree.subject.code)].downcase}.#{dtree.tree[:code]}" %>
                   </a>
                 </div>
               <% end #iterate through this dimension's connections to LOs %>
@@ -50,7 +50,7 @@
     </div>
     <div id="<%=i%>-lo-column" class="dimension-item subject-column <%= 'hidden' if i != subject_visible %>">
       <ul class="list-group">
-        <li class="dimension-header"><%= @translations["subject.#{i}.name"] %> - <%= @hierarchies[@treeTypeRec[:outcome_depth]].pluralize %>
+        <li class="dimension-header"><%= @translations[Subject.get_default_name_key(i)] %> - <%= @hierarchies[@treeTypeRec[:outcome_depth]].pluralize %>
           <% if @subj_gradebands[i].length > 0 %>
           - <%= translate('app.labels.grade_band_show').pluralize if (@subj_gradebands[i].length > 1) %>
             <%= translate('app.labels.grade_band_show') if (@subj_gradebands[i].length == 1)

--- a/app/views/trees/sequence.html.erb
+++ b/app/views/trees/sequence.html.erb
@@ -70,7 +70,7 @@
     <% subj_counter += 1 %>
     <div id="<%=i%>-column" class="sequence-item subject-column<%= subj_counter > subj_default_count ? " hidden" : "" %>">
       <ul class="list-group">
-        <li class="sequence-header"><%= Translation.where(locale: @locale_code, key: @subjects[i].base_key + ".name").first.value %></li>
+        <li class="sequence-header"><%= @subjects[i].get_name(@locale_code) %></li>
         <% j.each do |k| %>
           <li id="lo_<%= k[:id] %>" class="sequence-item sequence-item--collapsable list-group-item lo_gb_code_<%= k[:gb_code] %>" data-lo-id="<%= k[:id] %>">
             <a class="truncate-if-collapsed" href="<%= tree_path(k[:id])%>" title="<%= k[:text] %>"><%= k[:text] %></a>

--- a/lib/tasks/add_earth_science.rake
+++ b/lib/tasks/add_earth_science.rake
@@ -8,21 +8,21 @@ namespace :add_earth_science do
 	  	@ear = Subject.create(
 		    tree_type_id: @tfv.id,
 		    code: 'ear',
-		    base_key: 'subject.ear'
+		    base_key: 'subject.tfv.v01.ear'
 		    )
       puts "created subject: Earth, Space, and Environmental Science"
       locales = Locale.all
       @loc_en = locales.where(:code => 'en').first
       @loc_tr = locales.where(:code => 'tr').first
       puts "retrieved locales"
-	  	rec, status, message = Translation.find_or_update_translation(BaseRec::LOCALE_EN, 'subject.ear.name', 'Earth, Space, & Environmental Science')
+	  	rec, status, message = Translation.find_or_update_translation(BaseRec::LOCALE_EN, 'subject.default.ear.name', 'Earth, Space, & Environmental Science')
   		throw "ERROR updating sector translation: #{message}" if status == BaseRec::REC_ERROR
-  		rec, status, message = Translation.find_or_update_translation(BaseRec::LOCALE_EN, 'subject.ear.abbr', 'Ear')
+  		rec, status, message = Translation.find_or_update_translation(BaseRec::LOCALE_EN, 'subject.default.ear.abbr', 'Ear')
   		throw "ERROR updating sector translation: #{message}" if status == BaseRec::REC_ERROR
-  		rec, status, message = Translation.find_or_update_translation(BaseRec::LOCALE_TR, 'subject.ear.name', '
+  		rec, status, message = Translation.find_or_update_translation(BaseRec::LOCALE_TR, 'subject.default.ear.name', '
   		Dünya, Uzay ve Çevre Bilimi')
   		throw "ERROR updating sector translation: #{message}" if status == BaseRec::REC_ERROR
-  		rec, status, message = Translation.find_or_update_translation(BaseRec::LOCALE_TR, 'subject.ear.abbr', 'Dün')
+  		rec, status, message = Translation.find_or_update_translation(BaseRec::LOCALE_TR, 'subject.default.ear.abbr', 'Dün')
   		throw "ERROR updating sector translation: #{message}" if status == BaseRec::REC_ERROR
       puts "created subject translations"
 

--- a/lib/tasks/dimensions.rake
+++ b/lib/tasks/dimensions.rake
@@ -28,9 +28,9 @@ namespace :dimensions do
       geo: 'Geology'
     }
     BaseRec::BASE_SUBJECTS.each do |s|
-        rec, status, message = Translation.find_or_update_translation(BaseRec::LOCALE_EN, "subject.base.#{s}.abbr", "#{s}")
+        rec, status, message = Translation.find_or_update_translation(BaseRec::LOCALE_EN, Subject.get_default_abbr_key(s), "#{s}")
         throw "ERROR updating subject translation: #{message}" if status == BaseRec::REC_ERROR
-        rec, status, message =  Translation.find_or_update_translation(BaseRec::LOCALE_EN, "subject.base.#{s}.name", "#{s_lookup[:"#{s}"]}")
+        rec, status, message =  Translation.find_or_update_translation(BaseRec::LOCALE_EN, Subject.get_default_name_key(s), "#{s_lookup[:"#{s}"]}")
         throw "ERROR updating subject translation: #{message}" if status == BaseRec::REC_ERROR
         puts "Saved Translations for #{s}, #{s_lookup[:"#{s}"]}"
     end

--- a/lib/tasks/seed_eg_stem.rake
+++ b/lib/tasks/seed_eg_stem.rake
@@ -160,119 +160,119 @@ namespace :seed_eg_stem do
       @subjects << Subject.create(
         tree_type_id: @egstem.id,
         code: 'bio',
-        base_key: 'subject.egstemuniv.bio'
+        base_key: 'subject.egstemuniv.v01.bio'
       )
     end
     if Subject.where(tree_type_id: @egstem.id, code: 'cap').count < 1
       @subjects << Subject.create(
         tree_type_id: @egstem.id,
         code: 'cap',
-        base_key: 'subject.egstemuniv.cap'
+        base_key: 'subject.egstemuniv.v01.cap'
       )
     end
     if Subject.where(tree_type_id: @egstem.id, code: 'che').count < 1
       @subjects << Subject.create(
         tree_type_id: @egstem.id,
         code: 'che',
-        base_key: 'subject.egstemuniv.che'
+        base_key: 'subject.egstemuniv.v01.che'
       )
     end
     if Subject.where(tree_type_id: @egstem.id, code: 'engl').count < 1
       @subjects << Subject.create(
         tree_type_id: @egstem.id,
         code: 'engl',
-        base_key: 'subject.egstemuniv.engl'
+        base_key: 'subject.egstemuniv.v01.engl'
       )
     end
     if Subject.where(tree_type_id: @egstem.id, code: 'edu').count < 1
       @subjects << Subject.create(
         tree_type_id: @egstem.id,
         code: 'edu',
-        base_key: 'subject.egstemuniv.edu'
+        base_key: 'subject.egstemuniv.v01.edu'
       )
     end
     if Subject.where(tree_type_id: @egstem.id, code: 'geo').count < 1
       @subjects << Subject.create(
         tree_type_id: @egstem.id,
         code: 'geo',
-        base_key: 'subject.egstemuniv.geo'
+        base_key: 'subject.egstemuniv.v01.geo'
       )
     end
     if Subject.where(tree_type_id: @egstem.id, code: 'mat').count < 1
       @subjects << Subject.create(
         tree_type_id: @egstem.id,
         code: 'mat',
-        base_key: 'subject.egstemuniv.mat'
+        base_key: 'subject.egstemuniv.v01.mat'
       )
     end
     if Subject.where(tree_type_id: @egstem.id, code: 'mec').count < 1
       @subjects << Subject.create(
         tree_type_id: @egstem.id,
         code: 'mec',
-        base_key: 'subject.egstemuniv.mec'
+        base_key: 'subject.egstemuniv.v01.mec'
       )
     end
     if Subject.where(tree_type_id: @egstem.id, code: 'phy').count < 1
       @subjects << Subject.create(
         tree_type_id: @egstem.id,
         code: 'phy',
-        base_key: 'subject.egstemuniv.phy'
+        base_key: 'subject.egstemuniv.v01.phy'
       )
     end
     puts "Subjects are created for EGSTEM"
 
     #bio
-    rec, status, message = Translation.find_or_update_translation(BaseRec::LOCALE_EN, 'subject.egstemuniv.bio.name', 'Biology')
+    rec, status, message = Translation.find_or_update_translation(BaseRec::LOCALE_EN, 'subject.egstemuniv.v01.bio.name', 'Biology')
     throw "ERROR updating sector translation: #{message}" if status == BaseRec::REC_ERROR
-    rec, status, message = Translation.find_or_update_translation(BaseRec::LOCALE_EN, 'subject.egstemuniv.bio.abbr', 'Bio')
+    rec, status, message = Translation.find_or_update_translation(BaseRec::LOCALE_EN, 'subject.egstemuniv.v01.bio.abbr', 'Bio')
     throw "ERROR updating sector translation: #{message}" if status == BaseRec::REC_ERROR
 
     #cap
-    rec, status, message = Translation.find_or_update_translation(BaseRec::LOCALE_EN, 'subject.egstemuniv.cap.name', 'Capstones')
+    rec, status, message = Translation.find_or_update_translation(BaseRec::LOCALE_EN, 'subject.egstemuniv.v01.cap.name', 'Capstones')
     throw "ERROR updating sector translation: #{message}" if status == BaseRec::REC_ERROR
-    rec, status, message = Translation.find_or_update_translation(BaseRec::LOCALE_EN, 'subject.egstemuniv.cap.abbr', 'Cap')
+    rec, status, message = Translation.find_or_update_translation(BaseRec::LOCALE_EN, 'subject.egstemuniv.v01.cap.abbr', 'Cap')
     throw "ERROR updating sector translation: #{message}" if status == BaseRec::REC_ERROR
 
     #che
-    rec, status, message = Translation.find_or_update_translation(BaseRec::LOCALE_EN, 'subject.egstemuniv.che.name', 'Chemistry')
+    rec, status, message = Translation.find_or_update_translation(BaseRec::LOCALE_EN, 'subject.egstemuniv.v01.che.name', 'Chemistry')
     throw "ERROR updating sector translation: #{message}" if status == BaseRec::REC_ERROR
-    rec, status, message = Translation.find_or_update_translation(BaseRec::LOCALE_EN, 'subject.egstemuniv.che.abbr', 'Chem')
+    rec, status, message = Translation.find_or_update_translation(BaseRec::LOCALE_EN, 'subject.egstemuniv.v01.che.abbr', 'Chem')
     throw "ERROR updating sector translation: #{message}" if status == BaseRec::REC_ERROR
 
     #engl
-    rec, status, message = Translation.find_or_update_translation(BaseRec::LOCALE_EN, 'subject.egstemuniv.engl.name', 'English')
+    rec, status, message = Translation.find_or_update_translation(BaseRec::LOCALE_EN, 'subject.egstemuniv.v01.engl.name', 'English')
     throw "ERROR updating sector translation: #{message}" if status == BaseRec::REC_ERROR
-    rec, status, message = Translation.find_or_update_translation(BaseRec::LOCALE_EN, 'subject.egstemuniv.engl.abbr', 'Engl')
+    rec, status, message = Translation.find_or_update_translation(BaseRec::LOCALE_EN, 'subject.egstemuniv.v01.engl.abbr', 'Engl')
     throw "ERROR updating sector translation: #{message}" if status == BaseRec::REC_ERROR
 
     #edu
-    rec, status, message = Translation.find_or_update_translation(BaseRec::LOCALE_EN, 'subject.egstemuniv.edu.name', 'Education')
+    rec, status, message = Translation.find_or_update_translation(BaseRec::LOCALE_EN, 'subject.egstemuniv.v01.edu.name', 'Education')
     throw "ERROR updating sector translation: #{message}" if status == BaseRec::REC_ERROR
-    rec, status, message = Translation.find_or_update_translation(BaseRec::LOCALE_EN, 'subject.egstemuniv.edu.abbr', 'Edu')
+    rec, status, message = Translation.find_or_update_translation(BaseRec::LOCALE_EN, 'subject.egstemuniv.v01.edu.abbr', 'Edu')
     throw "ERROR updating sector translation: #{message}" if status == BaseRec::REC_ERROR
 
     #geo
-    rec, status, message = Translation.find_or_update_translation(BaseRec::LOCALE_EN, 'subject.egstemuniv.geo.name', 'Geology')
+    rec, status, message = Translation.find_or_update_translation(BaseRec::LOCALE_EN, 'subject.egstemuniv.v01.geo.name', 'Geology')
     throw "ERROR updating sector translation: #{message}" if status == BaseRec::REC_ERROR
-    rec, status, message = Translation.find_or_update_translation(BaseRec::LOCALE_EN, 'subject.egstemuniv.geo.abbr', 'Geo')
+    rec, status, message = Translation.find_or_update_translation(BaseRec::LOCALE_EN, 'subject.egstemuniv.v01.geo.abbr', 'Geo')
     throw "ERROR updating sector translation: #{message}" if status == BaseRec::REC_ERROR
 
     #mat
-    rec, status, message = Translation.find_or_update_translation(BaseRec::LOCALE_EN, 'subject.egstemuniv.mat.name', 'Mathematics')
+    rec, status, message = Translation.find_or_update_translation(BaseRec::LOCALE_EN, 'subject.egstemuniv.v01.mat.name', 'Mathematics')
     throw "ERROR updating sector translation: #{message}" if status == BaseRec::REC_ERROR
-    rec, status, message = Translation.find_or_update_translation(BaseRec::LOCALE_EN, 'subject.egstemuniv.mat.abbr', 'Math')
+    rec, status, message = Translation.find_or_update_translation(BaseRec::LOCALE_EN, 'subject.egstemuniv.v01.mat.abbr', 'Math')
     throw "ERROR updating sector translation: #{message}" if status == BaseRec::REC_ERROR
 
     #mec
-    rec, status, message = Translation.find_or_update_translation(BaseRec::LOCALE_EN, 'subject.egstemuniv.mec.name', 'Mechanics')
+    rec, status, message = Translation.find_or_update_translation(BaseRec::LOCALE_EN, 'subject.egstemuniv.v01.mec.name', 'Mechanics')
     throw "ERROR updating sector translation: #{message}" if status == BaseRec::REC_ERROR
-    rec, status, message = Translation.find_or_update_translation(BaseRec::LOCALE_EN, 'subject.egstemuniv.mec.abbr', 'Mec')
+    rec, status, message = Translation.find_or_update_translation(BaseRec::LOCALE_EN, 'subject.egstemuniv.v01.mec.abbr', 'Mec')
     throw "ERROR updating sector translation: #{message}" if status == BaseRec::REC_ERROR
 
     #phy
-    rec, status, message = Translation.find_or_update_translation(BaseRec::LOCALE_EN, 'subject.egstemuniv.phy.name', 'Physics')
+    rec, status, message = Translation.find_or_update_translation(BaseRec::LOCALE_EN, 'subject.egstemuniv.v01.phy.name', 'Physics')
     throw "ERROR updating sector translation: #{message}" if status == BaseRec::REC_ERROR
-    rec, status, message = Translation.find_or_update_translation(BaseRec::LOCALE_EN, 'subject.egstemuniv.phy.abbr', 'Phy')
+    rec, status, message = Translation.find_or_update_translation(BaseRec::LOCALE_EN, 'subject.egstemuniv.v01.phy.abbr', 'Phy')
     throw "ERROR updating sector translation: #{message}" if status == BaseRec::REC_ERROR
 
     puts "subject translations are created for EGSTEM"

--- a/lib/tasks/seed_turkey.rake
+++ b/lib/tasks/seed_turkey.rake
@@ -169,7 +169,7 @@ namespace :seed_turkey do
       @subjects << Subject.create(
         tree_type_id: @tfv.id,
         code: 'bio',
-        base_key: 'subject.tfv.bio'
+        base_key: 'subject.tfv.v01.bio'
       )
     end
     @bio = Subject.where(tree_type_id: @tfv.id, code: 'bio').first
@@ -177,7 +177,7 @@ namespace :seed_turkey do
       @subjects << Subject.create(
         tree_type_id: @tfv.id,
         code: 'che',
-        base_key: 'subject.tfv.che'
+        base_key: 'subject.tfv.v01.che'
       )
     end
     @che = Subject.where(tree_type_id: @tfv.id, code: 'che').first
@@ -185,7 +185,7 @@ namespace :seed_turkey do
       @subjects << Subject.create(
         tree_type_id: @tfv.id,
         code: 'mat',
-        base_key: 'subject.tfv.mat'
+        base_key: 'subject.tfv.v01.mat'
       )
     end
     @mat = Subject.where(tree_type_id: @tfv.id, code: 'mat').first
@@ -193,7 +193,7 @@ namespace :seed_turkey do
       @subjects << Subject.create(
         tree_type_id: @tfv.id,
         code: 'sci',
-        base_key: 'subject.tfv.sci'
+        base_key: 'subject.tfv.v01.sci'
       )
     end
     @sci = Subject.where(tree_type_id: @tfv.id, code: 'sci').first
@@ -201,7 +201,7 @@ namespace :seed_turkey do
       @subjects << Subject.create(
         tree_type_id: @tfv.id,
         code: 'phy',
-        base_key: 'subject.tfv.phy'
+        base_key: 'subject.tfv.v01.phy'
       )
     end
     @phy = Subject.where(tree_type_id: @tfv.id, code: 'phy').first
@@ -209,7 +209,7 @@ namespace :seed_turkey do
       @subjects << Subject.create(
         tree_type_id: @tfv.id,
         code: 'ear',
-        base_key: 'subject.tfv.ear'
+        base_key: 'subject.tfv.v01.ear'
       )
     end
     @ear = Subject.where(tree_type_id: @tfv.id, code: 'ear').first
@@ -217,59 +217,59 @@ namespace :seed_turkey do
     @subj_math = [@mat]
     @subj_sci = [@sci]
 
-    rec, status, message = Translation.find_or_update_translation(BaseRec::LOCALE_EN, 'subject.tfv.bio.name', 'Biology')
+    rec, status, message = Translation.find_or_update_translation(BaseRec::LOCALE_EN, 'subject.tfv.v01.bio.name', 'Biology')
     throw "ERROR updating sector translation: #{message}" if status == BaseRec::REC_ERROR
-    rec, status, message = Translation.find_or_update_translation(BaseRec::LOCALE_EN, 'subject.tfv.bio.abbr', 'Bio')
+    rec, status, message = Translation.find_or_update_translation(BaseRec::LOCALE_EN, 'subject.tfv.v01.bio.abbr', 'Bio')
     throw "ERROR updating sector translation: #{message}" if status == BaseRec::REC_ERROR
-    rec, status, message = Translation.find_or_update_translation(BaseRec::LOCALE_TR, 'subject.tfv.bio.name', 'Biyoloji')
+    rec, status, message = Translation.find_or_update_translation(BaseRec::LOCALE_TR, 'subject.tfv.v01.bio.name', 'Biyoloji')
     throw "ERROR updating sector translation: #{message}" if status == BaseRec::REC_ERROR
-    rec, status, message = Translation.find_or_update_translation(BaseRec::LOCALE_TR, 'subject.tfv.bio.abbr', 'Biy')
-    throw "ERROR updating sector translation: #{message}" if status == BaseRec::REC_ERROR
-
-    rec, status, message = Translation.find_or_update_translation(BaseRec::LOCALE_EN, 'subject.tfv.che.name', 'Chemistry')
-    throw "ERROR updating sector translation: #{message}" if status == BaseRec::REC_ERROR
-    rec, status, message = Translation.find_or_update_translation(BaseRec::LOCALE_EN, 'subject.tfv.che.abbr', 'Chem')
-    throw "ERROR updating sector translation: #{message}" if status == BaseRec::REC_ERROR
-    rec, status, message = Translation.find_or_update_translation(BaseRec::LOCALE_TR, 'subject.tfv.che.name', 'Kimya')
-    throw "ERROR updating sector translation: #{message}" if status == BaseRec::REC_ERROR
-    rec, status, message = Translation.find_or_update_translation(BaseRec::LOCALE_TR, 'subject.tfv.che.abbr', 'Kim')
+    rec, status, message = Translation.find_or_update_translation(BaseRec::LOCALE_TR, 'subject.tfv.v01.bio.abbr', 'Biy')
     throw "ERROR updating sector translation: #{message}" if status == BaseRec::REC_ERROR
 
-    rec, status, message = Translation.find_or_update_translation(BaseRec::LOCALE_EN, 'subject.tfv.mat.name', 'Mathematics')
+    rec, status, message = Translation.find_or_update_translation(BaseRec::LOCALE_EN, 'subject.tfv.v01.che.name', 'Chemistry')
     throw "ERROR updating sector translation: #{message}" if status == BaseRec::REC_ERROR
-    rec, status, message = Translation.find_or_update_translation(BaseRec::LOCALE_EN, 'subject.tfv.mat.abbr', 'Math')
+    rec, status, message = Translation.find_or_update_translation(BaseRec::LOCALE_EN, 'subject.tfv.v01.che.abbr', 'Chem')
     throw "ERROR updating sector translation: #{message}" if status == BaseRec::REC_ERROR
-    rec, status, message = Translation.find_or_update_translation(BaseRec::LOCALE_TR, 'subject.tfv.mat.name', 'Matematik')
+    rec, status, message = Translation.find_or_update_translation(BaseRec::LOCALE_TR, 'subject.tfv.v01.che.name', 'Kimya')
     throw "ERROR updating sector translation: #{message}" if status == BaseRec::REC_ERROR
-    rec, status, message = Translation.find_or_update_translation(BaseRec::LOCALE_TR, 'subject.tfv.mat.abbr', 'Mat')
-    throw "ERROR updating sector translation: #{message}" if status == BaseRec::REC_ERROR
-
-    rec, status, message = Translation.find_or_update_translation(BaseRec::LOCALE_EN, 'subject.tfv.phy.name', 'Physics')
-    throw "ERROR updating sector translation: #{message}" if status == BaseRec::REC_ERROR
-    rec, status, message = Translation.find_or_update_translation(BaseRec::LOCALE_EN, 'subject.tfv.phy.abbr', 'Phy')
-    throw "ERROR updating sector translation: #{message}" if status == BaseRec::REC_ERROR
-    rec, status, message = Translation.find_or_update_translation(BaseRec::LOCALE_TR, 'subject.tfv.phy.name', 'Fizik')
-    throw "ERROR updating sector translation: #{message}" if status == BaseRec::REC_ERROR
-    rec, status, message = Translation.find_or_update_translation(BaseRec::LOCALE_TR, 'subject.tfv.phy.abbr', 'Fiz')
+    rec, status, message = Translation.find_or_update_translation(BaseRec::LOCALE_TR, 'subject.tfv.v01.che.abbr', 'Kim')
     throw "ERROR updating sector translation: #{message}" if status == BaseRec::REC_ERROR
 
-    rec, status, message = Translation.find_or_update_translation(BaseRec::LOCALE_EN, 'subject.tfv.sci.name', 'Science')
+    rec, status, message = Translation.find_or_update_translation(BaseRec::LOCALE_EN, 'subject.tfv.v01.mat.name', 'Mathematics')
     throw "ERROR updating sector translation: #{message}" if status == BaseRec::REC_ERROR
-    rec, status, message = Translation.find_or_update_translation(BaseRec::LOCALE_EN, 'subject.tfv.sci.abbr', 'Sci')
+    rec, status, message = Translation.find_or_update_translation(BaseRec::LOCALE_EN, 'subject.tfv.v01.mat.abbr', 'Math')
     throw "ERROR updating sector translation: #{message}" if status == BaseRec::REC_ERROR
-    rec, status, message = Translation.find_or_update_translation(BaseRec::LOCALE_TR, 'subject.tfv.sci.name', 'Bilim')
+    rec, status, message = Translation.find_or_update_translation(BaseRec::LOCALE_TR, 'subject.tfv.v01.mat.name', 'Matematik')
     throw "ERROR updating sector translation: #{message}" if status == BaseRec::REC_ERROR
-    rec, status, message = Translation.find_or_update_translation(BaseRec::LOCALE_TR, 'subject.tfv.sci.abbr', 'Bil')
+    rec, status, message = Translation.find_or_update_translation(BaseRec::LOCALE_TR, 'subject.tfv.v01.mat.abbr', 'Mat')
     throw "ERROR updating sector translation: #{message}" if status == BaseRec::REC_ERROR
 
-    rec, status, message = Translation.find_or_update_translation(BaseRec::LOCALE_EN, 'subject.tfv.ear.name', 'Earth, Space, & Environmental Science')
+    rec, status, message = Translation.find_or_update_translation(BaseRec::LOCALE_EN, 'subject.tfv.v01.phy.name', 'Physics')
     throw "ERROR updating sector translation: #{message}" if status == BaseRec::REC_ERROR
-    rec, status, message = Translation.find_or_update_translation(BaseRec::LOCALE_EN, 'subject.tfv.ear.abbr', 'Ear')
+    rec, status, message = Translation.find_or_update_translation(BaseRec::LOCALE_EN, 'subject.tfv.v01.phy.abbr', 'Phy')
     throw "ERROR updating sector translation: #{message}" if status == BaseRec::REC_ERROR
-    rec, status, message = Translation.find_or_update_translation(BaseRec::LOCALE_TR, 'subject.tfv.ear.name', '
+    rec, status, message = Translation.find_or_update_translation(BaseRec::LOCALE_TR, 'subject.tfv.v01.phy.name', 'Fizik')
+    throw "ERROR updating sector translation: #{message}" if status == BaseRec::REC_ERROR
+    rec, status, message = Translation.find_or_update_translation(BaseRec::LOCALE_TR, 'subject.tfv.v01.phy.abbr', 'Fiz')
+    throw "ERROR updating sector translation: #{message}" if status == BaseRec::REC_ERROR
+
+    rec, status, message = Translation.find_or_update_translation(BaseRec::LOCALE_EN, 'subject.tfv.v01.sci.name', 'Science')
+    throw "ERROR updating sector translation: #{message}" if status == BaseRec::REC_ERROR
+    rec, status, message = Translation.find_or_update_translation(BaseRec::LOCALE_EN, 'subject.tfv.v01.sci.abbr', 'Sci')
+    throw "ERROR updating sector translation: #{message}" if status == BaseRec::REC_ERROR
+    rec, status, message = Translation.find_or_update_translation(BaseRec::LOCALE_TR, 'subject.tfv.v01.sci.name', 'Bilim')
+    throw "ERROR updating sector translation: #{message}" if status == BaseRec::REC_ERROR
+    rec, status, message = Translation.find_or_update_translation(BaseRec::LOCALE_TR, 'subject.tfv.v01.sci.abbr', 'Bil')
+    throw "ERROR updating sector translation: #{message}" if status == BaseRec::REC_ERROR
+
+    rec, status, message = Translation.find_or_update_translation(BaseRec::LOCALE_EN, 'subject.tfv.v01.ear.name', 'Earth, Space, & Environmental Science')
+    throw "ERROR updating sector translation: #{message}" if status == BaseRec::REC_ERROR
+    rec, status, message = Translation.find_or_update_translation(BaseRec::LOCALE_EN, 'subject.tfv.v01.ear.abbr', 'Ear')
+    throw "ERROR updating sector translation: #{message}" if status == BaseRec::REC_ERROR
+    rec, status, message = Translation.find_or_update_translation(BaseRec::LOCALE_TR, 'subject.tfv.v01.ear.name', '
     Dünya, Uzay ve Çevre Bilimi')
     throw "ERROR updating sector translation: #{message}" if status == BaseRec::REC_ERROR
-    rec, status, message = Translation.find_or_update_translation(BaseRec::LOCALE_TR, 'subject.tfv.ear.abbr', 'Dün')
+    rec, status, message = Translation.find_or_update_translation(BaseRec::LOCALE_TR, 'subject.tfv.v01.ear.abbr', 'Dün')
     throw "ERROR updating sector translation: #{message}" if status == BaseRec::REC_ERROR
   end #create_subjects
 

--- a/lib/tasks/seed_turkey.rake
+++ b/lib/tasks/seed_turkey.rake
@@ -7,6 +7,9 @@ namespace :seed_turkey do
   desc "create the Curriculum Tree Type and Version"
   task create_tree_type: :environment do
 
+    #WARNING: Original tree type code for this curriculum was 'TFV', not 'tfv.'
+    #         Running this task as-is will alter the wrong TreeType record.
+
     # reference version record from seeds.rb
     @v01 = Version.where(code: 'v01').first
     throw "Missing version record" if !@v01

--- a/lib/tasks/seed_turkey_v02.rake
+++ b/lib/tasks/seed_turkey_v02.rake
@@ -132,7 +132,7 @@ namespace :seed_turkey_v02 do
       @subjects << Subject.create(
         tree_type_id: @tfv.id,
         code: 'bio',
-        base_key: 'subject.tfv.bio'
+        base_key: 'subject.tfv.v02.bio'
       )
     end
     @bio = Subject.where(tree_type_id: @tfv.id, code: 'bio').first
@@ -140,7 +140,7 @@ namespace :seed_turkey_v02 do
       @subjects << Subject.create(
         tree_type_id: @tfv.id,
         code: 'che',
-        base_key: 'subject.tfv.che'
+        base_key: 'subject.tfv.v02.che'
       )
     end
     @che = Subject.where(tree_type_id: @tfv.id, code: 'che').first
@@ -148,7 +148,7 @@ namespace :seed_turkey_v02 do
       @subjects << Subject.create(
         tree_type_id: @tfv.id,
         code: 'mat',
-        base_key: 'subject.tfv.mat'
+        base_key: 'subject.tfv.v02.mat'
       )
     end
     @mat = Subject.where(tree_type_id: @tfv.id, code: 'mat').first
@@ -156,7 +156,7 @@ namespace :seed_turkey_v02 do
       @subjects << Subject.create(
         tree_type_id: @tfv.id,
         code: 'sci',
-        base_key: 'subject.tfv.sci'
+        base_key: 'subject.tfv.v02.sci'
       )
     end
     @sci = Subject.where(tree_type_id: @tfv.id, code: 'sci').first
@@ -164,7 +164,7 @@ namespace :seed_turkey_v02 do
       @subjects << Subject.create(
         tree_type_id: @tfv.id,
         code: 'phy',
-        base_key: 'subject.tfv.phy'
+        base_key: 'subject.tfv.v02.phy'
       )
     end
     @phy = Subject.where(tree_type_id: @tfv.id, code: 'phy').first
@@ -172,7 +172,7 @@ namespace :seed_turkey_v02 do
       @subjects << Subject.create(
         tree_type_id: @tfv.id,
         code: 'ear',
-        base_key: 'subject.tfv.ear'
+        base_key: 'subject.tfv.v02.ear'
       )
     end
     @ear = Subject.where(tree_type_id: @tfv.id, code: 'ear').first

--- a/lib/tasks/seed_turkey_v02b.rake
+++ b/lib/tasks/seed_turkey_v02b.rake
@@ -50,15 +50,15 @@ namespace :seed_turkey_v02b do
       tech = Subject.create(
         tree_type_id: @tfv.id,
         code: 'tech',
-        base_key: 'subject.tfv.tech',
+        base_key: 'subject.tfv.v02.tech',
         min_grade: 0,
         max_grade: 12
       )
     end
-    Translation.find_or_update_translation(@loc_en.code, 'subject.tfv.tech.name', 'Tech Engineering')
-    Translation.find_or_update_translation(@loc_en.code, 'subject.tfv.tech.abbr', 'Tech')
-    Translation.find_or_update_translation(@loc_en.code, 'subject.base.tech.name', 'Tech Engineering')
-    Translation.find_or_update_translation(@loc_en.code, 'subject.base.tech.abbr', 'tech')
+    Translation.find_or_update_translation(@loc_en.code, 'subject.tfv.v02.tech.name', 'Tech Engineering')
+    Translation.find_or_update_translation(@loc_en.code, 'subject.tfv.v02.tech.abbr', 'Tech')
+    Translation.find_or_update_translation(@loc_en.code, 'subject.default.tech.name', 'Tech Engineering')
+    Translation.find_or_update_translation(@loc_en.code, 'subject.default.tech.abbr', 'tech')
 
     @subjects = []
     @bio = Subject.where(tree_type_id: @tfv.id, code: 'bio').first

--- a/lib/tasks/translation_keys.rake
+++ b/lib/tasks/translation_keys.rake
@@ -24,12 +24,12 @@ namespace :translation_keys do
         puts "missing locale abbr translation for #{s.code} Subject: #{s.id}"
       end
       names.each do |rec|
-        puts "Updating translation #{rec.id}: '#{rec.value}' with key: #{subject.get_versioned_name_key}"
-        rec.update(key: subject.get_versioned_name_key)
+        puts "Updating translation #{rec.id}: '#{rec.value}' with key: #{s.get_versioned_name_key}"
+        rec.update(key: s.get_versioned_name_key)
       end
       abbrs.each do |rec|
-        puts "Updating translation #{rec.id}: '#{rec.value}' with key: #{subject.get_versioned_abbr_key}"
-        rec.update(key: subject.get_versioned_abbr_key)
+        puts "Updating translation #{rec.id}: '#{rec.value}' with key: #{s.get_versioned_abbr_key}"
+        rec.update(key: s.get_versioned_abbr_key)
       end
       puts "[Subject #{s.id}] Updating subject base key from '#{s.base_key}' to #{s.build_base_key}"
       s.update(base_key: s.build_base_key)

--- a/lib/tasks/translation_keys.rake
+++ b/lib/tasks/translation_keys.rake
@@ -1,0 +1,65 @@
+# translation_keys.rake
+namespace :translation_keys do
+  desc "Fix subject name and abbr translation keys in both Subject and Translation Records"
+  task fix_subjects: :environment do
+    subjects = Subject.all
+    subject_codes = subjects.pluck('code').uniq
+    BaseRec::BASE_SUBJECTS.map {|code| subject_codes << code if !subject_codes.include?(code) }
+
+    #fix translation keys for:
+    # - Curriculum specific subject name
+    # - Curriculum specific subject abbreviation
+    # Then fix subject base keys
+    subjects.each do |s|
+      names = Translation.where(:key => "#{s.base_key}.name")
+      abbrs = Translation.where(:key => "#{s.base_key}.abbr")
+      if names.count == 0
+        puts "missing name translations for #{s.code} Subject: #{s.id}"
+      elsif names.count == 1
+        puts "missing locale name translation for #{s.code} Subject: #{s.id}"
+      end
+      if abbrs.count == 0
+        puts "missing abbr translations for #{s.code} Subject: #{s.id}"
+      elsif abbrs.count == 1
+        puts "missing locale abbr translation for #{s.code} Subject: #{s.id}"
+      end
+      names.each do |rec|
+        puts "Updating translation #{rec.id}: '#{rec.value}' with key: #{subject.get_versioned_name_key}"
+        rec.update(key: subject.get_versioned_name_key)
+      end
+      abbrs.each do |rec|
+        puts "Updating translation #{rec.id}: '#{rec.value}' with key: #{subject.get_versioned_abbr_key}"
+        rec.update(key: subject.get_versioned_abbr_key)
+      end
+      puts "[Subject #{s.id}] Updating subject base key from '#{s.base_key}' to #{s.build_base_key}"
+      s.update(base_key: s.build_base_key)
+    end
+
+    #fix translation keys for:
+    # - Default subject name for subject code from BaseRec
+    # - Default subject abbreviation for subject code from BaseRec
+    subject_codes.each do |code|
+      names = Translation.where(:key => "subject.base.#{code}.name")
+      abbrs = Translation.where(:key => "subject.base.#{code}.abbr")
+      if names.count == 0
+        puts "missing default name translations for code: #{code}"
+      elsif names.count == 1
+        puts "in at least one locale, missing a default name translation for code: #{code}"
+      end
+      if abbrs.count == 0
+        puts "missing default abbr translations for code: #{code}"
+      elsif abbrs.count == 1
+        puts "in at least one locale, missing a default abbr translation for code: #{code}"
+      end
+      names.each do |rec|
+        puts "Updating translation #{rec.id}: '#{rec.value}' with key: #{Subject.get_default_name_key(code)}"
+        rec.update(key: Subject.get_default_name_key(code))
+      end
+      abbrs.each do |rec|
+        puts "Updating translation #{rec.id}: '#{rec.value}' with key: #{Subject.get_default_abbr_key(code)}"
+        rec.update(key: Subject.get_default_abbr_key(code))
+      end
+    end
+
+  end # task fix_subjects
+end


### PR DESCRIPTION
- Adds new rake process: `translation_keys:fix_subjects` to update Subject base keys, and Translation keys for subject names and abbreviations
- Updates rake files with new coding for looking up subjects
- Updated documentation of translation keys in the Subject model. Methods to lookup subject translation keys in the subject model are now:
```
def build_base_key
    treeTypeRec = TreeType.find(tree_type_id)
    versionRec = Version.find(treeTypeRec.version_id)
    return "subject.#{treeTypeRec.code}.#{versionRec.code}.#{code}"
  end

  # Returns curriculum-specific translation key for a subject name.
  def get_versioned_name_key
    return "#{build_base_key}.name"
  end

  # Returns curriculum-specific translation key for a subject abbreviation.
  def get_versioned_abbr_key
    return "#{build_base_key}.abbr"
  end

  # The default Translation key for BaseRec subject names
  def self.get_default_name_key(code)
    return "subject.default.#{code}.name"
  end

  # The default Translation key for BaseRec subject abbreviations
  def self.get_default_abbr_key(code)
    return "subject.default.#{code}.abbr"
  end
```
- Update app code to use the new translation lookup methods
- Fix exception caused by missing data in the Sectors controller, discovered while testing changes to  subject translation lookup. Instead of generating an exception, write the issue to the data_complaints log and work around it.


**NOTE:** After putting this update in production, run: `RAILS_ENV=production bundle exec rake translation_keys:fix_subjects`