### PR TITLE
STESSA 2 Curriculum Rake File and Sequencing Cleanup

### DIFF
--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -171,6 +171,7 @@ body {
   .generic-grid {
     display: grid;
     width: 100%;
+    overflow-wrap: anywhere;
     align-content: space-between;
     &.generic-grid--xl-xs { grid-template-columns: 89% 4%; }
     &.generic-grid--cols-1 { grid-template-columns: 100% }

--- a/app/models/base_rec.rb
+++ b/app/models/base_rec.rb
@@ -79,7 +79,7 @@ class BaseRec < ActiveRecord::Base
     if convert_id_to_google_folder_url.include?(resource_type)
       ret = "<a href='https://drive.google.com/drive/folders/#{content_text}' target='_blank'>#{resource_name}</a>"
     elsif convert_id_to_google_ss_url.include?(resource_type)
-      ret = "<a href='https://docs.google.com/spreadsheets/d/#{content_text}' target='_blank'>#{resource_name}</a>"
+      ret = "<a href='https://docs.google.com/spreadsheets/d/#{content_text}' target='_blank'>#{resource_name.singularize}</a>"
     end
     return ret
   end

--- a/app/views/trees/_competencies_column.html.erb
+++ b/app/views/trees/_competencies_column.html.erb
@@ -51,7 +51,7 @@
       <!-- TO DO: Find a different workaround for hiding indicator-level items -->
       <% elsif h[:depth] > @treeTypeRec.outcome_depth+1 %>
       <% else %>
-        <li id="<%= h[:subj_code] %>_tree_<%= h[:id] %>" class="sequence-item maint-sub-header indent-<%= h[:depth]-1 %> <%= h[:selectors_by_parent] %> level-<%= h[:depth] - 1 %>" data-treeid="<%= h[:id] %>">
+        <li id="<%= h[:subj_code] %>_tree_<%= h[:id] %>" class="sequence-item maint-sub-header list-group-item indent-<%= h[:depth]-1 %> <%= h[:selectors_by_parent] %> level-<%= h[:depth] - 1 %>" data-treeid="<%= h[:id] %>">
           <a class="" onclick="toggle_visibility('.child-of-<%= code.split(".").join("-") %>', '#trigger-<%= code.split(".").join("-") %>')">
             <i id="trigger-<%= code.split(".").join("-") %>" class="fa fa-compress pull-left option-selected link-blue accordion" title="collapse"></i>
           </a>

--- a/lib/tasks/seed_stessa_1.rake
+++ b/lib/tasks/seed_stessa_1.rake
@@ -1,8 +1,13 @@
 # seed_eg_stessa_1rake
 namespace :seed_eg_stem do
 
-  task populate: [:create_tree_type, :load_locales, :create_admin_user, :create_grade_bands, :create_subjects, :create_uploads, :create_sectors]
+  task populate: [:setup, :create_tree_type, :load_locales, :create_admin_user, :create_grade_bands, :create_subjects, :create_uploads, :create_sectors, :dimension_translations, :outcome_translations, :tree_resource_translations, :ensure_default_translations]
 
+  task setup: :environment do
+    @versionNum = 'v01'
+    @curriculumCode = 'egstem'
+    @sectorCode = 'gr_chall'
+  end
 
   ###################################################################################
   # set up Curriculum Tree Type and Version
@@ -13,6 +18,7 @@ namespace :seed_eg_stem do
     # reference version record from seeds.rb
     @v01 = Version.where(code: 'v01').first
     throw "Missing version record" if !@v01
+    @ver = @v01
 
     # create Tree Type record for the Curriculum
     myTreeTypes = TreeType.where(code: 'egstemuniv')
@@ -21,46 +27,93 @@ namespace :seed_eg_stem do
       hierarchy_codes: 'grade,sem,unit,lo,indicator',
       valid_locales: BaseRec::LOCALE_EN+','+BaseRec::LOCALE_AR_EG,
       sector_set_code: 'gr_chall',
-      sector_set_name_key: 'sector.set.gr.chal.name',
+      sector_set_name_key: 'sector.set.gr_chal.name',
       curriculum_title_key: 'curriculum.egstemuniv.title', #'Egypt STEM Teacher Prep Curriculum'
       outcome_depth: 3,
       version_id: @v01.id,
       working_status: true,
       dim_codes: 'bigidea,miscon',
-      tree_code_format: 'grade,unit,lo',
-      detail_headers: 'grade,sem,unit,lo,indicator,[bigidea],{explain},[miscon],[sector],[connect],[resource]',
-      grid_headers: 'grade,unit,(sub_unit),comp,[bigidea],{explain},[miscon]'
+      tree_code_format: 'subject,grade,sem,unit,lo',
+      # To Do: Write documentation on obtaining translation keys
+      # - for dimension translation use dim.get_dim_resource_key
+      # NOTE: Please avoid underscores (_) and commas (,)
+      #       in item names.
+      #
+      # Detail headers notation key:
+      #   item - HEADER
+      #   [item] - TABLE item, dimension.
+      #   {resource#n} - TABLE item, outcome resource translation
+      #   <item> - TABLE item, sectors
+      #   +item+ - TABLE item, treetrees
+      #   {item#n#...} - TABLE item collection, multiple outcome resource translations
+      #                     - unit#n =lookup in Tree::RESOURCE_TYPES, else lookup in Outcome::RESOURCE_TYPES
+      #   {resources#n#...} - TABLE item, full width of table,
+      #                  with numeric codes identifying which
+      #                  categories of this item to display.
+      #                  e.g., may use indexes in the
+      #                  Outcome::RESOURCE_TYPES array.
+      #   tableItem_tableItem_... - up to 4 columns table items allowed in one row.
+      detail_headers: 'grade,sem,unit,lo,[bigidea],{resource#6},[miscon],<sector>,+treetree+,{resources#0#1#2#3#4#5}',
+      grid_headers: 'grade,unit,lo,[bigidea],[miscon]',
+      #Display codes are zero-relative indexes in Dimension::RESOURCE_TYPES
+      #Dimensions must appear in this string to have a show page
+      #E.g., dim_display: 'miscon#0#1#2#3,bigidea#4#5#8,concept#1',
+      dim_display: 'miscon#0#1#2#3#4#5#6#7',
     }
     if myTreeTypes.count < 1
       TreeType.create(myTreeTypeValues)
     else
-      TreeType.update(myTreeType.first.id, myTreeTypeValues)
+      TreeType.update(myTreeTypes.first.id, myTreeTypeValues)
     end
     throw "Invalid Tree Type Count" if TreeType.where(code: 'egstemuniv').count != 1
-    @egstem = TreeType.where(code: 'egstemuniv').first
+    @tt = TreeType.where(code: 'egstemuniv').first
 
-    # Create translation(s) for hierarchy codes
-    rec, status, message = Translation.find_or_update_translation(BaseRec::LOCALE_EN, 'curriculum.egstemuniv.hierarchy.grade', 'Grade')
+    puts "Create Default app title translations in English and Arabic"
+    rec, status, message =  Translation.find_or_update_translation(BaseRec::LOCALE_EN, 'app.title', 'Egypt STEM Curriculum')
+    throw "ERROR updating default app title translation: #{message}" if status == BaseRec::REC_ERROR
+    rec, status, message =  Translation.find_or_update_translation(BaseRec::LOCALE_AR_EG, 'app.title', 'منهج مصر للعلوم والتكنولوجيا والهندسة والرياضيات')
+    throw "ERROR updating default app title translation: #{message}" if status == BaseRec::REC_ERROR
+
+    # Create ENGLISH translation(s) for hierarchy codes
+    rec, status, message = Translation.find_or_update_translation(BaseRec::LOCALE_EN, @tt.hierarchy_name_key('grade'), 'Grade')
     throw "ERROR updating sector translation: #{message}" if status == BaseRec::REC_ERROR
-    rec, status, message = Translation.find_or_update_translation(BaseRec::LOCALE_EN, 'curriculum.egstemuniv.hierarchy.sem', 'Semester')
+    rec, status, message = Translation.find_or_update_translation(BaseRec::LOCALE_EN, @tt.hierarchy_name_key('sem'), 'Semester')
     throw "ERROR updating sector translation: #{message}" if status == BaseRec::REC_ERROR
-    rec, status, message = Translation.find_or_update_translation(BaseRec::LOCALE_EN, 'curriculum.egstemuniv.hierarchy.unit', 'Unit')
+    rec, status, message = Translation.find_or_update_translation(BaseRec::LOCALE_EN, @tt.hierarchy_name_key('unit'), 'Unit')
     throw "ERROR updating sector translation: #{message}" if status == BaseRec::REC_ERROR
-    rec, status, message = Translation.find_or_update_translation(BaseRec::LOCALE_EN, 'curriculum.egstemuniv.hierarchy.lo', 'Learning Outcome')
-    throw "ERROR updating sector translation: #{message}" if status == BaseRec::REC_ERROR
-    rec, status, message = Translation.find_or_update_translation(BaseRec::LOCALE_EN, 'curriculum.egstemuniv.hierarchy.indicator', 'Indicator')
+    rec, status, message = Translation.find_or_update_translation(BaseRec::LOCALE_EN, @tt.hierarchy_name_key('lo'), 'Learning Outcome')
     throw "ERROR updating sector translation: #{message}" if status == BaseRec::REC_ERROR
 
-    #To Do - Enter translations for sector_set_name_key
-    rec, status, message = Translation.find_or_update_translation(BaseRec::LOCALE_EN, 'sector.set.gr.chal.name', 'Grand Challenges')
-    throw "ERROR updating curriculum.egstemuniv.title translation: #{message}" if status == BaseRec::REC_ERROR
+    # Enter ENGLISH translations for sector_set_name_key
+    rec, status, message = Translation.find_or_update_translation(BaseRec::LOCALE_EN, @tt.sector_set_name_key, 'Grand Challenges')
+    throw "ERROR updating #{@tt.sector_set_name_key}: #{message}" if status == BaseRec::REC_ERROR
 
-    #To Do - Enter translations for curriculum_title_key
-    rec, status, message = Translation.find_or_update_translation(BaseRec::LOCALE_EN, 'curriculum.egstemuniv.title', 'Egypt STEM Teacher Prep Curriculum')
-    throw "ERROR updating curriculum.egstemuniv.title translation: #{message}" if status == BaseRec::REC_ERROR
+    # Enter ENGLISH translations for curriculum_title_key
+    rec, status, message = Translation.find_or_update_translation(BaseRec::LOCALE_EN, @tt.title_key, 'Egypt STEM Teacher Prep Curriculum')
+    throw "ERROR updating curriculum.egstem.title translation: #{message}" if status == BaseRec::REC_ERROR
+
+    # Create ARABIC translation(s) for hierarchy codes
+    rec, status, message = Translation.find_or_update_translation(BaseRec::LOCALE_AR_EG, @tt.hierarchy_name_key('grade'), 'درجة')
+    throw "ERROR updating sector translation: #{message}" if status == BaseRec::REC_ERROR
+    rec, status, message = Translation.find_or_update_translation(BaseRec::LOCALE_AR_EG, @tt.hierarchy_name_key('sem'), 'نصف السنة')
+    throw "ERROR updating sector translation: #{message}" if status == BaseRec::REC_ERROR
+    rec, status, message = Translation.find_or_update_translation(BaseRec::LOCALE_AR_EG, @tt.hierarchy_name_key('unit'), 'وحدة')
+    throw "ERROR updating sector translation: #{message}" if status == BaseRec::REC_ERROR
+    rec, status, message = Translation.find_or_update_translation(BaseRec::LOCALE_AR_EG, @tt.hierarchy_name_key('lo'), 'نتائج التعلم')
+    throw "ERROR updating sector translation: #{message}" if status == BaseRec::REC_ERROR
+
+
+    # Enter ARABIC translations for sector_set_name_key
+    rec, status, message = Translation.find_or_update_translation(BaseRec::LOCALE_AR_EG, @tt.sector_set_name_key, 'التحديات الكبرى')
+    throw "ERROR updating #{@tt.sector_set_name_key}: #{message}" if status == BaseRec::REC_ERROR
+
+    # Enter ARABIC translations for curriculum_title_key
+    rec, status, message = Translation.find_or_update_translation(BaseRec::LOCALE_AR_EG, @tt.title_key, 'مصر STEM معلم إعداد المنهج')
+    throw "ERROR updating curriculum.egstem.title translation: #{message}" if status == BaseRec::REC_ERROR
+
 
     puts "Curriculum (Tree Type) is created for egstemuniv "
-    puts "  Created Curriculum: #{@egstem.code} with Hierarchy: #{@egstem.hierarchy_codes}"
+    puts "  Created Curriculum: #{@tt.code} with Hierarchy: #{@tt.hierarchy_codes}"
   end #create_tree_type
 
 
@@ -70,8 +123,8 @@ namespace :seed_eg_stem do
     @loc_en = Locale.where(code: 'en').first
     @loc_ar_EG = Locale.where(code: 'ar_EG').first
     puts "Locales: #{@loc_en.code}: #{@loc_en.name}, #{@loc_ar_EG.code}: #{@loc_ar_EG.name}"
+    @loc_other = @loc_ar_EG
   end #load_locales
-
 
   ###################################################################################
   desc "create the admin user(s)"
@@ -101,7 +154,7 @@ namespace :seed_eg_stem do
         work_address: "work_address",
         terms_accepted: true,
         confirmed_at: DateTime.now,
-        last_tree_type_id: @egstem
+        last_tree_type_id: @tt
       )
     end
     @user = User.where(email: 'admin@sample.com').first
