### PR TITLE
Tree Resources in Uploads at Multiple Tree Depths

### DIFF
--- a/app/assets/javascripts/ckeditor/config.js
+++ b/app/assets/javascripts/ckeditor/config.js
@@ -1,7 +1,6 @@
 /*
 Copyright (c) 2003-2011, CKSource - Frederico Knabben. All rights reserved.
 For licensing, see LICENSE.html or http://ckeditor.com/license
-
 eso note: This file copied from the source and modified.
 */
 
@@ -45,7 +44,7 @@ CKEDITOR.editorConfig = function( config )
     { name: 'links', items: [ 'Link', 'Unlink', 'Anchor' ] },
     { name: 'colors', items: [ 'TextColor', 'BGColor' ] },
     { name: 'basicstyles', groups: [ 'basicstyles', 'cleanup' ], items: [ 'Bold', 'Italic', 'Underline', 'Strike', 'Subscript', 'Superscript', '-', 'RemoveFormat' ] },
-    { name: 'insert', items: [ 'Table', 'HorizontalRule', 'SpecialChar' ] }
+    { name: 'insert', items: [ 'Table', 'HorizontalRule', 'SpecialChar', 'Smiley' ] }
   ];
   config.toolbar = 'mini'
 };

--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -182,6 +182,7 @@ body {
     &.generic-grid--labels-2 { grid-template-columns: 50% 50%; }
     &.generic-grid--labels-3 { grid-template-columns: 33.33% 33.33% 33.33%; }
     &.generic-grid--labels-4 { grid-template-columns: 25% 25% 25% 25%; }
+    p { display: block; width: 100%; }
   }
 }
 

--- a/app/controllers/trees_controller.rb
+++ b/app/controllers/trees_controller.rb
@@ -826,6 +826,7 @@ class TreesController < ApplicationController
     if process_tree
       editMe = params['editme']
       @editMe = false
+      @updated_at = @tree.updated_at
       # turn off detail editing page for now
       if editMe && editMe == @tree.id.to_s && current_user.present?
         @editMe = true

--- a/app/controllers/trees_controller.rb
+++ b/app/controllers/trees_controller.rb
@@ -946,11 +946,24 @@ class TreesController < ApplicationController
       elsif Outcome::RESOURCE_TYPES.include?(@edit_type)
         @ref = Translation.find_translation_name(
             @locale_code,
-            @tree.outcome.get_resource_key(@edit_type),
+            translation_params[:key],
             ""
           )
         #To Do: normalize these translations
-        @ref_label = I18n.t("trees.labels.teacher_field_#{Outcome::RESOURCE_TYPES.index(@edit_type) + 1}")
+        @ref_label = Outcome.get_resource_name(@edit_type, @treeTypeRec.code, @versionRec.code, @locale_code)
+        @translation_key = translation_params[:key]
+      elsif Tree::RESOURCE_TYPES.include?(@edit_type)
+        @ref = Translation.find_translation_name(
+            @locale_code,
+            translation_params[:key],
+            ""
+          )
+        @ref_label = Translation.find_translation_name(
+            @locale_code,
+            Tree.get_resource_type_key(@edit_type, @treeTypeRec.code, @versionRec.code),
+            ""
+          )
+        @translation_key = translation_params[:key]
       elsif @edit_type.split("#")[0] == "ref_settings"
         resource_types = @edit_type.split("#")
         if resource_types.length > 1
@@ -997,8 +1010,7 @@ class TreesController < ApplicationController
   def update
     errors = []
     update_type = tree_params[:edit_type]
-    attr_tree = (update_type == 'tree' && tree_params[:attr_id] ?
-      Tree.find(tree_params[:attr_id]) : nil)
+    attr_tree = (update_type == 'tree' && tree_params[:attr_id] ? Tree.find(tree_params[:attr_id]) : nil)
     tree_to_update = update_type == "indicator" ? Tree.find(tree_params[:attr_id]) : @tree
     message = tree_to_update.update_fields(
       update_type,
@@ -1009,6 +1021,7 @@ class TreesController < ApplicationController
       weeks: tree_params[:weeks],
       hours: tree_params[:hours],
       resource: tree_params[:resource],
+      resource_key: translation_params ? translation_params[:key] : nil,
       resource_name_arr: tree_params[:resource_name],
       resource_name_keys: tree_params[:resource_key],
       tree_tree_id: update_type == 'treetree' ? tree_params[:attr_id] : nil,

--- a/app/controllers/uploads_controller.rb
+++ b/app/controllers/uploads_controller.rb
@@ -791,7 +791,7 @@ class UploadsController < ApplicationController
             resource_key,
             resource_text
           )
-          rptErrorMsg += "#{rptErrorMsg.length > 0 ? " ," : "" }Updated Resource Type: #{type}"
+          rptErrorMsg += "#{rptErrorMsg.length > 0 ? ", " : "" }Updated Resource Type: #{type}"
         end
       end
       # output the translation record if any changes
@@ -830,7 +830,7 @@ class UploadsController < ApplicationController
       outRecId = outRec.id
       Outcome::RESOURCE_TYPES.each do |type|
         resource_text = rowH["Learning Outcome::#{type}"]
