### PR TITLE
Fix exception on competences page

### DIFF
--- a/lib/tasks/seed_turkey_v02.rake
+++ b/lib/tasks/seed_turkey_v02.rake
@@ -37,7 +37,7 @@ namespace :seed_turkey_v02 do
       dim_codes: 'essq,bigidea,miscon',
       tree_code_format: 'grade,unit,sub_unit,comp',
       detail_headers: 'grade,unit,(sub_unit),comp,[bigidea],[ess_q],{explain},[miscon],[sector],[connect],[refs]',
-      grid_headers: 'grade,unit,(sub_unit),comp,[bigidea],[ess_q],explain,[miscon],[connect],[refs]'
+      grid_headers: 'grade,unit,(sub_unit),comp,[bigidea],[ess_q],explain,[miscon]'
     }
     if myTreeType.count < 1
       TreeType.create(myTreeTypeValues)

--- a/lib/tasks/seed_turkey_v02a.rake
+++ b/lib/tasks/seed_turkey_v02a.rake
@@ -31,10 +31,10 @@ namespace :seed_turkey_v02a do
       # miscon_dim_type: 'miscon',
       # big_ideas_dim_type: 'bigidea',
       # ess_q_dim_type: 'essq',
-      dim_codes: 'essq,bigidea,miscon',
+      dim_codes: 'essq,bigidea,pract,miscon',
       tree_code_format: 'subject,grade,unit,sub_unit,comp',
       detail_headers: 'grade,unit,(sub_unit),comp,<essq<,>bigidea>,[pract],{explain},[miscon],[sector],[connect],[refs]',
-      grid_headers: 'grade,unit,(sub_unit),comp,[essq],[bigidea],[pract],explain,[miscon],[connect],[refs]'
+      grid_headers: 'grade,unit,(sub_unit),comp,[essq],[bigidea],[pract],{explain},[miscon]'
     }
     if myTreeType.count < 1
       raise 'Missing Tree Type record for tfv v02'


### PR DESCRIPTION
In rake tasks that build the turkey v02 TreeType, fix the TreeType.grid_headers fields to reflect what should show up in the detail grid for each competence, and include 'pract' in the TreeType.dim_codes array.