@@ -116,9 +169,9 @@ namespace :seed_eg_stem do
     %w(fresh soph junior senior).each do |g|
       begin
         gf = (g == 'k') ? 0 : sort_counter
-        if GradeBand.where(tree_type_id: @egstem.id, code: g).count < 1
+        if GradeBand.where(tree_type_id: @tt.id, code: g).count < 1
           GradeBand.create(
-            tree_type_id: @egstem.id,
+            tree_type_id: @tt.id,
             code: g,
             sort_order: gf
           )
@@ -129,21 +182,21 @@ namespace :seed_eg_stem do
       end
     end
 
-    @gb_fresh = GradeBand.where(tree_type_id: @egstem.id, code: 'fresh').first
-    @gb_soph = GradeBand.where(tree_type_id: @egstem.id, code: 'soph').first
-    @gb_junior = GradeBand.where(tree_type_id: @egstem.id, code: 'junior').first
-    @gb_senior = GradeBand.where(tree_type_id: @egstem.id, code: 'senior').first
+    @gb_fresh = GradeBand.where(tree_type_id: @tt.id, code: 'fresh').first
+    @gb_soph = GradeBand.where(tree_type_id: @tt.id, code: 'soph').first
+    @gb_junior = GradeBand.where(tree_type_id: @tt.id, code: 'junior').first
+    @gb_senior = GradeBand.where(tree_type_id: @tt.id, code: 'senior').first
     @gb_univ = [@gb_fresh, @gb_soph, @gb_junior, @gb_senior]
     puts "grade bands are created for EGSTEM"
 
     # put in translations for Grade Names