-        if !resource_text.blank?
+        if resource_text.present?
           resource_key = outRec.get_resource_key(type)
           Translation.find_or_update_translation(
             @locale_code,

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -140,7 +140,7 @@ module ApplicationHelper
               "create", #action
               nil #category codes not implemented for sectors
             ]
-          table[:num_rows] =  [@detailsHash[catCodes].length, table[:num_rows]].max
+          table[:num_rows] =  [@detailsHash[catCode].length, table[:num_rows]].max
           table[:depths] << nil
           @editTypes[catCode] = { :name => "sector"}
         #table uses 'treetree' partial

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -92,13 +92,14 @@ module ApplicationHelper
       table[:num_rows] = 1
       table[:title_code_type_action_catsArr] = []
       table[:partial] = "evenly_spaced_details"
+      table[:depths] = []
       details.each do |d|
         ttac_arr = []
         table[:num_cols] += 1
         #table building 'evenly_spaced_details' partial
         if d.first == "{" && d.last == "}" #outcome resource(s)
           catCodes = d[1..d.length - 2].split("#")
-          resource_types = catCodes[0] == 't' ? Tree::RESOURCE_TYPES : Outcome::RESOURCE_TYPES
+          resource_types = hierarchy_codes.include?(catCodes[0]) ? Tree::RESOURCE_TYPES : Outcome::RESOURCE_TYPES
           table[:title_code_type_action_catsArr] << [
               "", #title
               resource_types[catCodes[1].to_i], #code
@@ -107,7 +108,7 @@ module ApplicationHelper
               catCodes[1..catCodes.length - 1] #numeric category codes
             ]
           table[:partial] = "resources" if catCodes[0] == "resources"
-          table[:depth] = hierarchy_codes.index(catCodes[0])
+          table[:depths] << hierarchy_codes.index(catCodes[0])
           @editTypes[resource_types[catCodes[1].to_i]] = {
             :name => (hierarchy_codes.include?(catCodes[0]) ? "tree_resource" : "resource"),
             :codes => catCodes[1..catCodes.length - 1]
@@ -124,6 +125,7 @@ module ApplicationHelper
             ]
           table[:num_cols] += catCodes.length - 1
           table[:num_rows] =  [@detailsHash[catCodes[0]].length, table[:num_rows]].max
+          table[:depths] << nil
           @editTypes[catCodes[0]] = {
             :name => "dimtree",
             :codes => catCodes[1..catCodes.length - 1]
@@ -139,6 +141,7 @@ module ApplicationHelper
               nil #category codes not implemented for sectors
             ]
           table[:num_rows] =  [@detailsHash[catCodes].length, table[:num_rows]].max
+          table[:depths] << nil
           @editTypes[catCode] = { :name => "sector"}
         #table uses 'treetree' partial
         elsif d.first == "+" && d.last == "+" #treetree
@@ -155,6 +158,7 @@ module ApplicationHelper
             ]
           table[:num_cols] += 3
           table[:partial] = 'treetree' #treetrees have a special partial
+          table[:depths] << nil
           @editTypes[catCode] = {:name => 'treetree'}
         else
           header_area = true

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -98,16 +98,18 @@ module ApplicationHelper
         #table building 'evenly_spaced_details' partial
         if d.first == "{" && d.last == "}" #outcome resource(s)
           catCodes = d[1..d.length - 2].split("#")
+          resource_types = catCodes[0] == 't' ? Tree::RESOURCE_TYPES : Outcome::RESOURCE_TYPES
           table[:title_code_type_action_catsArr] << [
               "", #title
-              Outcome::RESOURCE_TYPES[catCodes[1].to_i], #code
-              Outcome::RESOURCE_TYPES[catCodes[1].to_i],
+              resource_types[catCodes[1].to_i], #code
+              resource_types[catCodes[1].to_i],
               "edit", #action
               catCodes[1..catCodes.length - 1] #numeric category codes
             ]
-          table[:partial] = catCodes[0] if catCodes[0] != "resource"
-          @editTypes[Outcome::RESOURCE_TYPES[catCodes[1].to_i]] = {
-            :name => "resource",
+          table[:partial] = "resources" if catCodes[0] == "resources"
+          table[:depth] = hierarchy_codes.index(catCodes[0])
+          @editTypes[resource_types[catCodes[1].to_i]] = {
+            :name => (hierarchy_codes.include?(catCodes[0]) ? "tree_resource" : "resource"),
             :codes => catCodes[1..catCodes.length - 1]
           }
         #table building 'evenly_spaced_details' partial

--- a/app/models/base_rec.rb
+++ b/app/models/base_rec.rb
@@ -65,4 +65,24 @@ class BaseRec < ActiveRecord::Base
 
   DIM_CHANGE_LOG_PATH = "#{Rails.root}/log/dimension_changes.out"
 
+  def self.process_resource_content(resource_type, resource_name, content_text)
+    convert_id_to_google_folder_url = [
+      'depth_0_materials',
+      'depth_1_materials',
+      'depth_2_materials',
+      'lp_folder'
+    ]
+    convert_id_to_google_ss_url = [
+      'lp_ss_id'
+    ]
+    ret = content_text
+    if convert_id_to_google_folder_url.include?(resource_type)
+      ret = "<a href='https://drive.google.com/drive/folders/#{content_text}' target='_blank'>#{resource_name}</a>"
+    elsif convert_id_to_google_ss_url.include?(resource_type)
+      ret = "<a href='https://docs.google.com/spreadsheets/d/#{content_text}' target='_blank'>#{resource_name}</a>"
+    end
+    return ret
+  end
+
+
 end

--- a/app/models/outcome.rb
+++ b/app/models/outcome.rb
@@ -7,14 +7,17 @@ class Outcome < BaseRec
   # Only add new resource types to end.
   RESOURCE_TYPES = [
     "proj_ref",
-    "learn_prog",
+    "learn_prog", #lesson plans
     "class_text",
     "activity",
     "teacher_ref",
     "goal",
-    "explain",
+    "explain", #teacher support/explanatory comments
     "evid_learning",
-    "connections",
+    "connections", #capstone connections
+    "sec_topic",
+    "sec_code",
+    "cog_demand", #SEC Cognitive Demand
   ]
 
   # Field Translations

--- a/app/models/outcome.rb
+++ b/app/models/outcome.rb
@@ -22,6 +22,7 @@ class Outcome < BaseRec
     "sec_code",
     "cog_demand", #SEC Cognitive Demand
     "lp_ss_id", #Lesson Plan (expect a Google Spreadsheet Id)
+    "review_comments" #WL Review Comments
   ]
 
   # Field Translations

