### PR TITLE
Detail whitespace

### DIFF
--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -94,6 +94,10 @@ body {
     padding-left: 15px;
   }
 
+  .padding-right {
+    padding-right: 15px;
+  }
+
   .right-margin {
     margin-right: 5px;
   }

--- a/app/assets/stylesheets/trees.scss
+++ b/app/assets/stylesheets/trees.scss
@@ -246,6 +246,10 @@
   }
 
   .detail-page {
+    .grid-2 {
+      display: grid;
+      grid-template-columns: 50% 50%;
+    }
     .label {
       background-color: #ddd;
     }

--- a/app/controllers/trees_controller.rb
+++ b/app/controllers/trees_controller.rb
@@ -763,6 +763,12 @@ class TreesController < ApplicationController
         elsif a.first == "(" && a.last == ")"
           detail_type = 'header'
           detail = a[1..a.length - 2]
+        elsif a.first == "<" && a.last == "<"
+          detail_type = 'left-col'
+          detail = a[1..a.length - 2]
+        elsif a.first == ">" && a.last == ">"
+          detail_type = 'right-col'
+          detail = a[1..a.length - 2]
         end
         detail = detail.split("_").join("")
         @detail_headers << {type: detail_type, name: detail, depth: hierarchy_codes.index(detail) } if detail_type == 'header'

--- a/app/views/trees/show.html.erb
+++ b/app/views/trees/show.html.erb
@@ -67,11 +67,15 @@
       <!-- Dynamically Ordered Tables -->
       <% @detail_areas.each do |area|
           detail = detail_lookup[:"#{area[:name]}"]
+          if area[:type] == "left-col"
           %>
+            <div class='related-items-table grid-2'>
           <%
-          if detail && (detail[:dim] || detail[:sector])%>
+          end #if detail && detail[:dim_code] == 'essq'
+          if detail && (detail[:dim] || detail[:sector])
+          %>
           <%=
-          render partial: "trees/show/detail_area", locals: {
+            render partial: "trees/show/detail_area", locals: {
               detail_title: detail[:title],
               details: detail[:details],
               dim: detail[:dim],
@@ -104,6 +108,9 @@
           <%
           end #detail && (detail[:dim] || detail[:sector]
           %>
+          <% if area[:type] == "right-col" %>
+            </div>
+          <% end #if detail && detail[:dim_code] == 'bigidea' %>
       <% end #@detail_areas.each do |area| %>
 
 

--- a/app/views/trees/show.html.erb
+++ b/app/views/trees/show.html.erb
@@ -127,78 +127,102 @@
           <div class='center-label sub-header-margin'>
             <%= Outcome.get_ref_name(Outcome::REF_TYPES[0], @locale_code, @sectorName) %>
           </div>
-          <div class="rel-sectors text-left padding-left">
-            <%= Translation.find_translation_name(
-            @locale_code,
-            @tree.outcome.get_ref_key(Outcome::REF_TYPES[0]),
-            ""
-            ).html_safe %>
-            <%= link_to(fa_icon("edit"), edit_tree_path(@tree.id, tree: { edit_type: Outcome::REF_TYPES[0] }), {:class => "fa-lg pull-right", :remote => true, 'data-toggle' =>  "modal", 'data-target' => '#modal_popup'}) if @editMe && can_edit_type?('refs') %>
+          <div class="rel-sectors text-left padding-left padding-right row margin-top margin-bottom">
+            <div class="col col-11">
+              <%= Translation.find_translation_name(
+              @locale_code,
+              @tree.outcome.get_ref_key(Outcome::REF_TYPES[0]),
+              ""
+              ).html_safe %>
+            </div>
+            <div class="col col-1">
+             <%= link_to(fa_icon("edit"), edit_tree_path(@tree.id, tree: { edit_type: Outcome::REF_TYPES[0] }), {:class => "fa-lg pull-right", :remote => true, 'data-toggle' =>  "modal", 'data-target' => '#modal_popup'}) if @editMe && can_edit_type?('refs') %>
+            </div>
           </div>
         </div>
         <div class='teacher-item'>
           <div class='center-label sub-header-margin'>
             <%= Outcome.get_ref_name(Outcome::REF_TYPES[1], @locale_code, @sectorName) %>
           </div>
-          <div class="rel-sectors text-left padding-left">
-            <%= Translation.find_translation_name(
-            @locale_code,
-            @tree.outcome.get_ref_key(Outcome::REF_TYPES[1]),
-            ""
-            ).html_safe %>
-            <%= link_to(fa_icon("edit"), edit_tree_path(@tree.id, tree: { edit_type: Outcome::REF_TYPES[1] }), {:class => "fa-lg pull-right", :remote => true, 'data-toggle' =>  "modal", 'data-target' => '#modal_popup'}) if @editMe && can_edit_type?('refs') %>
+          <div class="rel-sectors text-left padding-left padding-right row margin-top margin-bottom">
+            <div class="col col-11">
+              <%= Translation.find_translation_name(
+              @locale_code,
+              @tree.outcome.get_ref_key(Outcome::REF_TYPES[1]),
+              ""
+              ).html_safe %>
+            </div>
+            <div class="col col-1">
+             <%= link_to(fa_icon("edit"), edit_tree_path(@tree.id, tree: { edit_type: Outcome::REF_TYPES[1] }), {:class => "fa-lg pull-right", :remote => true, 'data-toggle' =>  "modal", 'data-target' => '#modal_popup'}) if @editMe && can_edit_type?('refs') %>
+            </div>
           </div>
         </div>
         <div class='teacher-item'>
           <div class='center-label sub-header-margin'>
             <%= Outcome.get_ref_name(Outcome::REF_TYPES[2], @locale_code, @sectorName) %>
           </div>
-          <div class="rel-sectors text-left padding-left">
-            <%= Translation.find_translation_name(
-            @locale_code,
-            @tree.outcome.get_ref_key(Outcome::REF_TYPES[2]),
-            ""
-            ).html_safe %>
-            <%= link_to(fa_icon("edit"), edit_tree_path(@tree.id, tree: { edit_type: Outcome::REF_TYPES[2] }), {:class => "fa-lg pull-right", :remote => true, 'data-toggle' =>  "modal", 'data-target' => '#modal_popup'}) if @editMe && can_edit_type?('refs') %>
+          <div class="rel-sectors text-left padding-left padding-right row margin-top margin-bottom">
+            <div class="col col-11">
+              <%= Translation.find_translation_name(
+              @locale_code,
+              @tree.outcome.get_ref_key(Outcome::REF_TYPES[2]),
+              ""
+              ).html_safe %>
+            </div>
+            <div class="col col-1">
+             <%= link_to(fa_icon("edit"), edit_tree_path(@tree.id, tree: { edit_type: Outcome::REF_TYPES[2] }), {:class => "fa-lg pull-right", :remote => true, 'data-toggle' =>  "modal", 'data-target' => '#modal_popup'}) if @editMe && can_edit_type?('refs') %>
+            </div>
           </div>
         </div>
         <div class='teacher-item'>
           <div class='center-label sub-header-margin'>
             <%= Outcome.get_ref_name(Outcome::REF_TYPES[3], @locale_code, @sectorName) %>
           </div>
-          <div class="rel-sectors text-left padding-left">
-            <%= Translation.find_translation_name(
-            @locale_code,
-            @tree.outcome.get_ref_key(Outcome::REF_TYPES[3]),
-            ""
-            ).html_safe %>
-            <%= link_to(fa_icon("edit"), edit_tree_path(@tree.id, tree: { edit_type: Outcome::REF_TYPES[3] }), {:class => "fa-lg pull-right", :remote => true, 'data-toggle' =>  "modal", 'data-target' => '#modal_popup'}) if @editMe && can_edit_type?('refs') %>
+          <div class="rel-sectors text-left padding-left padding-right row margin-top margin-bottom">
+            <div class="col col-11">
+              <%= Translation.find_translation_name(
+              @locale_code,
+              @tree.outcome.get_ref_key(Outcome::REF_TYPES[3]),
+              ""
+              ).html_safe %>
+            </div>
+            <div class="col col-1">
+             <%= link_to(fa_icon("edit"), edit_tree_path(@tree.id, tree: { edit_type: Outcome::REF_TYPES[3] }), {:class => "fa-lg pull-right", :remote => true, 'data-toggle' =>  "modal", 'data-target' => '#modal_popup'}) if @editMe && can_edit_type?('refs') %>
+            </div>
           </div>
         </div>
         <div class='teacher-item'>
           <div class='center-label sub-header-margin'>
             <%= Outcome.get_ref_name(Outcome::REF_TYPES[4], @locale_code, @sectorName) %>
           </div>
-          <div class="rel-sectors text-left padding-left">
-           <%= Translation.find_translation_name(
-            @locale_code,
-            @tree.outcome.get_ref_key(Outcome::REF_TYPES[4]),
-            ""
-            ).html_safe %>
-           <%= link_to(fa_icon("edit"), edit_tree_path(@tree.id, tree: { edit_type: Outcome::REF_TYPES[4] }), {:class => "fa-lg pull-right", :remote => true, 'data-toggle' =>  "modal", 'data-target' => '#modal_popup'}) if @editMe && can_edit_type?('refs') %>
+          <div class="rel-sectors text-left padding-left padding-right row margin-top margin-bottom">
+            <div class="col col-11">
+              <%= Translation.find_translation_name(
+              @locale_code,
+              @tree.outcome.get_ref_key(Outcome::REF_TYPES[4]),
+              ""
+              ).html_safe %>
+            </div>
+            <div class="col col-1">
+             <%= link_to(fa_icon("edit"), edit_tree_path(@tree.id, tree: { edit_type: Outcome::REF_TYPES[4] }), {:class => "fa-lg pull-right", :remote => true, 'data-toggle' =>  "modal", 'data-target' => '#modal_popup'}) if @editMe && can_edit_type?('refs') %>
+            </div>
           </div>
         </div>
         <div class='teacher-item'>
           <div class='center-label sub-header-margin'>
             <%= Outcome.get_ref_name(Outcome::REF_TYPES[5], @locale_code, @sectorName) %>
           </div>
-          <div class="rel-sectors text-left padding-left">
-            <%= Translation.find_translation_name(
-            @locale_code,
-            @tree.outcome.get_ref_key(Outcome::REF_TYPES[5]),
-            ""
-            ).html_safe %>
-            <%= link_to(fa_icon("edit"), edit_tree_path(@tree.id, tree: { edit_type: Outcome::REF_TYPES[5] }), {:class => "fa-lg pull-right", :remote => true, 'data-toggle' =>  "modal", 'data-target' => '#modal_popup'}) if @editMe && can_edit_type?('refs') %>
+          <div class="rel-sectors text-left padding-left padding-right row margin-top margin-bottom">
+            <div class="col col-11">
+              <%= Translation.find_translation_name(
+              @locale_code,
+              @tree.outcome.get_ref_key(Outcome::REF_TYPES[5]),
+              ""
+              ).html_safe %>
+            </div>
+            <div class="col col-1">
+             <%= link_to(fa_icon("edit"), edit_tree_path(@tree.id, tree: { edit_type: Outcome::REF_TYPES[5] }), {:class => "fa-lg pull-right", :remote => true, 'data-toggle' =>  "modal", 'data-target' => '#modal_popup'}) if @editMe && can_edit_type?('refs') %>
+            </div>
           </div>
         </div>
       </div>

--- a/app/views/trees/show/_connect_detail.html.erb
+++ b/app/views/trees/show/_connect_detail.html.erb
@@ -33,8 +33,11 @@
           </div>
         </div>
         <div class='connections-grid'>
+          <% connectionsFound = 0 %>
           <% @relatedBySubj.each do |subj, rel|%>
-            <% rel.each do |r| %>
+            <% rel.each do |r|
+               connectionsFound += 1
+            %>
               <div class='connections-item'>
                 <%= r[:relationship] %>
               </div>
@@ -56,6 +59,16 @@
                 <% end %>
               </div>
             <% end %>
+          <% end %>
+          <% if connectionsFound == 0 %>
+              <div class='connections-item rel-sectors'>
+              </div>
+              <div class='connections-item rel-sectors'>
+              </div>
+              <div class='connections-item rel-sectors'>
+              </div>
+              <div class='connections-item rel-sectors'>
+              </div>
           <% end %>
         </div>
       </div>

--- a/app/views/trees/show/_detail_area.html.erb
+++ b/app/views/trees/show/_detail_area.html.erb
@@ -18,7 +18,7 @@
       <div class='col col-lg-12 rel-sectors'>
         <%= @translations[d.dim_name_key] %>
         <% if @editMe && can_edit %>
-        <%= link_to(fa_icon("times"), tree_path(@tree.id, tree: { edit_type: 'dimtree', attr_id: dt[:id], active: false}, sector_tree: {active: false}), {:class => "fa-lg pull-right", 'data-confirm' => I18n.t('app.labels.confirm_deactivate', item: @translations[d.dim_name_key]), method: :patch}) if @editMe %>
+        <%= link_to(fa_icon("times"), tree_path(@tree.id, tree: { edit_type: 'dimtree', attr_id: dt[:id], active: false}, sector_tree: {active: false}), {:class => "fa-lg", 'data-confirm' => I18n.t('app.labels.confirm_deactivate', item: @translations[d.dim_name_key]), method: :patch}) if @editMe %>
         <% end #if @editMe %>
       </div>
     </div>
@@ -44,7 +44,7 @@
         html_options = {data: { :sector => st.sector.id }}
       ) %>
       <% if @editMe && can_edit %>
-        <%= link_to(fa_icon("times"), tree_path(@tree.id, tree: { edit_type: 'sector', attr_id: st[:id], active: false}, sector_tree: {active: false}), {:class => "fa-lg pull-right", 'data-confirm' => I18n.t('app.labels.confirm_deactivate', item: @translations[st.sector.name_key]), method: :patch}) if @editMe %>
+        <%= link_to(fa_icon("times"), tree_path(@tree.id, tree: { edit_type: 'sector', attr_id: st[:id], active: false}, sector_tree: {active: false}), {:class => "fa-lg", 'data-confirm' => I18n.t('app.labels.confirm_deactivate', item: @translations[st.sector.name_key]), method: :patch}) if @editMe %>
       <% end %>
     </div>
   </div>

--- a/app/views/trees/show/_detail_area.html.erb
+++ b/app/views/trees/show/_detail_area.html.erb
@@ -5,12 +5,14 @@
       <%= link_to(fa_icon("plus-square"), edit_tree_path(@tree.id, tree: { edit_type: 'sector', attr_id: 'new'}), {:remote => true, :class => "fa-lg pull-right", 'data-toggle' =>  "modal", 'data-target' => '#modal_popup'}) if @editMe && sector && can_edit %>
     </div>
   </div>
+  <% detailsFound = 0 %>
   <% details.each do |dt| %>
   <!-- Dimensions Table (e.g., misconceptions, etc) -->
   <%
   if dim
     d = dt.dimension
     if d.dim_code == dim_code
+      detailsFound += 1
     %>
     <div class='row'>
       <div class='col col-lg-12 rel-sectors'>
@@ -24,6 +26,7 @@
     end #if d.dim_code == dim_code
   elsif sector
     st = dt
+    detailsFound += 1
   %>
     <div class='row'>
     <div class='col col-lg-12 rel-sectors'>
@@ -49,4 +52,9 @@
 <% end #if dim, elsif sector
 end #details.each do |dt|
 %>
+<% if detailsFound == 0 %>
+  <div class="row">
+    <div class="col rel-sectors"></div>
+  </div>
+<% end %>
 </div>

--- a/app/views/trees/show/_tree_detail_area.html.erb
+++ b/app/views/trees/show/_tree_detail_area.html.erb
@@ -27,7 +27,7 @@
 <% elsif comment %>
   <div class='comments'>
     <div class='row center-label-bold top-label'>
-      <div class='col col-lg-12'>
+      <div class='col col-lg-12 rel-sector'>
         <%= I18n.translate('app.labels.comments') %>
         <%= link_to(fa_icon("edit"), edit_tree_path(@tree.id, tree: { edit_type: 'comment'}), {:class => "fa-lg pull-right", :remote => true, 'data-toggle' =>  "modal", 'data-target' => '#modal_popup'}) if @editMe && can_edit %>
       </div>

--- a/lib/tasks/seed_turkey_v02a.rake
+++ b/lib/tasks/seed_turkey_v02a.rake
@@ -33,7 +33,7 @@ namespace :seed_turkey_v02a do
       # ess_q_dim_type: 'essq',
       dim_codes: 'essq,bigidea,miscon',
       tree_code_format: 'subject,grade,unit,sub_unit,comp',
-      detail_headers: 'grade,unit,(sub_unit),comp,[essq],[bigidea],[pract],{explain},[miscon],[sector],[connect],[refs]',
+      detail_headers: 'grade,unit,(sub_unit),comp,<essq<,>bigidea>,[pract],{explain},[miscon],[sector],[connect],[refs]',
       grid_headers: 'grade,unit,(sub_unit),comp,[essq],[bigidea],[pract],explain,[miscon],[connect],[refs]'
     }
     if myTreeType.count < 1
@@ -47,13 +47,13 @@ namespace :seed_turkey_v02a do
     puts "Curriculum (Tree Type) is updated for tfv "
     puts "  Updated Curriculum: #{@tfv.code} with Hierarchy: #{@tfv.hierarchy_codes}"
 
-    rec, status, message = Translation.find_or_update_translation(BaseRec::LOCALE_EN, Dimension.get_dim_type_key(myTreeType.ess_q_dim_type, myTreeType.code, @v02.code), 'K-12 Big Ideas')
-    throw "ERROR updating sector translation: #{message}" if status == BaseRec::REC_ERROR
-    STDOUT.puts 'Create translation record for Essential Questions as K-12 Big Ideas.'
+    # rec, status, message = Translation.find_or_update_translation(BaseRec::LOCALE_EN, Dimension.get_dim_type_key(myTreeType.ess_q_dim_type, myTreeType.code, @v02.code), 'K-12 Big Ideas')
+    # throw "ERROR updating sector translation: #{message}" if status == BaseRec::REC_ERROR
+    # STDOUT.puts 'Create translation record for Essential Questions as K-12 Big Ideas.'
 
-    rec, status, message = Translation.find_or_update_translation(BaseRec::LOCALE_EN, Dimension.get_dim_type_key(myTreeType.big_ideas_dim_type, myTreeType.code, @v02.code), 'Specific Big Ideas')
-    throw "ERROR updating sector translation: #{message}" if status == BaseRec::REC_ERROR
-    STDOUT.puts 'Create translation record for Big Ideas as Specific big ideas.'
+    # rec, status, message = Translation.find_or_update_translation(BaseRec::LOCALE_EN, Dimension.get_dim_type_key(myTreeType.big_ideas_dim_type, myTreeType.code, @v02.code), 'Specific Big Ideas')
+    # throw "ERROR updating sector translation: #{message}" if status == BaseRec::REC_ERROR
+    # STDOUT.puts 'Create translation record for Big Ideas as Specific big ideas.'
 
     # Create translation(s) for hierarchy codes
     rec, status, message = Translation.find_or_update_translation(BaseRec::LOCALE_EN, 'curriculum.tfv.hierarchy.sub_unit', 'Sub-Unit')


### PR DESCRIPTION
- display default whitespace (about 40px) for all tree detail fields when there is no data for that field
- in the TreeType.detail_headers string, two consecutive detail areas framed by two opening brackets ("<") and two closing brackets (">"), respectively, will be part of the same, two-column table. E.g., ".....,<essq<,>bigidea>....."

**NOTE:** after this update, run `RAILS_ENV=production bundle exec rake seed_turkey_v02a:populate` to update TreeType.detail_headers 