### PR TITLE
Mektebim Fixes

### DIFF
--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -101,6 +101,10 @@ body {
   .right-margin {
     margin-right: 5px;
   }
+
+  .min-height {
+    min-height: 75px;
+  }
 }
 
 // use font awesome fonts for glyphicon classes (for bootstrap 3 treeview library)

--- a/app/assets/stylesheets/trees.scss
+++ b/app/assets/stylesheets/trees.scss
@@ -86,6 +86,14 @@
       }
     }
 
+    .sequence-grid.cols-8, .dimension-grid.cols-8 {
+       grid-template-columns: 12.5% 12.5% 12.5% 12.5% 12.5% 12.5% 12.5% 12.5%;
+    }
+
+    .sequence-grid.cols-7, .dimension-grid.cols-7 {
+       grid-template-columns: 14% 14% 14% 14% 14% 14% 14%;
+    }
+
     .sequence-grid.cols-6, .dimension-grid.cols-6 {
        grid-template-columns: 16.5% 16.5% 16.5% 16.5% 16.5% 16.5%;
     }

--- a/app/assets/stylesheets/trees.scss
+++ b/app/assets/stylesheets/trees.scss
@@ -158,6 +158,9 @@
       li.maint-item {
         text-align: left;
       }
+      .dim-item ul, .dim-item li {
+        border: none;
+      }
       .indent-0 { margin-left: 0px; }
       .indent-1 { margin-left: 5px; }
       .indent-2 { margin-left: 10px; }

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -149,7 +149,8 @@ class ApplicationController < ActionController::Base
       elsif !@versionRec.code
         raise I18n.translate('app.errors.missing_version_code')
       end
-      @appTitle += " #{@versionRec.code} [#{@treeTypeRec.working_status ? I18n.t('app.labels.working_version') : I18n.t('app.labels.final_version')}]"
+      @appTitle += TreeType.where(:code => @treeTypeRec.code).count > 1 ? " #{@versionRec.code}" : ""
+      #"[#{@treeTypeRec.working_status ? I18n.t('app.labels.working_version') : I18n.t('app.labels.final_version')}]"
 
       # e.g., [{code: "bigidea", name: "Big Ideas"}, {...}, ...]
       @dimsArray = []

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -164,6 +164,7 @@ class ApplicationController < ActionController::Base
         @dimsArray << {code: dim_code, name: dim_name}
         @dimTypeTitleByCode[dim_code] = dim_name
       end
+      @dimDisplayHash = dim_display_hash(@treeTypeRec.dim_display)
     end
 
     def initTypeCode

--- a/app/controllers/dimensions_controller.rb
+++ b/app/controllers/dimensions_controller.rb
@@ -1,0 +1,59 @@
+class DimensionsController < ApplicationController
+  before_action :find_dimension, only: [:show, :edit, :update]
+
+  def show
+    @editMe = params[:editMe]
+    @dim_translation = Translation.find_translation_name(
+      @locale_code,
+      @dimension.get_dim_name_key,
+      ""
+    )
+    @subject_name = Translation.find_translation_name(
+        @locale_code,
+        Subject.get_default_name_key(@dimension.subject_code),
+        @dimension.subject_code
+      )
+  end
+
+  def edit
+    @dim_resource_category = Dimension.get_resource_name(
+      dimension_params[:resource_code],
+      @treeTypeRec.code,
+      @versionRec.code,
+      @locale_code,
+      "Missing Category Translation"
+    )
+  	@dim_resource_name = @dimension.resource_name(
+  	  @locale_code,
+  	  dimension_params[:resource_code],
+  	  ""
+	  )
+	  @resource_code = dimension_params[:resource_code]
+  end
+
+  def update
+  	if dimension_params[:resource_code] && dimension_params[:resource_text]
+	  	dim_resource_key = @dimension.resource_key(dimension_params[:resource_code])
+	  	Translation.find_or_update_translation(
+	  	  @locale_code,
+	  	  dim_resource_key,
+	  	  dimension_params[:resource_text]
+	  	)
+	  end
+    redirect_to dimension_path(@dimension.id, editMe: true)
+  end
+
+  private
+
+  def dimension_params
+    params.require(:dimension).permit(
+      :id,
+      :resource_code,
+      :resource_text
+    )
+  end
+
+  def find_dimension
+    @dimension = Dimension.find(params[:id])
+  end
+end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -63,4 +63,21 @@ module ApplicationHelper
     end
   end
 