--- a/app/models/outcome.rb
+++ b/app/models/outcome.rb
@@ -5,6 +5,9 @@ class Outcome < BaseRec
   # Do not change existing sequence of
   # RESOURCES_TYPES.
   # Only add new resource types to end.
+  #
+  # See special processing behavior for specific
+  # resource types in BaseRec.process_resource_content(type, content)
   RESOURCE_TYPES = [
     "proj_ref",
     "learn_prog", #lesson plans
@@ -18,6 +21,7 @@ class Outcome < BaseRec
     "sec_topic",
     "sec_code",
     "cog_demand", #SEC Cognitive Demand
+    "lp_ss_id", #Lesson Plan (expect a Google Spreadsheet Id)
   ]
 
   # Field Translations

--- a/app/models/tree.rb
+++ b/app/models/tree.rb
@@ -15,11 +15,19 @@ class Tree < BaseRec
   # hash to return cyrillic letter for english letter in sequence order
   GET_ENG_SEQ_CYR_IND_H = INDICATOR_CYR_SEQ_CYR.zip(INDICATOR_SEQ_ENG).to_h
 
+
+  # Do not change existing sequence of
+  # RESOURCES_TYPES.
+  # Only add new resource types to end.
+  #
+  # See special processing behavior for specific
+  # resource types in BaseRec.process_resource_content(type, content)
   RESOURCE_TYPES = [
-    "depth_0_materials", #materials for hierarchy depth 0
-    "depth_1_materials",
-    "depth_2_materials",
-    "lp_folder", #semester lesson plans folder
+    "depth_0_materials", # expect a google folder id.
+                         # materials for hierarchy depth 0
+    "depth_1_materials", # expect a google folder id.
+    "depth_2_materials", # expect a google folder id.
+    "lp_folder", # expect a google folder id. semester lesson plans folder
     "theme",
   ]
 
@@ -120,6 +128,7 @@ class Tree < BaseRec
     weeks: nil,
     hours: nil,
     resource: nil,
+    resource_key: nil,
     resource_name_arr: nil,
     resource_name_keys: nil,
     tree_tree_id: nil,
@@ -145,7 +154,7 @@ class Tree < BaseRec
       outcome.update(hours_per_week: hours.to_i) if hours
       Translation.find_or_update_translation(
         locale_code,
-        outcome.get_resource_key(update_type),
+        resource_key,
         resource.split("<script>").join("").split("</script>").join("")
       ) if resource
       if (resource_name_arr && resource_name_keys)

--- a/app/models/tree.rb
+++ b/app/models/tree.rb
@@ -15,6 +15,14 @@ class Tree < BaseRec
   # hash to return cyrillic letter for english letter in sequence order
   GET_ENG_SEQ_CYR_IND_H = INDICATOR_CYR_SEQ_CYR.zip(INDICATOR_SEQ_ENG).to_h
 
+  RESOURCE_TYPES = [
+    "depth_0_materials", #materials for hierarchy depth 0
+    "depth_1_materials",
+    "depth_2_materials",
+    "lp_folder", #semester lesson plans folder
+    "theme",
+  ]
+
   belongs_to :tree_type
   belongs_to :version
   belongs_to :subject
@@ -86,6 +94,21 @@ class Tree < BaseRec
     return "#{self.tree_type.code}.#{self.version.code}.#{self.subject.code}.#{self.grade_band.code}"
   end
 
+  def get_resource_key(resource_type)
+    if RESOURCE_TYPES.include?(resource_type)
+      return "#{base_key}.#{resource_type}"
+    else
+      return nil
+    end
+  end
+
+  def self.get_resource_type_key(resource_type, tree_type_code, version_code)
+    if RESOURCE_TYPES.include?(resource_type)
+      return "curriculum.#{tree_type_code}.#{version_code}.tree_resource_type_name.#{resource_type}"
+    else
+      return nil
+    end
+  end
 
   ####################################################
   def update_fields(

--- a/app/models/tree.rb
+++ b/app/models/tree.rb
@@ -139,6 +139,7 @@ class Tree < BaseRec
     x_dim_tree_id: nil
   )
     begin