-    rec, status, message = Translation.find_or_update_translation(BaseRec::LOCALE_EN, 'grades.egstemuniv.fresh.name', 'Freshman')
+    rec, status, message = Translation.find_or_update_translation(BaseRec::LOCALE_EN, GradeBand.build_name_key(@tt.code, 'fresh'), 'Freshman')
     throw "ERROR updating sector translation: #{message}" if status == BaseRec::REC_ERROR
-    rec, status, message = Translation.find_or_update_translation(BaseRec::LOCALE_EN, 'grades.egstemuniv.soph.name', 'Sophmore')
+    rec, status, message = Translation.find_or_update_translation(BaseRec::LOCALE_EN, GradeBand.build_name_key(@tt.code, 'soph'), 'Sophmore')
     throw "ERROR updating sector translation: #{message}" if status == BaseRec::REC_ERROR
-    rec, status, message = Translation.find_or_update_translation(BaseRec::LOCALE_EN, 'grades.egstemuniv.junior.name', 'Junior')
+    rec, status, message = Translation.find_or_update_translation(BaseRec::LOCALE_EN, GradeBand.build_name_key(@tt.code, 'junior'), 'Junior')
     throw "ERROR updating sector translation: #{message}" if status == BaseRec::REC_ERROR
-    rec, status, message = Translation.find_or_update_translation(BaseRec::LOCALE_EN, 'grades.egstemuniv.senior.name', 'Senior')
+    rec, status, message = Translation.find_or_update_translation(BaseRec::LOCALE_EN, GradeBand.build_name_key(@tt.code, 'senior'), 'Senior')
     throw "ERROR updating sector translation: #{message}" if status == BaseRec::REC_ERROR
 
   end #create_grade_bands
@@ -152,233 +205,257 @@ namespace :seed_eg_stem do
   ###################################################################################
   desc "create the subjects for this tree type (curriculum)"
   task create_subjects: :environment do