+  #parse the TreeType.dim_display string and
+  #return a hash of which dimensions should get a
+  #show page, and which resource types should appear
+  #on the page.
+  #example of the dim_display param: 'miscon#1#2,bigidea#8#11'
+  def dim_display_hash(dim_display)
+    ret = {}
+    dim_display.split(",").each do |dim_str|
+      #item 0 in dim_arr is the dim_code
+      #subsequent items are indexes in the
+      #Dimension::RESOURCE_TYPES array
+      dim_arr = dim_str.split("#")
+      ret[dim_arr[0]] = dim_arr[1..dim_arr.length].map { |c| Dimension::RESOURCE_TYPES[c.to_i] }
+    end
+    return ret
+  end
+
 end

--- a/app/helpers/translations_helper.rb
+++ b/app/helpers/translations_helper.rb
@@ -1,2 +1,6 @@
 module TranslationsHelper
+	def paragraph_to_br(str)
+		str = str[3..str.length] if str[0..2] == '<p>'
+		return str.gsub('<p>', '<br>').gsub('</p>', '')
+	end
 end

--- a/app/models/dimension.rb
+++ b/app/models/dimension.rb
@@ -9,6 +9,19 @@ class Dimension < BaseRec
   COMPETENCY = 'comp'
   STANDARD = 'standard'
   VAL_DIM_TYPES = [BIG_IDEA, MISCONCEPTION, ESSENTIAL_QUESTION]
+  # Do not change existing sequence of
+  # RESOURCES_TYPES.
+  # Only add new resource types to end.
+  RESOURCE_TYPES = [
+    'second_subj',
+    'correct_understanding',
+    'poss_source_miscon',
+    'compiler',
+    'citation',
+    'link',
+    'distractor',
+    'question_bank',
+  ]
 
   validate :valid_dim_type
 
@@ -97,6 +110,45 @@ class Dimension < BaseRec
       end #if info[1]
     end #filters.split(",").each do
     return ret
+  end
+
+  def self.get_resource_key(
+    resourceType,
+    treeTypeCode,
+    versionCode
+  )
+    return "curriculum.#{treeTypeCode}.#{versionCode}.dim.#{resourceType}"
+  end
+
+  def self.get_resource_name(
+    resourceType,
+    treeTypeCode,
+    versionCode,
+    localeCode,
+    default
+  )
+    return Translation.find_translation_name(
+      localeCode,
+      "curriculum.#{treeTypeCode}.#{versionCode}.dim.#{resourceType}",
+      default
+    )
+  end
+
+  def resource_key(resourceType)
+    return "dimension.#{id}.#{resourceType}"
+  end
+
+  def resource_name(
+    localeCode,
+    resourceType,
+    default
+  )
+    key = resource_key(resourceType)
+    return Translation.find_translation_name(
+      localeCode,
+      key,
+      default
+    )
   end
 
   private

--- a/app/models/tree.rb
+++ b/app/models/tree.rb
@@ -104,6 +104,7 @@ class Tree < BaseRec
     x_dim_tree_id: nil
   )
     begin
