### PR TITLE
Fix TreeType.grid_headers string in seed_turkey_v02

### DIFF
--- a/app/models/outcome.rb
+++ b/app/models/outcome.rb
@@ -2,6 +2,9 @@ class Outcome < BaseRec
 
   has_one :tree
 
+  # Do not change existing sequence of
+  # RESOURCES_TYPES.
+  # Only add new resource types to end.
   RESOURCE_TYPES = [
     "proj_ref",
     "learn_prog",
@@ -38,6 +41,7 @@ class Outcome < BaseRec
     end
   end
 
+# TO DO: take out sector_set_code. Not needed anymore.
   def self.get_ref_name(ref_type, locale_code, sector_set_code)
     ref_index = RESOURCE_TYPES.index(ref_type)
     name = ''
@@ -51,6 +55,7 @@ class Outcome < BaseRec
     return name
   end
 
+# TO DO: take out sector_set_code. Not needed anymore.
   def self.get_ref_hash(ref_type, locale_code, sector_set_code)
     ref_index = RESOURCE_TYPES.index(ref_type)
     name = ''

--- a/lib/tasks/seed_turkey_v02.rake
+++ b/lib/tasks/seed_turkey_v02.rake
@@ -48,7 +48,11 @@ namespace :seed_turkey_v02 do
       #   <item> - TABLE item, full width of table with two cols: item | item resources
       #   [item#n#n#n] - TABLE item, full width of table, with numeric codes identifying which categories of this item to display
       detail_headers: 'grade,unit,(sub_unit),comp,<bigidea<,>ess_q>,{explain},[miscon],[sector],[connect],[resource#0#1#2#3#4#5]',
-      grid_headers: 'grade,unit,(sub_unit),comp,[bigidea],[ess_q],explain,[miscon]'
+      # Grid headers notation key:
+      # item or (item) - Ignored for now
+      # [item] - grid column, may have multiple connected items
+      # {item} - grid column, single item
+      grid_headers: 'grade,unit,(sub_unit),comp,[essq],[bigidea],[pract],{explain},[miscon]'
     }
     if myTreeTypes.count < 1
       TreeType.create(myTreeTypeValues)


### PR DESCRIPTION
Last pull request before creating turkey branch.

- Fixes the detail grid display on the maint page once `bundle exec rake seed_turkey_v02:populate` is re-run
- Comment in the Outcome model to help avoid breaking Outcome Resource translation lookups