+      touch(:updated_at)
       # name_translation = name_translation[3..name_translation.length].gsub('<br>', '').gsub('</p>', '').gsub('<p>', '<br>') if name_translation
       Translation.find_or_update_translation(
         locale_code,

--- a/app/models/tree.rb
+++ b/app/models/tree.rb
@@ -600,6 +600,8 @@ class Tree < BaseRec
       #save old translation name key before
       #updating t.code and t.base_key in
       old_name_key = t.name_key
+      Tree::RESOURCE_TYPES.map { |rt| translationKeys << t.get_resource_key(rt) }
+      old_base_key = t.base_key
       t.code = new_code
       t.base_key = Tree.buildBaseKey(treeTypeCode, versionCode, subjectCode, new_code)
       #build new translation name key now that
@@ -608,6 +610,7 @@ class Tree < BaseRec
       t.sort_order = ix + sort_order_offset
       translationKeys << old_name_key
       translations_hash[old_name_key] = new_name_key
+      Tree::RESOURCE_TYPES.map { |rt| translations_hash["#{old_base_key}.#{rt}"] = t.get_resource_key(rt) }
       tree_codes_changed << {tree_id: t.id, new_code: t.format_code(localeCode,
         treeTypeRec.hierarchy_codes.split(","),
         treeTypeRec.tree_code_format,

--- a/app/views/trees/_dim_column.html.erb
+++ b/app/views/trees/_dim_column.html.erb
@@ -9,32 +9,34 @@
   </li>
   <% if dims && dims.count > 0 %>
     <% dims.each do |dim| %>
-      <% dim_link = dimension_path(dim.id) if @dimDisplayHash[dim.dim_code] %>
-      <li id="<%= "#{dim_subj_name}-dim-#{dim.id}"%>" class="dim-item dim-item--collapsable list-group-item ui-draggable" data-dimid="<%= dim.id %>">
-        <span class='pull-left'><strong><%= "#{translate('app.labels.subject')}:"%></strong> <%="#{dim_subj_name}" %></span>
+      <% if @translations[dim.dim_name_key] %>
+        <% dim_link = dimension_path(dim.id) if @dimDisplayHash[dim.dim_code] %>
+        <li id="<%= "#{dim_subj_name}-dim-#{dim.id}"%>" class="dim-item dim-item--collapsable list-group-item ui-draggable" data-dimid="<%= dim.id %>">
+          <span class='pull-left'><strong><%= "#{translate('app.labels.subject')}:"%></strong> <%="#{dim_subj_name}" %></span>
+            <br/>
+            <span class='pull-left'><strong><%= "#{grades_str}: " %></strong> <%= "#{dim.min_grade} - #{dim.max_grade}" %></span>
+
           <br/>
-          <span class='pull-left'><strong><%= "#{grades_str}: " %></strong> <%= "#{dim.min_grade} - #{dim.max_grade}" %></span>
+          <span class='pull-left left-justify'><strong><%= "#{dim_title.singularize}: " %></strong>
+            <% if dim_link %>
+              <a href="<%= dim_link %>">
+              <%= @translations[dim.dim_name_key].html_safe %>
+              </a>
+            <% else %>
+              <%= @translations[dim.dim_name_key].html_safe %>
+            <% end %>
+          </span>
+          <br/>
 
-        <br/>
-        <span class='pull-left left-justify'><strong><%= "#{dim_title.singularize}: " %></strong>
-          <% if dim_link %>
-            <a href="<%= dim_link %>">
-            <%= @translations[dim.dim_name_key].html_safe %>
-            </a>
-          <% else %>
-            <%= @translations[dim.dim_name_key].html_safe %>
-          <% end %>
-        </span>
-        <br/>
-
-        <% if can_edit && @editing%>
-          <div class="pull-right">
-              <a class="connect-handle lo-handle" onclick=""><i class="fa fa-link pull-right" title="make a connection"></i></a>
-              <%= link_to(fa_icon("times", class: "pull-right"), update_dimension_trees_path(dimension: { id: dim.id, active: false}), {'data-confirm' => I18n.t('app.labels.confirm_deactivate', item: @translations[dim.dim_name_key]), method: :patch}) %>
-              <%= link_to(fa_icon("edit", class: "pull-right"), dimension_form_trees_path( dimension: { id: dim.id}), {:remote => true, 'data-toggle' =>  "modal", 'data-target' => '#modal_popup'}) %>
-          </div>
+          <% if can_edit && @editing%>
+            <div class="pull-right">
+                <a class="connect-handle lo-handle" onclick=""><i class="fa fa-link pull-right" title="make a connection"></i></a>
+                <%= link_to(fa_icon("times", class: "pull-right"), update_dimension_trees_path(dimension: { id: dim.id, active: false}), {'data-confirm' => I18n.t('app.labels.confirm_deactivate', item: @translations[dim.dim_name_key]), method: :patch}) %>
+                <%= link_to(fa_icon("edit", class: "pull-right"), dimension_form_trees_path( dimension: { id: dim.id}), {:remote => true, 'data-toggle' =>  "modal", 'data-target' => '#modal_popup'}) %>
+            </div>
+        <% end %>
+        </li>
       <% end %>
-      </li>
-    <% end %>
+    <% end #dims.each do |dim| %>
   <% end #if dims %>
 </ul>

--- a/app/views/trees/_edit.html.erb
+++ b/app/views/trees/_edit.html.erb
@@ -8,6 +8,7 @@
     <%= f.hidden_field :active, name: 'tree[active]', value: true %>
     <%= f.hidden_field :edit_type, name: 'tree[edit_type]', value: @edit_type %>
     <%= f.hidden_field :attr_id, name: 'tree[attr_id]', value: @attr_id  if (@edit_type != 'outcome') %>
+    <%= f.hidden_field :translation_key, name: 'translation[key]', value: @translation_key  if @translation_key %>
   </div>
   <!--feilds for editing the Outcome and Indicator text-->
 	<% if @edit_type == 'outcome' || @edit_type == 'tree' %>

--- a/app/views/trees/show.html.erb
+++ b/app/views/trees/show.html.erb
@@ -95,6 +95,7 @@
               tree: @tree,
               indicator: table[:indicator],
               resource_codes: cats,
+              parent: parents_by_depth[table[:depth]],
             }
           %>
         <% end %>

--- a/app/views/trees/show.html.erb
+++ b/app/views/trees/show.html.erb
@@ -113,4 +113,8 @@
       </div>
     </div>
   <% end %>
+  <br>
+  <div class="pull-left">
+    <%= I18n.translate("app.labels.last_updated", time: @updated_at) %>
+  </div>
 </div>

--- a/app/views/trees/show.html.erb
+++ b/app/views/trees/show.html.erb
@@ -95,14 +95,10 @@
               tree: @tree,
               indicator: table[:indicator],
               resource_codes: cats,
-              parent: parents_by_depth[table[:depth]],
+              parents: (table[:depths].length > 0 ? table[:depths].map { |d| parents_by_depth[d]} : nil) ,
             }
           %>
         <% end %>
-
-
-
-
 
 
 

--- a/app/views/trees/show/_evenly_spaced_details.html.erb
+++ b/app/views/trees/show/_evenly_spaced_details.html.erb
@@ -61,7 +61,7 @@
                 category_codes: @editTypes[detail_code][:codes],
                 render_label: false,
                 can_edit: can_edit_type?(detail_code) || current_user.subject_admin?(@subject_code),
-                parent: parent
+                parent: parents[ix]
                }
             %>
 

