### PR TITLE
Refactor detail_headers display

### DIFF
--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -8,20 +8,23 @@ body {
   .login-bg {
     background: url("/login_bg.jpg") no-repeat center fixed;
     background-size: cover;
-    min-height: 91vh;
+    min-height: 93vh;
     height: 95%;
     margin: 0 -15px;
     padding-top: 10%;
     padding-bottom: 10%;
     color: black;
+    a { color: red; }
   }
   .translucent {
     background: white;
-    opacity: .9;
+    opacity: .7;
     border-radius: 10px;
     max-width: 75vw;
+    display: inline-block;
     margin: auto;
     padding: 10px 15px;
+    #user_work_address { width: 100%; }
   }
   .smallest-text {
     font-size: 0.6rem;
@@ -128,7 +131,29 @@ body {
   .min-height {
     min-height: 75px;
   }
+
+  .generic-grid {
+    display: grid;
+    width: 100%;
+    align-content: space-around;
+    &.generic-grid--xl-xs { grid-template-columns: 89% 4%; }
+    &.generic-grid--cols-1 { grid-template-columns: 100% }
+    &.generic-grid--cols-2 { grid-template-columns: 50% 50%; }
+    &.generic-grid--cols-3 { grid-template-columns: 33% 33% 33%; }
+    &.generic-grid--cols-4 { grid-template-columns: 25% 25% 25% 25%; }
+
+    &.generic-grid--labels-1 { grid-template-columns: 100%; }
+    &.generic-grid--labels-2 { grid-template-columns: 50% 50%; }
+    &.generic-grid--labels-3 { grid-template-columns: 33.33% 33.33% 33.33%; }
+    &.generic-grid--labels-4 { grid-template-columns: 25% 25% 25% 25%; }
+  }
 }
+
+.dark-border {
+  border: 1px solid black;
+}
+.dark-border--left {border-left: 1px solid black;}
+.dark-border--right {border-right: 1px solid black;}
 
 .cloud-tag {
   border: 1px solid grey;

--- a/app/models/outcome.rb
+++ b/app/models/outcome.rb
@@ -12,17 +12,24 @@ class Outcome < BaseRec
     "activity",
     "teacher_ref",
     "goal",
+    "explain",
+    "evid_learning",
+    "connections",
   ]
 
   # Field Translations
+
+  # deprecated
   def get_evidence_of_learning_key
     return base_key + ".evid_learning"
   end
 
+  # deprecated
   def get_connections_key
     return base_key + ".connections"
   end
 
+  #deprecated
   def get_explain_key
     return base_key + ".explain"
   end

--- a/app/views/trees/show.html.erb
+++ b/app/views/trees/show.html.erb
@@ -94,7 +94,7 @@
               dim_code: detail[:dim_code],
               outcomes: detail[:outcome],
               sector: detail[:sector],
-              resources: (area[:type] == 'resource-col'),
+              category_codes: (area[:codes] && area[:codes].length > 3 ? area[:codes][0..2]: area[:codes]),
               can_edit: can_edit_type?(area[:name]) || current_user.subject_admin?(@subject_code),
              }
           %>

--- a/app/views/trees/show/_detail_area.html.erb
+++ b/app/views/trees/show/_detail_area.html.erb
@@ -1,14 +1,24 @@
 <div class='related-items-table'>
-  <div class='row center-label-bold top-label'>
-    <div class='col col-<%= resources ? 6 : 12 %>'>
+  <div class='row center-label-bold top-label generic-grid generic-grid--cols-<%= category_codes && category_codes.length <= 3 ? category_codes.length + 1 : 1 %>'>
+    <div class='padding-right padding-left'>
       <%= detail_title %>
       <%= link_to(fa_icon("plus-square"), edit_tree_path(@tree.id, tree: { edit_type: 'sector', attr_id: 'new'}), {:remote => true, :class => "fa-lg pull-right", 'data-toggle' =>  "modal", 'data-target' => '#modal_popup'}) if @editMe && sector && can_edit %>
     </div>
-    <% if resources %>
-        <div class='col col-6'>
-          <%= I18n.translate('trees.labels.dimension_resources', dim_name: detail_title.singularize) %>
+    <% if category_codes && dim %>
+      <% category_codes = category_codes.map { |c| Dimension::RESOURCE_TYPES[c.to_i] } %>
+      <% category_codes.each do |code| %>
+        <div class='dark-border--left padding-right padding-left'>
+          <%= "#{detail_title}: #{Dimension.get_resource_name(
+              code,
+              @treeTypeRec.code,
+              @versionRec.code,
+              @locale_code,
+              code
+            )}"
+          %>
         </div>
