### PR TITLE
Improve formatting on the tree detail page.

### DIFF
--- a/app/assets/stylesheets/trees.scss
+++ b/app/assets/stylesheets/trees.scss
@@ -246,9 +246,18 @@
   }
 
   .detail-page {
+    .row {
+      margin-left: 0;
+      margin-right: 0;
+    }
     .grid-2 {
       display: grid;
       grid-template-columns: 50% 50%;
+      .row {
+        margin-right: 0;
+        margin-left: 0;
+        border-right: 1px solid black;
+      }
     }
     .label {
       background-color: #ddd;
@@ -285,6 +294,7 @@
       text-align: left;
       border-left: 1px solid black;
       border-bottom: 1px solid black;
+      border-right: 1px solid black;
     }
     .last-col {
       border-right: 1px solid black;
@@ -292,6 +302,7 @@
     .rel-sector-col, .rel-reason-col, .subject-relations, .rel-sectors {
       border-left: 1px solid black;
       border-bottom: 1px solid black;
+      border-right: 1px solid black;
       a .pull-right i {
         margin-left: 5px;
       }
@@ -313,8 +324,8 @@
     }
     .teacher-grid {
       display: grid;
-      margin-left: -15px;
-      margin-right: -15px;
+      /* margin-left: -15px;
+      margin-right: -15px; */
       border-top: 1px solid black;
       border-right: 1px solid black;
       border-bottom: 1px solid black;
@@ -330,8 +341,8 @@
     .connections-grid {
       display: grid;
       grid-template-columns: 10% 10% 13% 67%;
-      margin-left: -15px;
-      margin-right: -15px;
+      /* margin-left: -15px;
+      margin-right: -15px; */
       border-top: 1px solid black;
       border-right: 1px solid black;
     }

--- a/app/views/trees/show/_detail_area.html.erb
+++ b/app/views/trees/show/_detail_area.html.erb
@@ -15,7 +15,7 @@
       detailsFound += 1
     %>
     <div class='row'>
-      <div class='col col-lg-12 rel-sectors'>
+      <div class='col col-lg-12 rel-sectors padding-left padding-right'>
         <%= @translations[d.dim_name_key] %>
         <% if @editMe && can_edit %>
         <%= link_to(fa_icon("times"), tree_path(@tree.id, tree: { edit_type: 'dimtree', attr_id: dt[:id], active: false}, sector_tree: {active: false}), {:class => "fa-lg", 'data-confirm' => I18n.t('app.labels.confirm_deactivate', item: @translations[d.dim_name_key]), method: :patch}) if @editMe %>
@@ -29,7 +29,7 @@
     detailsFound += 1
   %>
     <div class='row'>
-    <div class='col col-lg-12 rel-sectors'>
+    <div class='col col-lg-12 rel-sectors padding-left padding-right'>
       <%= link_to(
         "#{@translations[st.sector.name_key]}",
         sectors_path(

--- a/app/views/trees/show/_tree_detail_area.html.erb
+++ b/app/views/trees/show/_tree_detail_area.html.erb
@@ -7,10 +7,10 @@
     </div>
     <% tree.getAllChildren.each do |c| %>
     <div class='row'>
-      <div class='col col-lg-2 ind-col'>
+      <div class='col col-lg-2 rel-sector ind-col'>
         <%= c.code %>
       </div>
-      <div class='col col-lg-10 ind-col last-col'>
+      <div class='col col-lg-10 rel-sector ind-col last-col'>
         <%= @translations[c.buildNameKey] %>
         <%= link_to(fa_icon("edit"), edit_tree_path(@tree.id, tree: { edit_type: 'indicator', attr_id: c.id}), {:remote => true, 'data-toggle' =>  "modal", 'data-target' => '#modal_popup'}) if @editMe && can_edit %>
       </div>
@@ -33,7 +33,7 @@
       </div>
     </div>
     <div class='row'>
-      <div class='col col-lg-12 ind-col'>
+      <div class='col col-lg-12 rel-sector ind-col'>
         <%= Translation.find_translation_name(@locale_code,tree.outcome.get_explain_key, "") %>
       </div>
     </div>


### PR DESCRIPTION
- Stop k-12 and specific big idea columns from overlapping on the tree detail page. 