--- a/app/views/trees/show/_evenly_spaced_details.html.erb
+++ b/app/views/trees/show/_evenly_spaced_details.html.erb
@@ -19,6 +19,16 @@
             @treeTypeRec.code,
             @versionRec.code,
             @locale_code) if @editTypes[detail_code][:name] == "resource"
+          category_title = Translation.find_translation_name(
+              @locale_code,
+              Tree.get_resource_type_key(
+                Tree::RESOURCE_TYPES[cat.to_i],
+                @treeTypeRec.code,
+                @versionRec.code
+              ),
+              Tree::RESOURCE_TYPES[cat.to_i]
+            )  if @editTypes[detail_code][:name] == "tree_resource"
+
           category_title = Dimension.get_resource_name(
             Dimension::RESOURCE_TYPES[cat.to_i],
             @treeTypeRec.code,
@@ -51,6 +61,7 @@
                 category_codes: @editTypes[detail_code][:codes],
                 render_label: false,
                 can_edit: can_edit_type?(detail_code) || current_user.subject_admin?(@subject_code),
+                parent: parent
                }
             %>
 

--- a/app/views/trees/show/_resource.html.erb
+++ b/app/views/trees/show/_resource.html.erb
@@ -1,3 +1,4 @@
+<% resource_key = @tree.outcome.get_resource_key(type_code) %>
 <div class='dark-border--left teacher-item'>
   <% if render_label %>
   <div class='center-label sub-header-margin'>
@@ -8,12 +9,12 @@
     <div class="text-left padding-left padding-right row padding-top padding-bottom">
       <%= Translation.find_translation_name(
       @locale_code,
-      @tree.outcome.get_resource_key(type_code),
+      resource_key,
       ""
       ).html_safe %>
     </div>
     <div class="col col-1">
-     <%= link_to(fa_icon("edit"), edit_tree_path(@tree.id, tree: { edit_type: type_code }), {:class => "fa-lg pull-right", :remote => true, 'data-toggle' =>  "modal", 'data-target' => '#modal_popup'}) if @editMe && (can_edit_type?('resource') || current_user.subject_admin?(@subject_code)) %>
+     <%= link_to(fa_icon("edit"), edit_tree_path(@tree.id, tree: { edit_type: type_code }, translation: {key: resource_key}), {:class => "fa-lg pull-right", :remote => true, 'data-toggle' =>  "modal", 'data-target' => '#modal_popup'}) if @editMe && (can_edit_type?('resource') || current_user.subject_admin?(@subject_code)) %>
     </div>
   </div>
 </div>

--- a/app/views/trees/show/_resource.html.erb
+++ b/app/views/trees/show/_resource.html.erb
@@ -13,7 +13,7 @@
       ).html_safe %>
     </div>
     <div class="col col-1">
