### PR TITLE
Tree Class Method to Re-label Trees, Outcomes, and Outcome Resource Translations

### DIFF
--- a/app/assets/javascripts/dimensions.js
+++ b/app/assets/javascripts/dimensions.js
@@ -124,14 +124,14 @@ initializeDrag = function() {
       //find out if the item being dragged is of the same type as the
       //item it was dropped on.
       var types = [
-        item_to_connect.dataset["loid"] == undefined,
-        ui.helper[0].dataset["loid"] == undefined
+        item_to_connect.dataset["treeid"] == undefined,
+        ui.helper[0].dataset["treeid"] == undefined
       ];
       //if an item is dropped on an item that is not of the same type
       if (item_to_connect != null && types[0] != types[1]) {
         var tree_id, dimension_id;
-        if (ui.helper[0].dataset["loid"]) {
-          tree_id = ui.helper[0].dataset["loid"];
+        if (ui.helper[0].dataset["treeid"]) {
+          tree_id = ui.helper[0].dataset["treeid"];
           dimension_id = item_to_connect.id.split("_")[2];
         } else {
           tree_id = item_to_connect.id.split("_")[2];

--- a/app/assets/javascripts/sequence.js
+++ b/app/assets/javascripts/sequence.js
@@ -338,7 +338,7 @@ edit_tree_tree = function(tree_tree_id) {
  *    gradebands.
  */
 initializeSortAndDrag = function() {
-  $(".sequence-page .list-group").sortable({
+  $(".maint-page .list-group").sortable({
     //specify only .list-group-items
     //should be sortable (to
     //exclude subject headers)
@@ -348,9 +348,9 @@ initializeSortAndDrag = function() {
     stop: function(e, ui) {
       console.log("e:", e);
       console.log("ui:", ui);
-      tree_ids = $.map($(this).find(".sequence-item"), function(el) {
-        return el.id.split("_")[1];
-      });
+      tree_ids = $(".sequence-item").map(function () {
+        return $(this).data('treeid');
+      }).get();
       console.log(tree_ids);
       token = $("meta[name='csrf-token']").attr("content");
 
@@ -361,7 +361,7 @@ initializeSortAndDrag = function() {
         data: {
           source_controller: "trees",
           source_action: "reorder",
-          id_order: tree_ids
+          tree: { id_order: tree_ids }
         },
         dataType: "json",
         async: false

--- a/app/assets/javascripts/sequence.js
+++ b/app/assets/javascripts/sequence.js
@@ -380,7 +380,8 @@ initializeSortAndDrag = function() {
           })
         })
         .catch(function(err) {
-        console.log("ERROR:", err);
+          window.location.reload();
+          console.log("ERROR:", err);
       });
     }
   });

--- a/app/assets/javascripts/sequence.js
+++ b/app/assets/javascripts/sequence.js
@@ -367,7 +367,17 @@ initializeSortAndDrag = function() {
         async: false
       })
         .then(function(res) {
-          console.log(res);
+          console.log(res.tree_codes_changed);
+          var subject_code = $("#subject_code_hidden").text();
+          res.tree_codes_changed.forEach(function (h) {
+            $("#"+subject_code+"_tree_"+h["tree_id"])
+              .find(".js-tree-code")
+              .html(
+                "<strong><em>"
+                +h["new_code"]
+                +"</em></strong>"
+              )
+          })
         })
         .catch(function(err) {
         console.log("ERROR:", err);

--- a/app/assets/javascripts/sequence.js
+++ b/app/assets/javascripts/sequence.js
@@ -365,7 +365,11 @@ initializeSortAndDrag = function() {
         },
         dataType: "json",
         async: false
-      }).catch(function(err) {
+      })
+        .then(function(res) {
+          console.log(res);
+        })
+        .catch(function(err) {
         console.log("ERROR:", err);
       });
     }

--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -25,7 +25,7 @@ body {
       font-weight: bold;
       max-width: 60%;
       margin: auto;
-      color: #ff3a3a;
+      color: red;
       text-shadow: 0 0 10px black;
     }
     .login-form {

--- a/app/assets/stylesheets/trees.scss
+++ b/app/assets/stylesheets/trees.scss
@@ -180,7 +180,7 @@
       .indent-8 { margin-left: 40px; }
     }
 
-    .sequence-item, .sequence-header, .dimension-item, .dimension-header {
+    .sequence-header, .dimension-item, .dimension-header {
       list-style-type: none;
       list-style-position: none;
       width: 100%;

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -149,7 +149,7 @@ class ApplicationController < ActionController::Base
       elsif !@versionRec.code
         raise I18n.translate('app.errors.missing_version_code')
       end
-      @appTitle += TreeType.where(:code => @treeTypeRec.code).count > 1 ? " #{@versionRec.code}" : "" if current_user.present?
+      @appTitle += TreeType.active.where(:code => @treeTypeRec.code).count > 1 ? " #{@versionRec.code}" : "" if current_user.present?
       #"[#{@treeTypeRec.working_status ? I18n.t('app.labels.working_version') : I18n.t('app.labels.final_version')}]"
 
       # e.g., [{code: "bigidea", name: "Big Ideas"}, {...}, ...]

--- a/app/controllers/trees_controller.rb
+++ b/app/controllers/trees_controller.rb
@@ -672,7 +672,7 @@ class TreesController < ApplicationController
     @dimension_translation = dimension_translation_matches.first ? dimension_translation_matches.first.value : ""
     if dim_tree_matches.length == 0
       @dim_tree = DimTree.new(tree_params)
-      @dim_tree.dim_explanation_key = DimTree.getDimExplanationKey(@tree[:base_key], @dim[:dim_code], @dim[:id])
+      @dim_tree.dim_explanation_key = DimTree.getDimExplanationKey(@tree[:id], @dim[:dim_code], @dim[:id])
       @method = :post
       @form_path = :create_dim_tree_trees
     else
@@ -952,6 +952,13 @@ class TreesController < ApplicationController
   end
 
   def reorder
+    # working on algorithm for reordering all depths
+    # take params:
+    # [id_order_arr], id of moved tree
+    # a = get new location of id in [id_order_arr]
+    # b = get recorded sort order of tree
+    # starting point for recoding= [a,b].min
+    # update_code_sequence(a/b, id_reorder_arr ...)
     Rails.logger.debug(params[:id_order].inspect)
     count = 1
     ActiveRecord::Base.transaction do

--- a/app/controllers/trees_controller.rb
+++ b/app/controllers/trees_controller.rb
@@ -293,7 +293,7 @@ class TreesController < ApplicationController
       tree_type_id: @treeTypeRec.id,
       version_id: @versionRec.id
     )
-    @trees = listing.joins(:grade_band).order("trees.sequence_order, code").all
+    @trees = listing.joins(:grade_band).order("trees.sort_order, code").all
     @tree = Tree.new(
       tree_type_id: @treeTypeRec.id,
       version_id: @versionRec.id

--- a/app/controllers/trees_controller.rb
+++ b/app/controllers/trees_controller.rb
@@ -235,19 +235,21 @@ class TreesController < ApplicationController
           tree.outcome.get_explain_key,
           nil
         ) : nil
+      gb_code = tree.grade_band.code
       newHash = {
         id: tree.id,
         depth: tree.depth,
         outcome: tree.outcome,
         weeks: tree.outcome ? tree.outcome.duration_weeks : nil,
         subj_code: @subject_code,
-        gb_code: tree.grade_band.code,
+        gb_code: gb_code,
         code: tree.code,
         formatted_code: tree.outcome ? tree.format_code(
             @locale_code,
             @treeTypeRec.hierarchy_codes.split(","),
             @treeTypeRec.tree_code_format,
-            subjectLocaleCode
+            subjectLocaleCode,
+            gb_code
           ) : tree.codeArray.last,
         selectors_by_parent: selectors_by_parent,
         depth_name: @hierarchies[tree.depth-1],

--- a/app/controllers/trees_controller.rb
+++ b/app/controllers/trees_controller.rb
@@ -951,6 +951,12 @@ class TreesController < ApplicationController
     redirect_to tree_path(@tree.id, editme: @tree.id)
   end
 
+
+  # @param {Array[int]} id_order An array of Tree ids. Determines the new sort
+  #                              order for a set of Trees in the curriculum.
+  #                              Will contain either all of the Tree ids for the
+  #                              subject, or all of the Tree ids for the subject
+  #                              and a single gradeband.
   def reorder
     # working on algorithm for reordering all depths
     # take params:
@@ -959,18 +965,22 @@ class TreesController < ApplicationController
     # b = get recorded sort order of tree
     # starting point for recoding= [a,b].min
     # update_code_sequence(a/b, id_reorder_arr ...)
-    Rails.logger.debug(params[:id_order].inspect)
-    count = 1
-    ActiveRecord::Base.transaction do
-    params[:id_order].each do |id|
-      t = Tree.find(id)
-      t.sequence_order = count
-      t.save
-      count += 1
-    end
-    end
+    Rails.logger.debug(tree_params[:id_order].inspect)
+    # OLD METHOD:
+    # count = 1
+    # ActiveRecord::Base.transaction do
+    # params[:id_order].each do |id|
+    #   t = Tree.find(id)
+    #   t.sequence_order = count
+    #   t.save
+    #   count += 1
+    # end
+    # end
+    #
+    #
+    tree_codes_changed = Tree.update_code_sequence(tree_params[:id_order])
     respond_to do |format|
-      format.json {render json: {hello_message: 'hello world'}}
+      format.json {render json: {tree_codes_changed: tree_codes_changed}}
     end
   end
 
@@ -999,6 +1009,7 @@ class TreesController < ApplicationController
       :resource,
       :weeks,
       :hours,
+      :id_order => [],
       :resource_name => [],
       :resource_key => [],
     )
@@ -1050,10 +1061,6 @@ class TreesController < ApplicationController
     rescue
       ActionController::Parameters.new
     end
-  end
-
-  def reorder_params
-    params.permit(:id_order)
   end
 
   def addNodeToArrHash (parent, subCode, newHash)

--- a/app/controllers/uploads_controller.rb
+++ b/app/controllers/uploads_controller.rb
@@ -1111,7 +1111,7 @@ class UploadsController < ApplicationController
         currentRec.get_dim_name_key,
         dim_name
       )
-      dimExplKey = DimTree.getDimExplanationKey(treeRec[:rec].base_key, dim_type, currentRec.id)
+      dimExplKey = DimTree.getDimExplanationKey(treeRec[:rec].id, dim_type, currentRec.id)
       dimTree = DimTree.create(
         tree_id: treeRec[:rec].id,
         dimension_id: currentRec.id,
@@ -1131,7 +1131,7 @@ class UploadsController < ApplicationController
       currentRec.min_grade = min_grade if min_grade < currentRec.min_grade
       currentRec.max_grade = max_grade if max_grade > currentRec.max_grade
       currentRec.save
-      dimExplKey = DimTree.getDimExplanationKey(treeRec[:rec].base_key, dim_type, currentRec.id)
+      dimExplKey = DimTree.getDimExplanationKey(treeRec[:rec].id, dim_type, currentRec.id)
       dimTrees = DimTree.where(tree_id: treeRec[:rec].id, dimension_id: currentRec.id)
       if dimTrees.count < 1
         dimTree = DimTree.create(

--- a/app/models/dim_tree.rb
+++ b/app/models/dim_tree.rb
@@ -13,8 +13,8 @@ class DimTree < BaseRec
 
   # Standard for dim_explanation_key
   # e.g. TFV.v01.bio.9.1.1.1.miscon.3.expl
-  def self.getDimExplanationKey(treeBaseKey, dimType, dimId)
-    return "#{treeBaseKey}.#{dimType}.#{dimId}.expl"
+  def self.getDimExplanationKey(treeId, dimType, dimId)
+    return "tree.#{treeId}.#{dimType}.#{dimId}.expl"
   end
 
 

--- a/app/models/outcome.rb
+++ b/app/models/outcome.rb
@@ -89,4 +89,8 @@ class Outcome < BaseRec
     RESOURCE_TYPES.map { |type| get_resource_key(type) }
   end
 
+  def list_instance_translation_keys(outc_base_key)
+    RESOURCE_TYPES.map { |type| "#{outc_base_key}.#{type}" }
+  end
+
 end

--- a/app/models/outcome.rb
+++ b/app/models/outcome.rb
@@ -38,6 +38,10 @@ class Outcome < BaseRec
     return tree_base_key + '.outc'
   end
 
+  def self.build_base_key(tree_base_key)
+    return tree_base_key + '.outc'
+  end
+
   ######
   # Field Translations: Outcome Resources
   def get_resource_key(resource_type)

--- a/app/models/outcome.rb
+++ b/app/models/outcome.rb
@@ -85,4 +85,8 @@ class Outcome < BaseRec
     }
   end
 
+  def list_translation_keys
+    RESOURCE_TYPES.map { |type| get_resource_key(type) }
+  end
+
 end

--- a/app/models/tree_type.rb
+++ b/app/models/tree_type.rb
@@ -1,5 +1,7 @@
 class TreeType < BaseRec
 
+  scope :active, -> { where(:active => true) }
+
   # Translation Field
   def hierarchy_name_key(hierarchy_code)
     return "curriculum.#{code}.hierarchy.#{hierarchy_code}"
@@ -32,14 +34,14 @@ class TreeType < BaseRec
   def self.versions_hash()
     ret_hash = Hash.new { |hash, key| hash[key] = [] }
     codes_found = []
-    all.each do |tree_type|
+    active.each do |tree_type|
       begin
         ver = Version.find(tree_type[:version_id])
         if codes_found.include?(tree_type.code.downcase)
           ver_code = ".#{ver.code}"
         else
           codes_found << tree_type.code.downcase
-          ver_code = TreeType.where(:code => tree_type.code).count > 1 ? ".#{ver.code}" : ''
+          ver_code = active.where(:code => tree_type.code).count > 1 ? ".#{ver.code}" : ''
         end
         curriculum_code = "#{tree_type.code}#{ver_code}"
         ret_hash[tree_type.id] << { str: curriculum_code, tree_type_id: tree_type.id, version_id: ver.id, working: tree_type.working_status }

--- a/app/views/trees/_competencies_column.html.erb
+++ b/app/views/trees/_competencies_column.html.erb
@@ -1,4 +1,5 @@
 <ul class="list-group maint-column">
+  <div id="subject_code_hidden" class="hidden"><%= @subject_code %></div>
   <li>
     <%= render partial: "maint_filter", locals: {col: "tree"} %>
   </li>
@@ -18,7 +19,7 @@
        %>
       <li id="<%= h[:subj_code] %>_tree_<%= h[:id] %>" class="sequence-item maint-item indent-3 <%= h[:selectors_by_parent] %> list-group-item level-<%= h[:depth] - 1 %>" data-treeid="<%= h[:id] %>">
         <a href="<%= tree_path(h[:id])%>" title="<%= h[:text] %>"><%= h[:depth_name] %>:
-        <strong><em><%= h[:formatted_code] %></em></strong>
+        <span class="js-tree-code"><strong><em><%= h[:formatted_code] %></em></strong></span>
         </a>
         <%= h[:text].html_safe %>
         <% if h[:dimtrees].length > 0 %>

--- a/app/views/trees/_competencies_column.html.erb
+++ b/app/views/trees/_competencies_column.html.erb
@@ -16,7 +16,7 @@
            }
          end
        %>
-      <li id="<%= h[:subj_code] %>_lo_<%= h[:id] %>" class="maint-item indent-3 <%= h[:selectors_by_parent] %> list-group-item level-<%= h[:depth] - 1 %>" data-loid="<%= h[:id] %>">
+      <li id="<%= h[:subj_code] %>_lo_<%= h[:id] %>" class="sequence-item maint-item indent-3 <%= h[:selectors_by_parent] %> list-group-item level-<%= h[:depth] - 1 %>" data-treeid="<%= h[:id] %>">
         <a href="<%= tree_path(h[:id])%>" title="<%= h[:text] %>"><%= h[:depth_name] %>:
         <strong><em><%= h[:formatted_code] %></em></strong>
         </a>
@@ -43,13 +43,14 @@
           <a class="" href="/<%= @locale_code %>/trees/<%= h[:id] %>?editme=<%= h[:id] %>">
             <i class="fa fa-edit pull-right" title="edit this LO"></i>
           </a>
+          <a class="sort-handle lo-handle" onclick=""><i class="fa fa-thumb-tack pull-right" title="Re-sequence"></i></a>
         </div>
         <% end %>
       </li>
       <!-- TO DO: Find a different workaround for hiding indicator-level items -->
       <% elsif h[:depth] > @treeTypeRec.outcome_depth+1 %>
       <% else %>
-        <li class="maint-sub-header indent-<%= h[:depth]-1 %> <%= h[:selectors_by_parent] %> level-<%= h[:depth] - 1 %>">
+        <li class="sequence-item maint-sub-header indent-<%= h[:depth]-1 %> <%= h[:selectors_by_parent] %> level-<%= h[:depth] - 1 %>" data-treeid="<%= h[:id] %>">
           <a class="" onclick="toggle_visibility('.child-of-<%= code.split(".").join("-") %>', '#trigger-<%= code.split(".").join("-") %>')">
             <i id="trigger-<%= code.split(".").join("-") %>" class="fa fa-compress pull-left option-selected link-blue accordion" title="collapse"></i>
           </a>

--- a/app/views/trees/_competencies_column.html.erb
+++ b/app/views/trees/_competencies_column.html.erb
@@ -16,7 +16,7 @@
            }
          end
        %>
-      <li id="<%= h[:subj_code] %>_lo_<%= h[:id] %>" class="sequence-item maint-item indent-3 <%= h[:selectors_by_parent] %> list-group-item level-<%= h[:depth] - 1 %>" data-treeid="<%= h[:id] %>">
+      <li id="<%= h[:subj_code] %>_tree_<%= h[:id] %>" class="sequence-item maint-item indent-3 <%= h[:selectors_by_parent] %> list-group-item level-<%= h[:depth] - 1 %>" data-treeid="<%= h[:id] %>">
         <a href="<%= tree_path(h[:id])%>" title="<%= h[:text] %>"><%= h[:depth_name] %>:
         <strong><em><%= h[:formatted_code] %></em></strong>
         </a>
@@ -41,16 +41,16 @@
         <div class="pull-right">
           <!-- TO DO: Implement working resequence button and deactivate button -->
           <a class="" href="/<%= @locale_code %>/trees/<%= h[:id] %>?editme=<%= h[:id] %>">
-            <i class="fa fa-edit pull-right" title="edit this LO"></i>
+            <i class="fa fa-edit pull-right" data-toggle="tooltip" title="<%= I18n.translate("trees.edit.tooltip", tree_depth_name: @hierarchies[@treeTypeRec[:outcome_depth]], tree_code: h[:formatted_code]) %>"></i>
           </a>
-          <a class="sort-handle lo-handle" onclick=""><i class="fa fa-thumb-tack pull-right" title="Re-sequence"></i></a>
+          <a class="sort-handle lo-handle" onclick=""><i class="fa fa-thumb-tack pull-right link-blue" data-toggle="tooltip" title="<%= I18n.translate("trees.sequencing.tooltip", tree_depth_name: @hierarchies[@treeTypeRec[:outcome_depth]]) %>"></i></a>
         </div>
         <% end %>
       </li>
       <!-- TO DO: Find a different workaround for hiding indicator-level items -->
       <% elsif h[:depth] > @treeTypeRec.outcome_depth+1 %>
       <% else %>
-        <li class="sequence-item maint-sub-header indent-<%= h[:depth]-1 %> <%= h[:selectors_by_parent] %> level-<%= h[:depth] - 1 %>" data-treeid="<%= h[:id] %>">
+        <li id="<%= h[:subj_code] %>_tree_<%= h[:id] %>" class="sequence-item maint-sub-header indent-<%= h[:depth]-1 %> <%= h[:selectors_by_parent] %> level-<%= h[:depth] - 1 %>" data-treeid="<%= h[:id] %>">
           <a class="" onclick="toggle_visibility('.child-of-<%= code.split(".").join("-") %>', '#trigger-<%= code.split(".").join("-") %>')">
             <i id="trigger-<%= code.split(".").join("-") %>" class="fa fa-compress pull-left option-selected link-blue accordion" title="collapse"></i>
           </a>

--- a/app/views/trees/maint.html.erb
+++ b/app/views/trees/maint.html.erb
@@ -12,7 +12,6 @@
 <br>
 <div class='text-center dimension-page'>
   <h2><%= @page_title %></h2>
-</div>
 <% if @editing
   @dimsArray.each do |dimObj|
     dim = dimObj[:code] %>
@@ -58,5 +57,4 @@
 
 
     </div>
-  </div>
 </div>

--- a/app/views/trees/sequence.html.erb
+++ b/app/views/trees/sequence.html.erb
@@ -117,7 +117,7 @@
             <% end %>
               <% if current_user.present? && can_edit_type?('connect') %>
                 <a class="connect-handle lo-handle" onclick=""><i class="fa fa-link pull-right" title="make a connection between this LO and another"></i></a>
-                <a class="sort-handle lo-handle" onclick=""><i class="fa fa-thumb-tack pull-right" title="resequence this LO within its subject"></i></a>
+                <!-- a class="sort-handle lo-handle" onclick=""><i class="fa fa-thumb-tack pull-right" title="resequence this LO within its subject"></i></a -->
               <% end %>
             </div>
           </li>

--- a/app/views/trees/show.html.erb
+++ b/app/views/trees/show.html.erb
@@ -81,8 +81,6 @@
 
         <% @detailTables.each do |table|
           title, code, type, action, cats = table[:title_code_type_action_catsArr][0]
-          puts "++++TABLE!!!! #{table[:title_code_type_action_catsArr]}"
-          puts "++++TABLE PARTIAL!!!! #{table[:partial]}"
           %>
           <%=
             render partial: "trees/show/#{table[:partial]}", locals: {

--- a/config/locales/pages.ar_EG.yml
+++ b/config/locales/pages.ar_EG.yml
@@ -185,6 +185,7 @@ ar_EG:
       title: "منهاج مصر للعلوم والتكنولوجيا والهندسة والرياضيات"
     sequencing:
       title: "علاقات"
+      tooltip: "انقر واسحب لإعادة تجهيز %{tree_depth_name}"
     maint:
       title: "التحرير"
     dimension:
@@ -198,6 +199,8 @@ ar_EG:
       relates_to: "متعلق ب"
     show:
       name: "صفحة تفاصيل المناهج"
+    edit:
+      tooltip: "تحرير %{tree_depth_name}: %{tree_code}"
     labels:
       filter_by_subject_grade: "تصفية حسب الموضوع والدرجة"
       future_vision: "التحديات الكبرى"

--- a/config/locales/pages.en.yml
+++ b/config/locales/pages.en.yml
@@ -187,6 +187,7 @@ en:
       title: "Mektebim STEM Curriculum"
     sequencing:
       title: "Relations"
+      tooltip: "Click and drag to resequence this %{tree_depth_name}"
     maint:
       title: "Editing"
     dimension:
@@ -200,6 +201,8 @@ en:
       relates_to: "relates to"
     show:
       name: "Curriculum Detail Page"
+    edit:
+      tooltip: "Edit %{tree_depth_name}: %{tree_code}"
     labels:
       filter_by_subject_grade: "Filter by Subject & Grade"
       future_vision: "Future Vision"

--- a/config/locales/pages.tr.yml
+++ b/config/locales/pages.tr.yml
@@ -94,6 +94,7 @@ tr:
       title: "Mektebim STEM Müfredatı"
     sequencing:
       title: "Dizileme"
+      tooltip: "Bu %{tree_depth_name} kaynağını yeniden oluşturmak için tıklayın ve sürükleyin"
     misconc:
       title: "Yanlış"
     bigidea:
@@ -101,6 +102,8 @@ tr:
       relates_to: "alakalı"
     show:
       name: "Müfredat Ayrıntı Sayfası"
+    edit:
+      tooltip: "%{tree_depth_name} 'i düzenleyin: %{tree_code}"
     labels:
       show_areas: "Birimleri Göster"
       show_components: "Bölümlerini Göster"

--- a/lib/tasks/seed_stessa_2.rake
+++ b/lib/tasks/seed_stessa_2.rake
@@ -41,10 +41,11 @@ namespace :seed_stessa_2 do
       tree_code_format: 'subject,grade,lo',
       # To Do: Write documentation on obtaining translation keys
       # - for dimension translation use dim.get_dim_resource_key
+      # NOTE: Please avoid underscores (_) and commas (,)
+      #       in item names.
       #
       # Detail headers notation key:
       #   item - HEADER
-      #   (item) - optional HEADER item
       #   [item] - TABLE item, dimension.
       #   {resource#n} - TABLE item, outcome resource translation
       #   <item> - TABLE item, sectors

--- a/lib/tasks/seed_turkey_v02.rake
+++ b/lib/tasks/seed_turkey_v02.rake
@@ -28,7 +28,7 @@ namespace :seed_turkey_v02 do
     myTreeTypes = TreeType.where(code: @curriculumCode, version_id: @ver.id)
     myTreeTypeValues = {
       code: @curriculumCode,
-      hierarchy_codes: 'grade,unit,sub_unit,comp',
+      hierarchy_codes: 'grade,unit,subunit,comp',
       valid_locales: BaseRec::LOCALE_EN+','+BaseRec::LOCALE_TR,
       sector_set_code: 'future,hide',
       sector_set_name_key: 'sector.set.future.name',
@@ -37,13 +37,14 @@ namespace :seed_turkey_v02 do
       version_id: @ver.id,
       working_status: true,
       dim_codes: 'essq,bigidea,pract,miscon',
-      tree_code_format: 'subject,grade,unit,sub_unit,comp',
+      tree_code_format: 'subject,grade,unit,subunit,comp',
       # To Do: Write documentation on obtaining translation keys
       # - for dimension translation use dim.get_dim_resource_key
       #
       # Detail headers notation key:
-      #   item - HEADER
-      #   (item) - optional HEADER item
+      # NOTE: Please avoid underscores (_) and commas (,)
+      #       in item names.
+      #   item - HEADER item
       #   [item] - TABLE item, dimension.
       #   {resource#n} - TABLE item, outcome resource translation
       #   <item> - TABLE item, sector
@@ -55,12 +56,12 @@ namespace :seed_turkey_v02 do
       #                  e.g., may use indexes in the
       #                  Outcome::RESOURCE_TYPES array.
       #   tableItem_tableItem_... - up to 4 columns table items allowed in one row.
-      detail_headers: 'grade,unit,sub_unit,comp,[bigidea]_[essq],[pract],{resource#6},[miscon#2#1],<sector>,+treetree+,{resources#0#1#2#3#4#5}',
+      detail_headers: 'grade,unit,subunit,comp,[bigidea]_[essq],[pract],{resource#6},[miscon#2#1],<sector>,+treetree+,{resources#0#1#2#3#4#5}',
       # Grid headers notation key:
       # item or (item) - Ignored for now
       # [item] - grid column, may have multiple connected items
       # {item} - grid column, single item
-      grid_headers: 'grade,unit,(sub_unit),comp,[essq],[bigidea],[pract],{explain},[miscon]',
+      grid_headers: 'grade,unit,subunit,comp,[essq],[bigidea],[pract],{explain},[miscon]',
       dim_display: 'miscon#0#1#2#3#4#5#6#7',
     }
     if myTreeTypes.count < 1
@@ -72,9 +73,9 @@ namespace :seed_turkey_v02 do
     throw "ERROR: Missing tfv tree type" if treeTypes.count < 1
     @tt = treeTypes.first
 
-    rec, status, message = Translation.find_or_update_translation(BaseRec::LOCALE_EN, 'app.title', 'Mektebim Curriculum App')
+    rec, status, message = Translation.find_or_update_translation(BaseRec::LOCALE_EN, 'app.title', 'Mektebim STEM Curriculum App')
     throw "ERROR updating sector translation: #{message}" if status == BaseRec::REC_ERROR
-    rec, status, message = Translation.find_or_update_translation(BaseRec::LOCALE_TR, 'app.title', 'Mektebim Müfredat Uygulaması')
+    rec, status, message = Translation.find_or_update_translation(BaseRec::LOCALE_TR, 'app.title', 'Mektebim STEM Müfredat Uygulaması')
     throw "ERROR updating sector translation: #{message}" if status == BaseRec::REC_ERROR
 
     # Create translation(s) for hierarchy codes
@@ -83,7 +84,7 @@ namespace :seed_turkey_v02 do
     rec, status, message = Translation.find_or_update_translation(BaseRec::LOCALE_EN, 'curriculum.tfv.hierarchy.unit', 'Unit')
     throw "ERROR updating sector translation: #{message}" if status == BaseRec::REC_ERROR
     STDOUT.puts 'Create translation record for essential questions as K-12 Big Ideas.'
-    rec, status, message = Translation.find_or_update_translation(BaseRec::LOCALE_EN, 'curriculum.tfv.hierarchy.sub_unit', 'Sub-Unit')
+    rec, status, message = Translation.find_or_update_translation(BaseRec::LOCALE_EN, 'curriculum.tfv.hierarchy.subunit', 'Sub-Unit')
     throw "ERROR updating sector translation: #{message}" if status == BaseRec::REC_ERROR
     STDOUT.puts 'Create translation record for Sub-Unit.'
     rec, status, message = Translation.find_or_update_translation(BaseRec::LOCALE_EN, 'curriculum.tfv.hierarchy.comp', 'Competence')


### PR DESCRIPTION
**Re-coding/Re-sequencing**
- Adds `Tree#update_code_sequence(idOrderArr, treeTypeCode, versionCode, subjectCode)`, which takes an array of ids for all active Trees with a given subject code, and relabels/updates Tree.sort_order to match the order of the `idOrderArr` array.
  - also updates the Outcome base_keys and Translation keys for the updates Trees and Outcomes.
  - takes  `treeTypeCode, versionCode, subjectCode` as params to avoid db queries when building new base_keys for all of the Trees recs

**Hide deactivated curriculum**
- Allow Curriculums to be hidden by deactivating the TreeType rec.

**Fix missing subunits**
- Restore subunits on the Tree Detail page. These were lost when refactoring the page.

Notes: 
- Merge AFTER #138. Many of the "changed files" in this PR are from there.
- was unable to find anything like a `save_all` method for an ActiveRecordAssociation, that would allow us to save changes to all of the updated Trees, Outcomes, and Translations in three db hits (1 per class). 
- when we make it possible to deactivate Trees, we probably need a Tree#deactivate method to re-key the Tree and it's Outcome/Translations. Otherwise we might end up having Translations with duplicate keys where one Translation is from a deactivated Tree rec, and the other is from a relabeled one.
- This pull request is not as big as it looks-- many of the "files changed" are actually the same as 