-    <% end %>
+      <% end #category_codes.each do %>
+    <% end #if category_codes && dim %>
   </div>
   <% detailsFound = 0 %>
   <% details.each do |dt| %>
@@ -20,24 +30,37 @@
       detailsFound += 1
     %>
     <div class='row'>
-      <div class='col col-<%= resources ? 6 : 12 %> rel-sectors padding-left padding-right'>
-        <% dim_link = dimension_path(d.id) if @dimDisplayHash[d.dim_code] %>
-        <% if dim_link %>
-          <a href="<%= dim_link %>">
-            <%= @translations[d.dim_name_key].html_safe %>
-          </a>
-        <% else %>
-          <%= @translations[d.dim_name_key].html_safe %>
-        <% end %>
-        <% if @editMe && can_edit %>
-        <%= link_to(fa_icon("times"), tree_path(@tree.id, tree: { edit_type: 'dimtree', attr_id: dt[:id], active: false}, sector_tree: {active: false}), {:class => "fa-lg", 'data-confirm' => I18n.t('app.labels.confirm_deactivate', item: @translations[d.dim_name_key]), method: :patch}) if @editMe %>
-        <% end #if @editMe %>
-      </div>
-      <% if resources %>
-        <div class="col col-6 rel-sectors padding-left padding-right">
-          <!-- To Do: populate with resources list -->
+      <div class='dark-border generic-grid generic-grid--cols-<%= category_codes && category_codes.length <= 3 ? category_codes.length + 1 : 1 %>'>
+        <div class="<%= @editMe && can_edit ? "generic-grid generic-grid--xl-xs" : "" %>">
+          <div class="padding-left padding-right">
+            <% dim_link = dimension_path(d.id) if @dimDisplayHash[d.dim_code] %>
+            <% if dim_link %>
+              <a href="<%= dim_link %>">
+                <%= @translations[d.dim_name_key].html_safe %>
+              </a>
+            <% else %>
+              <%= @translations[d.dim_name_key].html_safe %>
+            <% end %>
+          </div>
+          <div class="padding-right">
+            <% if @editMe && can_edit %>
+            <%= link_to(fa_icon("times"), tree_path(@tree.id, tree: { edit_type: 'dimtree', attr_id: dt[:id], active: false}, sector_tree: {active: false}), {:class => "fa-lg", 'data-confirm' => I18n.t('app.labels.confirm_deactivate', item: @translations[d.dim_name_key]), method: :patch}) if @editMe %>
+            <% end #if @editMe %>
+          </div>
         </div>
-      <% end %>
+        <% if category_codes %>
+          <% category_codes.each do |code| %>
+            <div class='dark-border--left col padding-left padding-right'>
+              <%= d.resource_name(
+                    @locale_code,
+                    code,
+                    ""
+                  ).html_safe
+              %>
+            </div>
+          <% end %>
+        <% end %>
+      </div>
     </div>
   <%
     end #if d.dim_code == dim_code

--- a/lib/tasks/seed_stessa_2.rake
+++ b/lib/tasks/seed_stessa_2.rake
@@ -59,7 +59,7 @@ namespace :seed_stessa_2 do
       #                  categories of this item to display.
       #                  e.g., may use indexes in the
       #                  Outcome::RESOURCE_TYPES array.
-      detail_headers: 'grade,unit,lo,weeks,hours,<bigidea<,>essq>,<concept<,>skill>,[miscon],[sector],[connect],[resource#1#3#2]',
+      detail_headers: 'grade,unit,lo,weeks,hours,<bigidea<,>essq>,<concept<,>skill>,[miscon#2#1],[sector],[connect],[resource#1#3#2]',
       grid_headers: 'grade,unit,lo,[bigidea],[essq],[concept],[skill],[miscon]',
       #Display codes are zero-relative indexes in Dimension::RESOURCE_TYPES
       #Dimensions must appear in this string to have a show page


### PR DESCRIPTION
- html/css fixes for the lockscreen and tree detail page. 
- add ability to show dimension resources on the tree detail page (max. of 3 resource codes)

Note: Refactor not yet complete, but these changes can be safely pulled in and the turkey_v02 and stessa_2 seed files can be safely run, if it would be helpful to see the new functionality.