-     <%= link_to(fa_icon("edit"), edit_tree_path(@tree.id, tree: { edit_type: type_code }), {:class => "fa-lg pull-right", :remote => true, 'data-toggle' =>  "modal", 'data-target' => '#modal_popup'}) if @editMe && can_edit_type?('resource') %>
+     <%= link_to(fa_icon("edit"), edit_tree_path(@tree.id, tree: { edit_type: type_code }), {:class => "fa-lg pull-right", :remote => true, 'data-toggle' =>  "modal", 'data-target' => '#modal_popup'}) if @editMe && (can_edit_type?('resource') || current_user.subject_admin?(@subject_code)) %>
     </div>
   </div>
 </div>

--- a/app/views/trees/show/_sector.html.erb
+++ b/app/views/trees/show/_sector.html.erb
@@ -1,6 +1,6 @@
 <% st = details %>
-<div class='row'>
-  <div class='col col-lg-12 dark-border--left padding-left padding-right padding-top margin-top margin-bottom'>
+<div class='row dark-border--left'>
+  <div class='col col-lg-12 padding-left padding-right padding-top margin-top margin-bottom'>
     <%= link_to(
       "#{@translations[st.sector.name_key]}",
       sectors_path(

--- a/app/views/trees/show/_tree_resource.html.erb
+++ b/app/views/trees/show/_tree_resource.html.erb
@@ -1,4 +1,5 @@
-<div class='dark-border--left teacher-item'>
+<% resource_key = parent.get_resource_key(type_code) %>
+<div class='dark-border--left'>
   <% if render_label %>
     <div class='center-label sub-header-margin'>
       <%= Tree.get_resource_name(type_code, @treeTypeRec.code, @versionRec.code, @locale_code) %>
@@ -8,12 +9,12 @@
     <div class="text-left padding-left padding-right row padding-top padding-bottom">
       <%= Translation.find_translation_name(
       @locale_code,
-      parent.get_resource_key(type_code),
+      resource_key,
       ""
       ).html_safe %>
     </div>
     <div class="col col-1">
-     <%= link_to(fa_icon("edit"), edit_tree_path(parent.id, tree: { edit_type: type_code, tree_redirect_id: @tree.id }), {:class => "fa-lg pull-right", :remote => true, 'data-toggle' =>  "modal", 'data-target' => '#modal_popup'}) if @editMe && can_edit_type?('resource') %>
+     <%= link_to(fa_icon("edit"), edit_tree_path(@tree.id, tree: { edit_type: type_code, tree_redirect_id: @tree.id }, translation: {key: resource_key}), {:class => "fa-lg pull-right", :remote => true, 'data-toggle' =>  "modal", 'data-target' => '#modal_popup'}) if @editMe && can_edit_type?('resource') %>
     </div>
   </div>
 </div>

--- a/app/views/trees/show/_tree_resource.html.erb
+++ b/app/views/trees/show/_tree_resource.html.erb
@@ -13,7 +13,7 @@
       ).html_safe %>
     </div>
     <div class="col col-1">
-     <%= #link_to(fa_icon("edit"), edit_tree_path(parent.id, tree: { edit_type: type_code, tree_redirect_id: @tree.id }), {:class => "fa-lg pull-right", :remote => true, 'data-toggle' =>  "modal", 'data-target' => '#modal_popup'}) if @editMe && can_edit_type?('resource') %>
+     <%= link_to(fa_icon("edit"), edit_tree_path(parent.id, tree: { edit_type: type_code, tree_redirect_id: @tree.id }), {:class => "fa-lg pull-right", :remote => true, 'data-toggle' =>  "modal", 'data-target' => '#modal_popup'}) if @editMe && can_edit_type?('resource') %>
     </div>
   </div>
 </div>

--- a/app/views/trees/show/_tree_resource.html.erb
+++ b/app/views/trees/show/_tree_resource.html.erb
@@ -1,0 +1,19 @@
+<div class='dark-border--left teacher-item'>
+  <% if render_label %>
+    <div class='center-label sub-header-margin'>
+      <%= Tree.get_resource_name(type_code, @treeTypeRec.code, @versionRec.code, @locale_code) %>
+    </div>
+  <% end %>
+  <div class="generic-grid generic-grid--xl-xs">
+    <div class="text-left padding-left padding-right row padding-top padding-bottom">
+      <%= Translation.find_translation_name(
+      @locale_code,
+      parent.get_resource_key(type_code),
+      ""
+      ).html_safe %>
+    </div>
+    <div class="col col-1">
+     <%= #link_to(fa_icon("edit"), edit_tree_path(parent.id, tree: { edit_type: type_code, tree_redirect_id: @tree.id }), {:class => "fa-lg pull-right", :remote => true, 'data-toggle' =>  "modal", 'data-target' => '#modal_popup'}) if @editMe && can_edit_type?('resource') %>
+    </div>
+  </div>
+</div>

--- a/config/locales/pages.ar_EG.yml
+++ b/config/locales/pages.ar_EG.yml
@@ -58,6 +58,7 @@ ar_EG:
       final_version: "نهائي"
       connect_form_title: "حفظ الاتصال؟"
       show_details: "اظهر التفاصيل"
+      last_updated: "Last updated at: %{time}"
     roles:
       name: 'الأدوار'
       admin:

--- a/config/locales/pages.en.yml
+++ b/config/locales/pages.en.yml
@@ -61,6 +61,7 @@ en:
       final_version: "Final"
       connect_form_title: "Save Connection?"
       show_details: "Show Details"
+      last_updated: "Last updated at: %{time}"
     roles:
       name: 'Roles'
       admin:

--- a/config/locales/pages.tr.yml
+++ b/config/locales/pages.tr.yml
@@ -36,6 +36,7 @@ tr:
       upload_new: 'Yükleme Ekle ve Yap'
       explanation: "Açıklama"
       sector_num: "Sektör %{num}"
+      last_updated: "Last updated at: %{time}"
       errors:
         max_subj_display_count: "Bir defada en fazla %{num} konu görüntülenebilir."
   nav_bar:

--- a/lib/tasks/seed_stessa_2.rake
+++ b/lib/tasks/seed_stessa_2.rake
@@ -434,6 +434,7 @@ namespace :seed_stessa_2 do
       ["SEC Code", "كود SEC"],
       ["SEC Cognitive Demand", "الطلب المعرفي SEC"],
       ["Daily Lesson Plans", "خطط الدروس اليومية"], #LP as a spreadsheet ID, processed differently than the LP at index 1.
+      ["WL Review Comments", "تعليقات مراجعة WL"]
     ]
 
     outc_resource_types_arr.each_with_index do |resource, i|