-    @subjects = []
-    if Subject.where(tree_type_id: @egstem.id, code: 'bio').count < 1
-      @subjects << Subject.create(
-        tree_type_id: @egstem.id,
-        code: 'bio',
-        base_key: 'subject.egstemuniv.v01.bio'
-      )
+     default_subject_translations = [
+    ]
+    @subjectsHash = {
+
+      # note if a subject is in the Library, it must be in this hash
+      bio: {abbr: 'bio', inCurric: true, engName: 'Biology', locAbbr: 'مادة الاحياء', locName: 'مادة الاحياء'},
+      cap: {abbr: 'cap', inCurric: true, engName: 'Capstones', locAbbr: 'كابستون', locName: 'كابستون'},
+      che: {abbr: 'chem', inCurric: true, engName: 'Chemistry', locAbbr: 'كيمياء', locName: 'كيمياء'},
+      edu: {abbr: 'edu', inCurric: true, engName: 'Education', locAbbr: 'التعليم', locName: 'التعليم'},
+      engl: {abbr: 'engl', inCurric: true, engName: 'English', locAbbr: 'الإنجليزية', locName: 'الإنجليزية'},
+      eng: {abbr: 'eng', inCurric: false, engName: 'Engineering', locAbbr: 'هندسة', locName: 'هندسة'},
+      mat: {abbr: 'math', inCurric: true, engName: 'Mathematics', locAbbr: 'الرياضيات', locName: 'الرياضيات'},
+      mec: {abbr: 'mec', inCurric: true, engName: 'Mechanics', locAbbr: 'علم الميكانيكا', locName: 'علم الميكانيكا'},
+      phy: {abbr: 'phy', inCurric: true, engName: 'Physics', locAbbr: 'الفيزياء', locName: 'الفيزياء'},
+      sci: {abbr: 'sci', inCurric: false, engName: 'Science', locAbbr: 'علم', locName: 'علم'},
+      ear: {abbr: 'Ear', inCurric: false, engName: 'Earth Science', locAbbr: 'علوم الأرض', locName: 'علوم الأرض'},
+      geo: {abbr: 'geo', inCurric: true, engName: 'Geology', locAbbr: 'جيولوجيا', locName: 'جيولوجيا'},
+      tech: {abbr: 'tech', inCurric: false, engName: 'Tech Engineering', locAbbr: 'هندسة التكنولوجيا', locName: 'هندسة التكنولوجيا'}
+    }
+
+    @subjectsHash.each do |key, subjHash|
+
+      # create the subject for this tree type
+      # note: using default start and end grade
+      # - need to be set: set_min_max_grades:run rake task after uploads are done
+      puts "find subject tree_type_id: #{@tt.id}, code: #{subjHash[:abbr]}"
+      subjs = Subject.where(tree_type_id: @tt.id, code: key)
+      if subjs.count < 1
+        puts "Creating Subject for #{key}"
+        subj = Subject.create(
+          tree_type_id: @tt.id,
+          code: key,
+          base_key: "subject.#{@tt.code}.#{@ver.code}.#{key}"
+        )
+      else
+        subj = subjs.first
+      end
+
+      # create english translation for subject name
+      rec, status, message = Translation.find_or_update_translation(BaseRec::LOCALE_EN, "subject.#{@tt.code}.#{@ver.code}.#{subjHash[:abbr]}.name", subjHash[:engName])
+      throw "ERROR updating sector translation: #{message}" if status == BaseRec::REC_ERROR
+
+      # create english translation for subject abbreviation
+      rec, status, message = Translation.find_or_update_translation(BaseRec::LOCALE_EN, "subject.#{@tt.code}.#{@ver.code}.#{subjHash[:abbr]}.abbr", subjHash[:abbr])
+      throw "ERROR updating sector translation: #{message}" if status == BaseRec::REC_ERROR
+
+      if subjHash[:inCurric]
+
+        if subjHash[:locName].present?
+          # create locale's translation for subject name
+          rec, status, message = Translation.find_or_update_translation(BaseRec::LOCALE_AR_EG, "subject.#{@tt.code}.#{@ver.code}.#{subjHash[:abbr]}.name", subjHash[:locName])
+          throw "ERROR updating sector translation: #{message}" if status == BaseRec::REC_ERROR
+        end
+
+        if subjHash[:locAbbr].present?
+          # create locale's translation for subject abbreviation
+          rec, status, message = Translation.find_or_update_translation(BaseRec::LOCALE_AR_EG, "subject.#{@tt.code}.#{@ver.code}.#{subjHash[:abbr]}.abbr", subjHash[:locAbbr])
+          throw "ERROR updating sector translation: #{message}" if status == BaseRec::REC_ERROR
+        end
+
+        puts "create upload for subject: #{subj.id} #{subj.code}"
+        if Upload.where(tree_type_code: @curriculumCode,
+          subject_id: subj.id,
+          grade_band_id: nil,
+          locale_id: @loc_en.id
+        ).count < 1
+          Upload.create!(
+            tree_type_code: @curriculumCode,
+            subject_id: subj.id,
+            grade_band_id: nil,
+            locale_id: @loc_en.id,
+            status: 0,
+            filename: "#{@tt.code}#{@ver.code}#{subj.code.capitalize}All#{@loc_en.code}.csv"
+          )
+        end
+
+        if Upload.where(tree_type_code: @curriculumCode,
+            subject_id: subj.id,
+            grade_band_id: nil,
+            locale_id: @loc_other.id
+          ).count < 1
+          Upload.create!(
+            tree_type_code: @curriculumCode,
+            subject_id: subj.id,
+            grade_band_id: nil,
+            locale_id: @loc_other.id,
+            status: 0,
+            filename: "#{@tt.code}#{@ver.code}#{subj.code.capitalize}All#{@loc_other.code}.csv"
+          )
+        end
+
+      end
+
     end