+      name_translation = name_translation[3..name_translation.length].gsub('<br>', '').gsub('</p>', '').gsub('<p>', '<br>') if name_translation
       Translation.find_or_update_translation(
         locale_code,
         buildNameKey,

--- a/app/models/tree_type.rb
+++ b/app/models/tree_type.rb
@@ -31,10 +31,17 @@ class TreeType < BaseRec
 
   def self.versions_hash()
     ret_hash = Hash.new { |hash, key| hash[key] = [] }
+    codes_found = []
     all.each do |tree_type|
       begin
         ver = Version.find(tree_type[:version_id])
-        curriculum_code = "#{tree_type.code}.#{ver.code}"
+        if codes_found.include?(tree_type.code.downcase)
+          ver_code = ".#{ver.code}"
+        else
+          codes_found << tree_type.code.downcase
+          ver_code = TreeType.where(:code => tree_type.code).count > 1 ? ".#{ver.code}" : ''
+        end
+        curriculum_code = "#{tree_type.code}#{ver_code}"
         ret_hash[tree_type.id] << { str: curriculum_code, tree_type_id: tree_type.id, version_id: ver.id, working: tree_type.working_status }
       rescue StandardError => e
         puts "Could not find version for treeType record: #{tree_type.inspect} Error: #{e.inspect}"

--- a/app/views/dimensions/_edit.html.erb
+++ b/app/views/dimensions/_edit.html.erb
@@ -1,0 +1,20 @@
+<div class="modal-header">
+   <h3 id="myModalLabel"><%= @dim_resource_category %></h3>
+</div>
+<div class="modal-body">
+
+  <%= form_for(@dimension) do |f| %>
+    <div class="hidden_fields">
+      <%= f.hidden_field :resource_code, name: 'dimension[resource_code]', value: @resource_code %>
+    </div>
+    <!--feilds for editing the Outcome and Indicator text-->
+  	<fieldset>
+    	<%= f.cktext_area :resource_text, name: 'dimension[resource_text]', id: 'resource_text', style: {className: "pull-left"}, value: @dim_resource_name, ckeditor: {toolbar: 'mini', language: @locale_code, uiColor: '#b0e0e6'}  %>
+    </fieldset>
+    <div class="modal-footer">
+      <button class="btn" data-dismiss="modal" aria-hidden="true">Close</button>
+      <button class="btn btn-primary">Save changes</button>
+    </div>
+  <% end %>
+
+</div>

--- a/app/views/dimensions/_resource.html.erb
+++ b/app/views/dimensions/_resource.html.erb
@@ -1,0 +1,16 @@
+<ul class='grid-item'>
+  <div class='dimension-header'>
+    <%= Dimension.get_resource_name(resource, @treeTypeRec.code, @versionRec.code, @locale_code, 'Missing Category Title') %>
+  </div>
+  <li class="dimension-item padding-left padding-right min-height">
+    <%= link_to(fa_icon("edit"), edit_dimension_path(@dimension.id, dimension: { resource_code: resource }), {:class => "fa-lg pull-right", :remote => true, 'data-toggle' =>  "modal", 'data-target' => '#modal_popup'}) if @editMe && can_edit_type?(@dimension.dim_code) %>
+    <%=
+      @dimension.resource_name(
+        @locale_code,
+        resource,
+        ""
+      ).html_safe
+    %>
+
+  </li>
+</ul>

--- a/app/views/dimensions/edit.js.erb
+++ b/app/views/dimensions/edit.js.erb
@@ -1,0 +1,2 @@
+$("#modal-container").html("<%= escape_javascript(render('dimensions/edit')) %>");
+$("#modal_popup").modal();

--- a/app/views/dimensions/show.html.erb
+++ b/app/views/dimensions/show.html.erb
@@ -1,0 +1,42 @@
+<% content_for(:title_code, 'trees.show.name') %>
+<% content_for(:page_class, 'trees') %>
+
+<%= dimTypeTitle = @dimTypeTitleByCode[@dimension.dim_code] %>
+
+<div class="dimension-page">
+  <div class="pull-left">
+  	<strong><%= dimTypeTitle %></strong>:
+  	<%= paragraph_to_br(@dim_translation).html_safe %>
+  </div>
+  <br>
+  <div class="pull-left">
+    <strong><%= I18n.translate('app.labels.subject') %></strong>:
+    <%= @subject_name %>
+  </div>
+  <br>
+  <div class="pull-left">
+    <% plural_grades = @dimension.max_grade - @dimension.min_grade != 0 %>
+    <strong><%= plural_grades ? I18n.translate('app.labels.grade_band').pluralize : I18n.translate('app.labels.grade_band') %></strong>:
+    <%=
+      plural_grades ?
+      "#{@dimension.min_grade} - #{@dimension.max_grade}" :
+      @dimension.min_grade
+     %>
+  </div>
+
+	<div class='col col-lg-12 text-right'>
+	  <% if @editMe %>
+	    <span class='font-weight-bold'>Editing (<%= link_to("#{I18n.t('app.labels.leave_edit_mode')}", dimension_path(@dimension.id) ) %>)</span>
+	  <% else %>
+	    <%= link_to("Edit #{dimTypeTitle}", dimension_path(@dimension.id, editMe: true) ) if can_edit_type?(@dimension.dim_code)
+	     %>
+	  <% end %>
+	</div>
+  <div class="dimension-grid cols-2">
+  	<% @dimDisplayHash[@dimension.dim_code].each do |resource| %>
+  	  <%=
+  	  	render partial: "resource", locals: { resource: resource }
+  	  %>
+  	<% end %>
+  </div>
+</div>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -11,7 +11,10 @@
         <% arr.each do |cur| %>
           <% selected_curriculum = (cur[:tree_type_id] == @treeTypeRec.id && cur[:version_id] == @versionRec.id) %>
           <option value="<%= [cur[:tree_type_id], cur[:version_id]].to_s %>"<%= selected_curriculum ? " selected" : "" %>>
-            <%= "#{cur[:str]} [#{cur[:working] ? translate('app.labels.working_version') : translate('app.labels.final_version')}]" %>
+            <%=
+            "#{cur[:str]}"
+            # "[#{cur[:working] ? translate('app.labels.working_version') : translate('app.labels.final_version')}]"
+            %>
           </option>
         <% end %>
       <% end %>
@@ -30,11 +33,11 @@
         <% if lc == 'tr'%>
           <% if @locale_code == 'tr' %>
             <li class='cur-locale'>
-              <span>Türk</span>
+              <span>Türkçe</span>
             </li>
           <% else %>
             <li class='locale-opt'>
-              <a href='/users/lang/tr<%= "?dim_type=#{@dim_type}" if @dim_type %>'>Türk</a>
+              <a href='/users/lang/tr<%= "?dim_type=#{@dim_type}" if @dim_type %>'>Türkçe</a>
             </li>
           <% end %>
         <% end %>

--- a/app/views/trees/_competencies_column.html.erb
+++ b/app/views/trees/_competencies_column.html.erb
@@ -20,7 +20,7 @@
         <a href="<%= tree_path(h[:id])%>" title="<%= h[:text] %>"><%= h[:depth_name] %>:
         <strong><em><%= h[:formatted_code] %></em></strong>
         </a>
-        <%= h[:text] %>
+        <%= h[:text].html_safe %>
         <% if h[:dimtrees].length > 0 %>
         <% h[:dimtrees].each do |dt|
              dim = dt.dimension

--- a/app/views/trees/_competency_grids_column.html.erb
+++ b/app/views/trees/_competency_grids_column.html.erb
@@ -38,7 +38,7 @@
                   <em><%= duration_str %></em>
                   </div>
                 <% end %>
-                <%= h[:text] %>
+                <%= h[:text].html_safe %>
               </div>
               <!--TO DO: draw this array from the grid_headers field in TreeType
                 ['essq','bigidea','pract','expl','miscon']
@@ -52,7 +52,7 @@
                       </div>
                       <% dimsInfo[area][:arr].each do |dim| %>
                         <div class="dim-item">
-                          <%= dim %>
+                          <%= dim.html_safe %>
                         </div>
                       <% end #ess_q_arr.each do |dim| %>
                     </div>

--- a/app/views/trees/_competency_grids_column.html.erb
+++ b/app/views/trees/_competency_grids_column.html.erb
@@ -22,7 +22,7 @@
              dim = dt.dimension
              dimsInfo[dim.dim_code][:found] += 1
              #dimSubjKey = Subject.get_default_name_key(dim.subject_code)
-             dimsInfo[dim.dim_code][:arr] << "#{@translations[dim.dim_name_key]}"
+             dimsInfo[dim.dim_code][:arr] << [dim.id, "#{@translations[dim.dim_name_key]}"]
           end # h[:dimtrees].each do |dt|
           %>
           <div class="related-items-table">
@@ -51,8 +51,15 @@
                         <%= dimsInfo[area][:found] != 1 ? @dimTypeTitleByCode[area].pluralize : @dimTypeTitleByCode[area].singularize %>
                       </div>
                       <% dimsInfo[area][:arr].each do |dim| %>
+                        <% dim_link = dimension_path(dim[0]) if @dimDisplayHash[area] %>
                         <div class="dim-item">
-                          <%= dim.html_safe %>
+                          <% if dim_link %>
+                            <a href="<%= dim_link %>">
+                              <%= dim[1].html_safe %>
+                            </a>
+                          <% else %>
+                            <%= dim[1].html_safe %>
+                          <% end %>
                         </div>
                       <% end #ess_q_arr.each do |dim| %>
                     </div>

--- a/app/views/trees/_dim_column.html.erb
+++ b/app/views/trees/_dim_column.html.erb
@@ -9,13 +9,22 @@
   </li>
   <% if dims && dims.count > 0 %>
     <% dims.each do |dim| %>
+      <% dim_link = dimension_path(dim.id) if @dimDisplayHash[dim.dim_code] %>
       <li id="<%= "#{dim_subj_name}-dim-#{dim.id}"%>" class="dim-item dim-item--collapsable list-group-item ui-draggable" data-dimid="<%= dim.id %>">
         <span class='pull-left'><strong><%= "#{translate('app.labels.subject')}:"%></strong> <%="#{dim_subj_name}" %></span>
           <br/>
           <span class='pull-left'><strong><%= "#{grades_str}: " %></strong> <%= "#{dim.min_grade} - #{dim.max_grade}" %></span>
 
         <br/>
-        <span class='pull-left left-justify'><strong><%= "#{dim_title.singularize}: " %></strong><%= @translations[dim.dim_name_key].html_safe %></span>
+        <span class='pull-left left-justify'><strong><%= "#{dim_title.singularize}: " %></strong>
+          <% if dim_link %>
+            <a href="<%= dim_link %>">
+            <%= @translations[dim.dim_name_key].html_safe %>
+            </a>
+          <% else %>
+            <%= @translations[dim.dim_name_key].html_safe %>
+          <% end %>
+        </span>
         <br/>
 
         <% if can_edit && @editing%>

--- a/app/views/trees/_dim_column.html.erb
+++ b/app/views/trees/_dim_column.html.erb
@@ -15,7 +15,7 @@
           <span class='pull-left'><strong><%= "#{grades_str}: " %></strong> <%= "#{dim.min_grade} - #{dim.max_grade}" %></span>
 
         <br/>
-        <span class='pull-left left-justify'><strong><%= "#{dim_title.singularize}: " %></strong><%= @translations[dim.dim_name_key] %></span>
+        <span class='pull-left left-justify'><strong><%= "#{dim_title.singularize}: " %></strong><%= @translations[dim.dim_name_key].html_safe %></span>
         <br/>
 
         <% if can_edit && @editing%>

--- a/app/views/trees/_dimension_form.html.erb
+++ b/app/views/trees/_dimension_form.html.erb
@@ -55,7 +55,7 @@
   <fieldset>
     <div>
     <div><label for='name'><%= translate('trees.dimension.textlabel', dim_name: dim_type_name) %>:</label></div>
-    <%= f.text_area :name, name: 'dimension[text]', id: 'name', value: @dimension_text %>
+    <%= f.cktext_area :name, name: 'dimension[text]', id: 'name', value: @dimension_text, ckeditor: {toolbar: 'mini', language: @locale_code, uiColor: '#b0e0e6'} %>
     </div>
   </fieldset>
 

--- a/app/views/trees/_edit.html.erb
+++ b/app/views/trees/_edit.html.erb
@@ -12,8 +12,8 @@
   <!--feilds for editing the Outcome and Indicator text-->
 	<% if @edit_type == 'outcome' || @edit_type == 'indicator' %>
 	<fieldset>
-	  <label for='name_translation' class="pull-left"><%= @edit_type == "outcome"  ? "#{I18n.translate('app.labels.outcome')}:" : "#{I18n.translate('app.labels.indicator')}:" %></label>
-  	<%= f.text_area :name_translation, name: 'tree[name_translation]', id: 'name_translation', style: {className: "pull-left"}, value: @translation  %>
+	  <label for='name_translation' class="center-label"><%= @edit_type == "outcome"  ? "#{I18n.translate('app.labels.outcome')}:" : "#{I18n.translate('app.labels.indicator')}:" %></label>
+  	<%= f.cktext_area :name_translation, name: 'tree[name_translation]', id: 'name_translation', style: {className: "pull-left"}, value: @translation, ckeditor: {toolbar: 'mini', language: @locale_code, uiColor: '#b0e0e6'}  %>
   </fieldset>
   <% elsif @edit_type == 'comment' %>
   <fieldset>

--- a/app/views/trees/show.html.erb
+++ b/app/views/trees/show.html.erb
@@ -43,7 +43,7 @@
               <% if h[:depth] > 0 %>
                 </strong>
               <% end %>
-              <%= @translations[rec.buildNameKey] %>
+              <%= @translations[rec.buildNameKey].html_safe %>
               <% if h[:depth] == 0 %>
                 </strong>
               <% end %>

--- a/app/views/trees/show/_detail_area.html.erb
+++ b/app/views/trees/show/_detail_area.html.erb
@@ -21,7 +21,14 @@
     %>
     <div class='row'>
       <div class='col col-<%= resources ? 6 : 12 %> rel-sectors padding-left padding-right'>
-        <%= @translations[d.dim_name_key].html_safe %>
+        <% dim_link = dimension_path(d.id) if @dimDisplayHash[d.dim_code] %>
+        <% if dim_link %>
+          <a href="<%= dim_link %>">
+            <%= @translations[d.dim_name_key].html_safe %>
+          </a>
+        <% else %>
+          <%= @translations[d.dim_name_key].html_safe %>
+        <% end %>
         <% if @editMe && can_edit %>
         <%= link_to(fa_icon("times"), tree_path(@tree.id, tree: { edit_type: 'dimtree', attr_id: dt[:id], active: false}, sector_tree: {active: false}), {:class => "fa-lg", 'data-confirm' => I18n.t('app.labels.confirm_deactivate', item: @translations[d.dim_name_key]), method: :patch}) if @editMe %>
         <% end #if @editMe %>

--- a/app/views/trees/show/_detail_area.html.erb
+++ b/app/views/trees/show/_detail_area.html.erb
@@ -21,7 +21,7 @@
     %>
     <div class='row'>
       <div class='col col-<%= resources ? 6 : 12 %> rel-sectors padding-left padding-right'>
-        <%= @translations[d.dim_name_key] %>
+        <%= @translations[d.dim_name_key].html_safe %>
         <% if @editMe && can_edit %>
         <%= link_to(fa_icon("times"), tree_path(@tree.id, tree: { edit_type: 'dimtree', attr_id: dt[:id], active: false}, sector_tree: {active: false}), {:class => "fa-lg", 'data-confirm' => I18n.t('app.labels.confirm_deactivate', item: @translations[d.dim_name_key]), method: :patch}) if @editMe %>
         <% end #if @editMe %>

--- a/config/locales/pages.en.yml
+++ b/config/locales/pages.en.yml
@@ -96,7 +96,7 @@ en:
   nav_bar:
     home:
       name: "Home"
-      hover: "Turkey STEM Home Page"
+      hover: "Mektebim STEM Home Page"
     curriculum:
       name: "Curriculum Tree"
       hover: "Displays the Curriculum Tree"
@@ -183,8 +183,8 @@ en:
       error_creating_code_val: "error creating translation #{code} to: #{val}"
   trees:
     index:
-      name: "Turkey STEM Curriculum"
-      title: "Turkey STEM Curriculum"
+      name: "Mektebim STEM Curriculum"
+      title: "Mektebim STEM Curriculum"
     sequencing:
       title: "Relations"
     maint:
@@ -246,10 +246,10 @@ en:
         explanation: "Reason for Relation"
   sectors:
     index:
-      name: "Turkey STEM Curriculum for Future Competencies"
-      title: "Turkey STEM Curriculum for Future Competencies"
+      name: "Mektebim STEM Curriculum for Future Competencies"
+      title: "Mektebim STEM Curriculum for Future Competencies"
     labels:
-      future_vision_filter: "Turkey STEM Curriculum for Future Competencies"
+      future_vision_filter: "Mektebim STEM Curriculum for Future Competencies"
   uploads:
     index:
       name: "Uploads Listing"

--- a/config/locales/pages.tr.yml
+++ b/config/locales/pages.tr.yml
@@ -1,7 +1,7 @@
 
 tr:
   app:
-    title: "Türkiye STEM Ana Sayfa"
+    title: "Mektebim STEM Ana Sayfa"
     labels:
       all: "Her Sey"
       save: "Save"
@@ -39,7 +39,7 @@ tr:
   nav_bar:
     home:
       name: "Ev"
-      hover: "Türkiye STEM Ana Sayfa"
+      hover: "Mektebim STEM Ana Sayfa"
     curriculum:
       name: "Gelecek Müfredat"
       hover: "Müfredat Ağacı'nı görüntüler"
@@ -90,8 +90,8 @@ tr:
       hover: "Web Sitesinden Çıkış Yap"
   trees:
     index:
-      name: "Türkiye STEM Müfredatı"
-      title: "Türkiye STEM Müfredatı"
+      name: "Mektebim STEM Müfredatı"
+      title: "Mektebim STEM Müfredatı"
     sequencing:
       title: "Dizileme"
     misconc:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -59,6 +59,13 @@ scope "(:locale)", locale: /tr|en|ar_EG/ do
     end
   end
 
+  resources :dimensions, only: [:show, :edit, :update] do
+    collection do
+      post 'show'
+      get 'show'
+    end
+  end
+
 
   devise_for :users
   devise_scope :user do

--- a/db/migrate/20200518000209_add_dim_display_to_tree_type.rb
+++ b/db/migrate/20200518000209_add_dim_display_to_tree_type.rb
@@ -1,0 +1,9 @@
+class AddDimDisplayToTreeType < ActiveRecord::Migration[5.1]
+  def up
+    add_column :tree_types, :dim_display, :string, default: "", null: false
+  end
+
+  def down
+  	remove_column :tree_types, :dim_display
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20200512140804) do
+ActiveRecord::Schema.define(version: 20200518000209) do
 
   create_table "dimension_trees", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.bigint "dimension_id", null: false