--- a/lib/tasks/seed_stessa_2.rake
+++ b/lib/tasks/seed_stessa_2.rake
@@ -475,4 +475,67 @@ namespace :seed_stessa_2 do
   task ensure_default_translations: :environment do
 
   end #task
+
+  #####################################
+  desc "One-time process to convert google folder-ids to google links in Tree Resource Translations"
+  task make_google_links: :environment do
+    @tt = TreeType.where(code: 'egstem').first
+    @ver = Version.find(@tt.version_id)
+    trees = Tree.where(tree_type_id: @tt.id)
+    url = "https://drive.google.com/drive/folders/"
+    trees.each do |t|
+      if t[:depth] == 0
+        course_materials_key = Tree.get_resource_key('depth_0_materials')
+        folder_id = Translation.find_translation_name(
+          "en",
+          course_materials_key,
+          nil
+        )
+        if folder_id && !folder_id.include?(url)
+          folder_id = "<a href='#{url}#{folder_id}' target='_blank'><i class='fa fa-folder'></i></a>"
+          Translation.find_or_update_translation(
+            "en",
+            course_materials_key,
+            folder_id
+          )
+        end
+      elsif t[:depth] == 1
+        semester_lp_folder = Tree.get_resource_key('lp_folder')
+        folder_id = Translation.find_translation_name(
+          "en",
+          semester_lp_folder,
+          nil
+        )
+        if folder_id && !folder_id.include?(url)
+          folder_id = "<a href='#{url}#{folder_id}' target='_blank'><i class='fa fa-folder'></i></a>"
+            Translation.find_or_update_translation(
+            "en",
+            semester_materials_key,
+            folder_id
+          )
+        end
+      elsif t[:depth] == 2
+        unit_materials_key = Tree.get_resource_key('depth_2_materials')
+        folder_id = Translation.find_translation_name(
+          "en",
+          unit_materials_key,
+          nil
+        )
+        if folder_id && !folder_id.include?(url)
+          folder_id = "<a href='#{url}#{folder_id}' target='_blank'><i class='fa fa-folder'></i></a>"
+          Translation.find_or_update_translation("en", unit_materials_key, folder_id)
+        end
+      elsif t.outcome_id
+        lp_key = t.outcome.get_resource_key('learn_prog')
+        #https://docs.google.com/spreadsheets/d/
+        #fa-file
+        file_id = Translation.find_translation_name("en", lp_key, nil)
+        if file_id && !file_id.include?("https://docs.google.com/spreadsheets/d/")
+          file_id = "<a href='https://docs.google.com/spreadsheets/d/#{folder_id}' target='_blank'><i class='fa fa-file'></i></a>"
+          Translation.find_or_update_translation("en", lp_key, file_id)
+        end
+      end
+    end #trees.each do |t|
+  end
+
 end

--- a/lib/tasks/seed_stessa_2.rake
+++ b/lib/tasks/seed_stessa_2.rake
@@ -58,7 +58,7 @@ namespace :seed_stessa_2 do
       #                  e.g., may use indexes in the
       #                  Outcome::RESOURCE_TYPES array.
       #   tableItem_tableItem_... - up to 4 columns table items allowed in one row.
-      detail_headers: 'grade,unit,lo,weeks,hours,[bigidea]_[essq],[concept]_[skill],[miscon#2#1],{resource#6},{resource#7},{grade#0}_{unit#2}_{sem#4},<sector>,+treetree+,{resources#1#3#2}',
+      detail_headers: 'grade,sem,unit,lo,weeks,hours,[bigidea]_[essq],[concept]_[skill],[miscon#2#1],{resource#6},{resource#7},{grade#0}_{unit#2}_{sem#4},<sector>,+treetree+,{resources#12#3#2}',
       grid_headers: 'grade,unit,lo,[bigidea],[essq],[concept],[skill],[miscon]',
       #Display codes are zero-relative indexes in Dimension::RESOURCE_TYPES
       #Dimensions must appear in this string to have a show page