-    if Subject.where(tree_type_id: @egstem.id, code: 'cap').count < 1
-      @subjects << Subject.create(
-        tree_type_id: @egstem.id,
-        code: 'cap',
-        base_key: 'subject.egstemuniv.v01.cap'
-      )
-    end
-    if Subject.where(tree_type_id: @egstem.id, code: 'che').count < 1
-      @subjects << Subject.create(
-        tree_type_id: @egstem.id,
-        code: 'che',
-        base_key: 'subject.egstemuniv.v01.che'
-      )
-    end
-    if Subject.where(tree_type_id: @egstem.id, code: 'engl').count < 1
-      @subjects << Subject.create(
-        tree_type_id: @egstem.id,
-        code: 'engl',
-        base_key: 'subject.egstemuniv.v01.engl'
-      )
-    end
-    if Subject.where(tree_type_id: @egstem.id, code: 'edu').count < 1
-      @subjects << Subject.create(
-        tree_type_id: @egstem.id,
-        code: 'edu',
-        base_key: 'subject.egstemuniv.v01.edu'
-      )
-    end
-    if Subject.where(tree_type_id: @egstem.id, code: 'geo').count < 1
-      @subjects << Subject.create(
-        tree_type_id: @egstem.id,
-        code: 'geo',
-        base_key: 'subject.egstemuniv.v01.geo'
-      )
-    end
-    if Subject.where(tree_type_id: @egstem.id, code: 'mat').count < 1
-      @subjects << Subject.create(
-        tree_type_id: @egstem.id,
-        code: 'mat',
-        base_key: 'subject.egstemuniv.v01.mat'
-      )
-    end
-    if Subject.where(tree_type_id: @egstem.id, code: 'mec').count < 1
-      @subjects << Subject.create(
-        tree_type_id: @egstem.id,
-        code: 'mec',
-        base_key: 'subject.egstemuniv.v01.mec'
-      )
-    end
-    if Subject.where(tree_type_id: @egstem.id, code: 'phy').count < 1
-      @subjects << Subject.create(
-        tree_type_id: @egstem.id,
-        code: 'phy',
-        base_key: 'subject.egstemuniv.v01.phy'
-      )
-    end
-    puts "Subjects are created for EGSTEM"
-
-    #bio
-    rec, status, message = Translation.find_or_update_translation(BaseRec::LOCALE_EN, 'subject.egstemuniv.v01.bio.name', 'Biology')
-    throw "ERROR updating sector translation: #{message}" if status == BaseRec::REC_ERROR
-    rec, status, message = Translation.find_or_update_translation(BaseRec::LOCALE_EN, 'subject.egstemuniv.v01.bio.abbr', 'Bio')
-    throw "ERROR updating sector translation: #{message}" if status == BaseRec::REC_ERROR
-
-    #cap
-    rec, status, message = Translation.find_or_update_translation(BaseRec::LOCALE_EN, 'subject.egstemuniv.v01.cap.name', 'Capstones')
-    throw "ERROR updating sector translation: #{message}" if status == BaseRec::REC_ERROR
-    rec, status, message = Translation.find_or_update_translation(BaseRec::LOCALE_EN, 'subject.egstemuniv.v01.cap.abbr', 'Cap')
-    throw "ERROR updating sector translation: #{message}" if status == BaseRec::REC_ERROR
-
-    #che
-    rec, status, message = Translation.find_or_update_translation(BaseRec::LOCALE_EN, 'subject.egstemuniv.v01.che.name', 'Chemistry')
-    throw "ERROR updating sector translation: #{message}" if status == BaseRec::REC_ERROR
-    rec, status, message = Translation.find_or_update_translation(BaseRec::LOCALE_EN, 'subject.egstemuniv.v01.che.abbr', 'Chem')
-    throw "ERROR updating sector translation: #{message}" if status == BaseRec::REC_ERROR
-
-    #engl
-    rec, status, message = Translation.find_or_update_translation(BaseRec::LOCALE_EN, 'subject.egstemuniv.v01.engl.name', 'English')
-    throw "ERROR updating sector translation: #{message}" if status == BaseRec::REC_ERROR
-    rec, status, message = Translation.find_or_update_translation(BaseRec::LOCALE_EN, 'subject.egstemuniv.v01.engl.abbr', 'Engl')
-    throw "ERROR updating sector translation: #{message}" if status == BaseRec::REC_ERROR
-
-    #edu
-    rec, status, message = Translation.find_or_update_translation(BaseRec::LOCALE_EN, 'subject.egstemuniv.v01.edu.name', 'Education')
-    throw "ERROR updating sector translation: #{message}" if status == BaseRec::REC_ERROR
-    rec, status, message = Translation.find_or_update_translation(BaseRec::LOCALE_EN, 'subject.egstemuniv.v01.edu.abbr', 'Edu')
-    throw "ERROR updating sector translation: #{message}" if status == BaseRec::REC_ERROR
-
-    #geo
-    rec, status, message = Translation.find_or_update_translation(BaseRec::LOCALE_EN, 'subject.egstemuniv.v01.geo.name', 'Geology')
-    throw "ERROR updating sector translation: #{message}" if status == BaseRec::REC_ERROR
-    rec, status, message = Translation.find_or_update_translation(BaseRec::LOCALE_EN, 'subject.egstemuniv.v01.geo.abbr', 'Geo')
-    throw "ERROR updating sector translation: #{message}" if status == BaseRec::REC_ERROR
-
-    #mat
-    rec, status, message = Translation.find_or_update_translation(BaseRec::LOCALE_EN, 'subject.egstemuniv.v01.mat.name', 'Mathematics')
-    throw "ERROR updating sector translation: #{message}" if status == BaseRec::REC_ERROR
-    rec, status, message = Translation.find_or_update_translation(BaseRec::LOCALE_EN, 'subject.egstemuniv.v01.mat.abbr', 'Math')
-    throw "ERROR updating sector translation: #{message}" if status == BaseRec::REC_ERROR
-
-    #mec
-    rec, status, message = Translation.find_or_update_translation(BaseRec::LOCALE_EN, 'subject.egstemuniv.v01.mec.name', 'Mechanics')
-    throw "ERROR updating sector translation: #{message}" if status == BaseRec::REC_ERROR
-    rec, status, message = Translation.find_or_update_translation(BaseRec::LOCALE_EN, 'subject.egstemuniv.v01.mec.abbr', 'Mec')
-    throw "ERROR updating sector translation: #{message}" if status == BaseRec::REC_ERROR
-
-    #phy
-    rec, status, message = Translation.find_or_update_translation(BaseRec::LOCALE_EN, 'subject.egstemuniv.v01.phy.name', 'Physics')
-    throw "ERROR updating sector translation: #{message}" if status == BaseRec::REC_ERROR
-    rec, status, message = Translation.find_or_update_translation(BaseRec::LOCALE_EN, 'subject.egstemuniv.v01.phy.abbr', 'Phy')
-    throw "ERROR updating sector translation: #{message}" if status == BaseRec::REC_ERROR
-
-    puts "subject translations are created for EGSTEM"
-  end #create_subjects
-
-
+  end
   ###################################################################################
   desc "create the upload control files"
   task create_uploads: :environment do