@@ -143,6 +143,7 @@ ActiveRecord::Schema.define(version: 20200512140804) do
     t.string "detail_headers", default: "", null: false
     t.string "grid_headers", default: "", null: false
     t.string "dim_codes", default: "bigidea,miscon", null: false
+    t.string "dim_display", default: "", null: false
     t.index ["code", "version_id"], name: "index_tree_types_on_code_and_version_id", unique: true
   end
 

--- a/lib/tasks/seed_stessa_2.rake
+++ b/lib/tasks/seed_stessa_2.rake
@@ -60,7 +60,11 @@ namespace :seed_stessa_2 do
       #                  e.g., may use indexes in the
       #                  Outcome::RESOURCE_TYPES array.
       detail_headers: 'grade,unit,lo,weeks,hours,<bigidea<,>essq>,<concept<,>skill>,<miscon>,[sector],[connect],[resource#1#3#2]',
-      grid_headers: 'grade,unit,lo,[bigidea],[essq],[concept],[skill],[miscon]'
+      grid_headers: 'grade,unit,lo,[bigidea],[essq],[concept],[skill],[miscon]',
+      #Display codes are zero-relative indexes in Dimension::RESOURCE_TYPES
+      #Dimensions must appear in this string to have a show page
+      #E.g., dim_display: 'miscon#0#1#2#3,bigidea#4#5#8,concept#1',
+      dim_display: 'miscon#0#1#2#3#4#5#6#7',
     }
     if myTreeType.count < 1
       TreeType.create(myTreeTypeValues)