@@ -432,7 +432,8 @@ namespace :seed_stessa_2 do
       ["Capstone Connection", "روابط"],
       ["SEC Topic", "موضوع SEC"],
       ["SEC Code", "كود SEC"],
-      ["SEC Cognitive Demand", "الطلب المعرفي SEC"]
+      ["SEC Cognitive Demand", "الطلب المعرفي SEC"],
+      ["Daily Lesson Plans", "خطط الدروس اليومية"], #LP as a spreadsheet ID, processed differently than the LP at index 1.
     ]
 
     outc_resource_types_arr.each_with_index do |resource, i|
@@ -485,14 +486,14 @@ namespace :seed_stessa_2 do
     url = "https://drive.google.com/drive/folders/"
     trees.each do |t|
       if t[:depth] == 0
-        course_materials_key = Tree.get_resource_key('depth_0_materials')
+        course_materials_key = t.get_resource_key('depth_0_materials')
         folder_id = Translation.find_translation_name(
           "en",
           course_materials_key,
           nil
         )
-        if folder_id && !folder_id.include?(url)
-          folder_id = "<a href='#{url}#{folder_id}' target='_blank'><i class='fa fa-folder'></i></a>"
+        if !folder_id.blank? && !folder_id.include?(url)
+          folder_id = "<a href='#{url}#{folder_id}' target='_blank'><i class='fa fa-lg fa-folder'></i></a>"
           Translation.find_or_update_translation(
             "en",
             course_materials_key,
@@ -500,29 +501,29 @@ namespace :seed_stessa_2 do
           )
         end
       elsif t[:depth] == 1
-        semester_lp_folder = Tree.get_resource_key('lp_folder')
+        semester_lp_folder = t.get_resource_key('lp_folder')
         folder_id = Translation.find_translation_name(
           "en",
           semester_lp_folder,
           nil
         )
-        if folder_id && !folder_id.include?(url)
-          folder_id = "<a href='#{url}#{folder_id}' target='_blank'><i class='fa fa-folder'></i></a>"
+        if !folder_id.blank? && !folder_id.include?(url)
+          folder_id = "<a href='#{url}#{folder_id}' target='_blank'><i class='fa fa-lg fa-folder'></i></a>"
             Translation.find_or_update_translation(
             "en",
-            semester_materials_key,
+            semester_lp_folder,
             folder_id
           )
         end
       elsif t[:depth] == 2
-        unit_materials_key = Tree.get_resource_key('depth_2_materials')
+        unit_materials_key = t.get_resource_key('depth_2_materials')
         folder_id = Translation.find_translation_name(
           "en",
           unit_materials_key,
           nil
         )
-        if folder_id && !folder_id.include?(url)
-          folder_id = "<a href='#{url}#{folder_id}' target='_blank'><i class='fa fa-folder'></i></a>"
+        if !folder_id.blank? && !folder_id.include?(url)
+          folder_id = "<a href='#{url}#{folder_id}' target='_blank'><i class='fa fa-lg fa-folder'></i></a>"
           Translation.find_or_update_translation("en", unit_materials_key, folder_id)
         end
       elsif t.outcome_id
@@ -530,8 +531,8 @@ namespace :seed_stessa_2 do
         #https://docs.google.com/spreadsheets/d/
         #fa-file
         file_id = Translation.find_translation_name("en", lp_key, nil)
-        if file_id && !file_id.include?("https://docs.google.com/spreadsheets/d/")
-          file_id = "<a href='https://docs.google.com/spreadsheets/d/#{folder_id}' target='_blank'><i class='fa fa-file'></i></a>"
+        if !file_id.blank? && !file_id.include?("https://docs.google.com/spreadsheets/d/")
+          file_id = "<a href='https://docs.google.com/spreadsheets/d/#{folder_id}' target='_blank'><i class='fa fa-lg fa-file'></i></a>"
           Translation.find_or_update_translation("en", lp_key, file_id)
         end
       end


### PR DESCRIPTION
Headers for EG STEM curriculum spreadsheet: 

- Course | Grade | Semester | Unit Name | Start Week | End Week | LO Code: | Learning Outcome | Essential Questions | Concepts | Skills | Learning Outcome::class_text | Learning Outcome::evid_learning | Primary Grand Challenge | Learning Outcome::connections | Pre-Requisites | Applications | Relations | Learning Outcome::sec_topic | Updated by | Last Update | Learning Outcome::explain | Grade::depth_0_materials | Semester::lp_folder | Big Idea | Semester::theme | Unit::depth_2_materials | Learning Outcome::review_comments | Learning Outcome::lp_ss_id | Learning Outcome::sec_code | Learning Outcome::cog_demand | US Standard | Egyptian Standard


- Adds Tree Resource translations. These can be attached to the LO, Unit, Semester, Grade, etc. by using the format:` Hierarchy Depth Name::resource_type`
  - e.g., Semester::theme
- Allow editing of Parent (e.g., Grade, Semester, Unit...) trees and their resources.
-  If a Tree, Outcome, or Dimension resource must be processed in a certain way during upload, make that behavior true for the resource type. If the translation does not need to be parsed/processed, it’s a different type of resource. Use BaseRec#process_resource_content(type_code, type_name, content) to apply the correct behavior.