-    # code here
-    # puts "Try to create uploads."
-    @gb_univ.each do |g|
-      @subjects.each do |s|
-        if Upload.where(
-          tree_type_code: @egstem.code,
-          subject_id: s.id,
-          grade_band_id: g.id,
-          locale_id: @loc_en.id
-        ).count < 1
-          # puts "Try to create uploads for grade #{g} subject #{s}"
-          Upload.create(
-            tree_type_code: @egstem.code,
-            subject_id: s.id,
-            grade_band_id: g.id,
-            locale_id: @loc_en.id,
-            status: 0,
-            filename: "#{@egstem.code}#{s.code.capitalize}#{g.code.capitalize}Eng.txt"
-          )
-        end
-      end
-    end
+
   end #create_uploads
 
 
   ###################################################################################
   desc "create the sectors (e.g. Grand Challenges, Future Sectors, ...)"
   task create_sectors: :environment do
-    if Sector.where(sector_set_code: 'gr_chall', code: '1').count < 1
-      Sector.create(sector_set_code: 'gr_chall', code: '1', name_key: 'sector.egstemuniv.1.name', base_key: 'sector.egstemuniv.1')
-    end
-    if Sector.where(sector_set_code: 'gr_chall', code: '2').count < 1
-      Sector.create(sector_set_code: 'gr_chall', code: '2', name_key: 'sector.egstemuniv.2.name', base_key: 'sector.egstemuniv.2')
-    end
-    if Sector.where(sector_set_code: 'gr_chall', code: '3').count < 1
-      Sector.create(sector_set_code: 'gr_chall', code: '3', name_key: 'sector.egstemuniv.3.name', base_key: 'sector.egstemuniv.3')
-    end
-    if Sector.where(sector_set_code: 'gr_chall', code: '4').count < 1
-      Sector.create(sector_set_code: 'gr_chall', code: '4', name_key: 'sector.egstemuniv.4.name', base_key: 'sector.egstemuniv.4')
-    end
-    if Sector.where(sector_set_code: 'gr_chall', code: '5').count < 1
-      Sector.create(sector_set_code: 'gr_chall', code: '5', name_key: 'sector.egstemuniv.5.name', base_key: 'sector.egstemuniv.5')
-    end
-    if Sector.where(sector_set_code: 'gr_chall', code: '6').count < 1
-      Sector.create(sector_set_code: 'gr_chall', code: '6', name_key: 'sector.egstemuniv.6.name', base_key: 'sector.egstemuniv.6')
-    end
-    if Sector.where(sector_set_code: 'gr_chall', code: '7').count < 1
-      Sector.create(sector_set_code: 'gr_chall', code: '7', name_key: 'sector.egstemuniv.7.name', base_key: 'sector.egstemuniv.7')
-    end
-    if Sector.where(sector_set_code: 'gr_chall', code: '8').count < 1
-      Sector.create(sector_set_code: 'gr_chall', code: '8', name_key: 'sector.egstemuniv.8.name', base_key: 'sector.egstemuniv.8')
-    end
-    if Sector.where(sector_set_code: 'gr_chall', code: '9').count < 1
-      Sector.create(sector_set_code: 'gr_chall', code: '9', name_key: 'sector.egstemuniv.9.name', base_key: 'sector.egstemuniv.9')
-    end
-    if Sector.where(sector_set_code: 'gr_chall', code: '10').count < 1
-      Sector.create(sector_set_code: 'gr_chall', code: '10', name_key: 'sector.egstemuniv.10.name', base_key: 'sector.egstemuniv.10')
-    end
-    if Sector.where(sector_set_code: 'gr_chall', code: '11').count < 1
-      Sector.create(sector_set_code: 'gr_chall', code: '11', name_key: 'sector.egstemuniv.11.name', base_key: 'sector.egstemuniv.11')
-    end
-    puts "Sectors are created for EGSTEM"
+     @sectorsHash = {
+      '1': {code: '1', engName: 'Deal with population growth and its consequences.',locName: 'التعامل مع النمو السكاني وعواقبه.'},
+      '2': {code: '2', engName: 'Improve the use of alternative energies.', locName: 'تحسين استخدام الطاقات البديلة.'},
+      '3': {code: '3', engName: 'Deal with urban congestion and its consequences.', locName: 'التعامل مع الازدحام الحضري وعواقبه.'},
+      '4': {code: '4', engName: 'Improve the scientific and technological environment for all.', locName: 'تحسين البيئة العلمية والتكنولوجية للجميع.'},
+      '5': {code: '5', engName: 'Work to eradicate public health issues/disease.', locName: 'العمل على القضاء على قضايا / أمراض الصحة العامة.'},
+      '6': {code: '6', engName: 'Improve uses of arid areas.', locName: 'تحسين استخدامات المناطق الجافة.'},
+      '7': {code: '7', engName: 'Manage and increase the sources of clean water.', locName: 'إدارة وزيادة مصادر المياه النظيفة.'},
+      '8': {code: '8', engName: 'Increase the industrial and agricultural bases of Egypt.', locName: 'زيادة القواعد الصناعية والزراعية لمصر.'},
+      '9': {code: '9', engName: 'Address and reduce pollution fouling our air, water and soil.', locName: 'معالجة وتقليل التلوث الناتج عن الهواء والماء والتربة.'},
+      '10': {code: '10', engName: 'Recycle garbage and waste for economic and environmental purposes.', locName: 'إعادة تدوير القمامة والنفايات للأغراض الاقتصادية والبيئية.'},
+      '11': {code: '11', engName: 'Reduce and adapt to the effect of climate change.', locName: 'الحد من تأثير تغير المناخ والتكيف معه.'}
+    }
+    @sectorsHash.each do |key, sectHash|
 
-    @sector1 = Sector.where(sector_set_code: 'gr_chall', code: '1').first
-    @sector2 = Sector.where(sector_set_code: 'gr_chall', code: '2').first
-    @sector3 = Sector.where(sector_set_code: 'gr_chall', code: '3').first
-    @sector4 = Sector.where(sector_set_code: 'gr_chall', code: '4').first
-    @sector5 = Sector.where(sector_set_code: 'gr_chall', code: '5').first
-    @sector6 = Sector.where(sector_set_code: 'gr_chall', code: '6').first
-    @sector7 = Sector.where(sector_set_code: 'gr_chall', code: '7').first
-    @sector8 = Sector.where(sector_set_code: 'gr_chall', code: '8').first
-    @sector9 = Sector.where(sector_set_code: 'gr_chall', code: '9').first
-    @sector10 = Sector.where(sector_set_code: 'gr_chall', code: '10').first
-    @sector11 = Sector.where(sector_set_code: 'gr_chall', code: '11').first
+      # create the sector
+      puts "create the sector: #{@sectorCode}, #{sectHash[:code]}"
+      sectors = Sector.where(sector_set_code: @sectorCode, code: sectHash[:code])
+      if sectors.count < 1
+        sector = Sector.create(
+          sector_set_code: @sectorCode,
+          code: sectHash[:code],
+          name_key: "sector.#{@sectorCode}.#{sectHash[:code]}.name",
+          base_key: "sector.#{@sectorCode}.#{sectHash[:code]}"
+        )
+      else
+        sector = sectors.first
+      end
 