@@ -377,6 +381,17 @@ namespace :seed_stessa_2 do
       ['skill', 'Skill', 'مهارة'],
       ['miscon', 'Misconception', 'اعتقاد خاطئ'],
     ]
+
+    dim_resource_types_arr = [
+      ['Second Subject', 'الموضوع الثاني'],
+      ['Correct Understanding', 'الفهم الصحيح'],
+      ['Possible Source of Misconception', 'مصدر محتمل للفهم الخاطئ'],
+      ['Compiler/Source'],
+      ['Primary Research Citation', 'مترجم / المصدر'],
+      ['Website Link References', 'مراجع رابط الموقع'],
+      ['Test Distractor Percent', 'اختبار نسبة تشتيت الانتباه'],
+      ['Link to Question Item Bank', 'رابط إلى بنك عناصر السؤال'],
+    ]
     dim_translations_arr.each do |dim|
       dim_name_key = Dimension.get_dim_type_key(
         dim[0],
@@ -386,6 +401,17 @@ namespace :seed_stessa_2 do
       rec, status, message = Translation.find_or_update_translation(BaseRec::LOCALE_EN, dim_name_key, dim[1])
       throw "ERROR updating dimension code translation: #{message}" if status == BaseRec::REC_ERROR
       rec, status, message = Translation.find_or_update_translation(BaseRec::LOCALE_AR_EG, dim_name_key, dim[2])
+      throw "ERROR updating dimension code translation: #{message}" if status == BaseRec::REC_ERROR
+    end
+    dim_resource_types_arr.each_with_index do |resource, i|
+      resource_name_key = Dimension.get_resource_key(
+        Dimension::RESOURCE_TYPES[i],
+        @tt.code,
+        @ver.code
+      )
+      rec, status, message = Translation.find_or_update_translation(BaseRec::LOCALE_EN, resource_name_key, resource[0])
+      throw "ERROR updating dimension code translation: #{message}" if status == BaseRec::REC_ERROR
+      rec, status, message = Translation.find_or_update_translation(BaseRec::LOCALE_AR_EG, resource_name_key, resource[1])
       throw "ERROR updating dimension code translation: #{message}" if status == BaseRec::REC_ERROR
     end
   end

--- a/lib/tasks/seed_turkey_v02.rake
+++ b/lib/tasks/seed_turkey_v02.rake
@@ -32,7 +32,7 @@ namespace :seed_turkey_v02 do
       valid_locales: BaseRec::LOCALE_EN+','+BaseRec::LOCALE_TR,
       sector_set_code: 'future,hide',
       sector_set_name_key: 'sector.set.future.name',
-      curriculum_title_key: 'curriculum.tfv.title', # 'Turkey STEM Curriculum'
+      curriculum_title_key: 'curriculum.tfv.title', # 'Mektebim STEM Curriculum'
       outcome_depth: 3,
       version_id: @ver.id,
       working_status: true,
@@ -83,7 +83,7 @@ namespace :seed_turkey_v02 do
     throw "ERROR updating sector.set.fut.sect.name: #{message}" if status == BaseRec::REC_ERROR
 
     #To Do - Enter translations for curriculum_title_key
-    rec, status, message = Translation.find_or_update_translation(BaseRec::LOCALE_EN, 'curriculum.tfv.title', 'Turkey STEM Curriculum')
+    rec, status, message = Translation.find_or_update_translation(BaseRec::LOCALE_EN, 'curriculum.tfv.title', 'Mektebim STEM Curriculum')
     throw "ERROR updating curriculum.tfv.title translation: #{message}" if status == BaseRec::REC_ERROR
 
     # # Titles of Turkish Dimension Pages (see seeds.rb for default english)


### PR DESCRIPTION
- Update 'Mektebim Curriculum' translation in seed_turkey_v02 rake file, and in locale file. 
  - Was "Turkey Curriculum," now "Mektebim Curriculum"
- Prevent [working] flag from being displayed in curriculum title. 
  - Working flag still exists. We can restore this part of the display when it becomes relevant (e.g., finalizing a curriculum becomes possible). 
- Only show curriculum version in curriculum title if there are multiple treetypes with the same curriculum code.

**Dimension Resources**
- migration adding `dim_display` column to the tree_types table
- dynamically control which dimensions have their own show page, and which resource types are displayed on that show page with the TreeType.dim_display string:
  - e.g., `dim_display: 'miscon#0#1#2#3,bigidea#4#5#8,concept#1'`
  - Dimensions must appear in this string to have a show page
  - Display codes are zero-relative indexes in Dimension::RESOURCE_TYPES
- Dimension show page accessible by clicking on dimensions that are links 
  - Dimensions are displayed as links if their dim_code appears in the `TreeType.dim_displays` string
- Dimension resources editable on the dimension show page
NOTE: after putting this update on the server, run `RAILS_ENV=production bundle exec rake seed_turkey_v02:populate`