+      # create the English translation for the Sector Name
+      rec, status, message = Translation.find_or_update_translation(BaseRec::LOCALE_EN, "sector.#{@sectorCode}.#{sectHash[:code]}.name", sectHash[:engName])
+      throw "ERROR updating sector translation: #{message}" if status == BaseRec::REC_ERROR
 
-    rec, status, message = Translation.find_or_update_translation(BaseRec::LOCALE_EN, 'sector.egstemuniv.1.name', 'Deal with population growth and its consequences.')
-    throw "ERROR updating sector translation: #{message}" if status == BaseRec::REC_ERROR
-    rec, status, message = Translation.find_or_update_translation(BaseRec::LOCALE_EN, 'sector.egstemuniv.2.name', 'Improve the use of alternative energies.')
-    throw "ERROR updating sector translation: #{message}" if status == BaseRec::REC_ERROR
-    rec, status, message = Translation.find_or_update_translation(BaseRec::LOCALE_EN, 'sector.egstemuniv.3.name', 'Deal with urban congestion and its consequences.')
-    throw "ERROR updating sector translation: #{message}" if status == BaseRec::REC_ERROR
-    rec, status, message = Translation.find_or_update_translation(BaseRec::LOCALE_EN, 'sector.egstemuniv.4.name', 'Improve the scientific and technological environment for all.')
-    throw "ERROR updating sector translation: #{message}" if status == BaseRec::REC_ERROR
-    rec, status, message = Translation.find_or_update_translation(BaseRec::LOCALE_EN, 'sector.egstemuniv.5.name', 'Work to eradicate public health issues/disease.')
-    throw "ERROR updating sector translation: #{message}" if status == BaseRec::REC_ERROR
-    rec, status, message = Translation.find_or_update_translation(BaseRec::LOCALE_EN, 'sector.egstemuniv.6.name', 'Improve uses of arid areas.')
-    throw "ERROR updating sector translation: #{message}" if status == BaseRec::REC_ERROR
-    rec, status, message = Translation.find_or_update_translation(BaseRec::LOCALE_EN, 'sector.egstemuniv.7.name', 'Manage and increase the sources of clean water.')
-    throw "ERROR updating sector translation: #{message}" if status == BaseRec::REC_ERROR
-    rec, status, message = Translation.find_or_update_translation(BaseRec::LOCALE_EN, 'sector.egstemuniv.8.name', 'Increase the industrial and agricultural bases of Egypt.')
-    throw "ERROR updating sector translation: #{message}" if status == BaseRec::REC_ERROR
-    rec, status, message = Translation.find_or_update_translation(BaseRec::LOCALE_EN, 'sector.egstemuniv.9.name', 'Address and reduce pollution fouling our air, water and soil.')
-    throw "ERROR updating sector translation: #{message}" if status == BaseRec::REC_ERROR
-    rec, status, message = Translation.find_or_update_translation(BaseRec::LOCALE_EN, 'sector.egstemuniv.10.name', 'Recycle garbage and waste for economic and environmental purposes.')
-    throw "ERROR updating sector translation: #{message}" if status == BaseRec::REC_ERROR
-    rec, status, message = Translation.find_or_update_translation(BaseRec::LOCALE_EN, 'sector.egstemuniv.11.name', 'Reduce and adapt to the effect of climate change.')
-    throw "ERROR updating sector translation: #{message}" if status == BaseRec::REC_ERROR
+      # create the Locale's translation for the Sector Name
+      rec, status, message = Translation.find_or_update_translation(BaseRec::LOCALE_AR_EG, "sector.#{@sectorCode}.#{sectHash[:code]}.name", sectHash[:locName])
+      throw "ERROR updating sector translation: #{message}" if status == BaseRec::REC_ERROR
 
-    puts "Sector translations are created for EGSTEM"
+    end
+    puts "Sector translations are created for sector set: #{@sectorCode}"
+
   end #create_sectors
 
+   ###################################################################################
+  desc "create translations for dimension types"
+  task dimension_translations: :environment do
+    dim_translations_arr = [
+      ['bigidea', 'Big Idea', 'فكرة هامة'],
+      ['miscon', 'Misconception', 'اعتقاد خاطئ'],
+    ]
+
+    dim_resource_types_arr = [
+      ['Second Subject', 'الموضوع الثاني'],
+      ['Correct Understanding', 'الفهم الصحيح'],
+      ['Possible Source of Misconception', 'مصدر محتمل للفهم الخاطئ'],
+      ['Compiler/Source'],
+      ['Primary Research Citation', 'مترجم / المصدر'],
+      ['Website Link References', 'مراجع رابط الموقع'],
+      ['Test Distractor Percent', 'اختبار نسبة تشتيت الانتباه'],
+      ['Link to Question Item Bank', 'رابط إلى بنك عناصر السؤال'],
+    ]
+    dim_translations_arr.each do |dim|
+      dim_name_key = Dimension.get_dim_type_key(
+        dim[0],
+        @tt.code,
+        @ver.code
+      )
+      rec, status, message = Translation.find_or_update_translation(BaseRec::LOCALE_EN, dim_name_key, dim[1])
+      throw "ERROR updating dimension code translation: #{message}" if status == BaseRec::REC_ERROR
+      rec, status, message = Translation.find_or_update_translation(BaseRec::LOCALE_AR_EG, dim_name_key, dim[2])
+      throw "ERROR updating dimension code translation: #{message}" if status == BaseRec::REC_ERROR
+    end
+    dim_resource_types_arr.each_with_index do |resource, i|
+      resource_name_key = Dimension.get_resource_key(
+        Dimension::RESOURCE_TYPES[i],
+        @tt.code,
+        @ver.code
+      )
+      rec, status, message = Translation.find_or_update_translation(BaseRec::LOCALE_EN, resource_name_key, resource[0])
+      throw "ERROR updating dimension code translation: #{message}" if status == BaseRec::REC_ERROR
+      rec, status, message = Translation.find_or_update_translation(BaseRec::LOCALE_AR_EG, resource_name_key, resource[1])
+      throw "ERROR updating dimension code translation: #{message}" if status == BaseRec::REC_ERROR
+    end
+  end
+
+  ###################################################################################
+  desc "create translations for outcome resources"
+  task outcome_translations: :environment do
+    outc_resource_types_arr = [
+      ["Multi, inter or trans disciplinary Grand Challenges based projects", "المشاريع القائمة على التحديات الكبرى المتعددة أو بين التخصصات"],
+      ["Daily Lesson Plans", "خطط الدروس اليومية"],
+      ["Textbook and Resource Materials to Use in Class", "الكتب والمواد الدراسية لاستخدامها في الفصل"],
+      ["Suggested Assessment Resources and Activities", "موارد وأنشطة التقييم المقترحة"],
+      ["Additional Background and Resource Materials for the Teacher", "معلومات أساسية وموارد إضافية للمعلم"],
+      ["Goal behaviour (What students will do, Practical learning targets)", "سلوك الهدف (ما سيفعله الطلاب ، أهداف التعلم العملية)"],
+      ["Reviewer Comments", "دعم المعلم"],
+      ["Evidence of Learning", "دليل التعلم"],
+      ["Capstone Connection", "روابط"],
+      ["SEC Topic", "موضوع SEC"],
+      ["SEC Code", "كود SEC"],
+      ["SEC Cognitive Demand", "الطلب المعرفي SEC"],
+      ["Daily Lesson Plans", "خطط الدروس اليومية"], #LP as a spreadsheet ID, processed differently than the LP at index 1.
+      ["WL Review Comments", "تعليقات مراجعة WL"]
+    ]
+
+    outc_resource_types_arr.each_with_index do |resource, i|
+      resource_name_key = Outcome.get_resource_key(
+        Outcome::RESOURCE_TYPES[i],
+        @tt.code,
+        @ver.code
+      )
+      rec, status, message = Translation.find_or_update_translation(BaseRec::LOCALE_EN, resource_name_key, resource[0])
+      throw "ERROR updating dimension code translation: #{message}" if status == BaseRec::REC_ERROR
+      rec, status, message = Translation.find_or_update_translation(BaseRec::LOCALE_AR_EG, resource_name_key, resource[1])
+      throw "ERROR updating dimension code translation: #{message}" if status == BaseRec::REC_ERROR
+    end
+  end
+
+  ###################################################################################
+  desc "create translations for outcome resources"
+  task tree_resource_translations: :environment do
+    tree_resource_types_arr = [
+      # ["Course Materials", "مواد الدورة"],
+      # ["Semester Materials", "مواد الفصل"],
+      # ["Unit Materials", "مواد الوحدة"],
+      # ["Semester Lesson Plans Folder", "مجلد خطط الدرس للفصل الدراسي"],
+      # ["Semester Theme", "موضوع الفصل"]
+    ]
+
+    tree_resource_types_arr.each_with_index do |resource, i|
+      # resource_name_key = Tree.get_resource_type_key(
+      #   Tree::RESOURCE_TYPES[i],
+      #   @tt.code,
+      #   @ver.code
+      # )
+      # rec, status, message = Translation.find_or_update_translation(BaseRec::LOCALE_EN, resource_name_key, resource[0])
+      # throw "ERROR updating tree resource translation: #{message}" if status == BaseRec::REC_ERROR
+      # rec, status, message = Translation.find_or_update_translation(BaseRec::LOCALE_AR_EG, resource_name_key, resource[1])
+      # throw "ERROR updating tree resource translation: #{message}" if status == BaseRec::REC_ERROR
+    end
+  end
+
+  ###################################################################################
+  desc "Ensure default subject translations exist"
+  task ensure_default_translations: :environment do
+
+  end #task
+
+  #############
 end

--- a/lib/tasks/seed_stessa_2.rake
+++ b/lib/tasks/seed_stessa_2.rake
@@ -58,7 +58,7 @@ namespace :seed_stessa_2 do
       #                  e.g., may use indexes in the
       #                  Outcome::RESOURCE_TYPES array.
       #   tableItem_tableItem_... - up to 4 columns table items allowed in one row.
-      detail_headers: 'grade,sem,unit,lo,weeks,hours,[bigidea]_[essq],[concept]_[skill],[miscon#2#1],{resource#6},{resource#7},{grade#0}_{unit#2}_{sem#4},<sector>,+treetree+,{resources#12#3#2}',
+      detail_headers: 'grade,sem,unit,lo,weeks,hours,{resource#6},{sem#4}_{sem#3}_{grade#0}_{unit#2},[bigidea]_[essq],[miscon#2#1],[concept]_[skill],{resource#2}_{resource#7},{resource#8},{resource#13},<sector>,[standardus]_[standardeg],+treetree+,{resources#12#3#2#11#10#9}',
       grid_headers: 'grade,unit,lo,[bigidea],[essq],[concept],[skill],[miscon]',
       #Display codes are zero-relative indexes in Dimension::RESOURCE_TYPES
       #Dimensions must appear in this string to have a show page


### PR DESCRIPTION
- update seed_stessa_2 rake file to show all fields in the EGSTEM upload (except for 'last updated' and 'updated by', which still need to be implemented). 
- On the editing page, make it possible to drag an outcome between two parent trees (fixes an issue where an empty unit/subunit/etc could not have Outcomes dragged between them). This is done by adding the 'list-group-item' class to the grade/semester/unit/etc elements, which allows the JQuery draggable function to include them in passive reordering. Because none of these parent elements have a the "handle" icon recognized by the draggable function, they still cannot be dragged around themselves.