### PR TITLE
Remember settings on connections page, rename pages/buttons, add print button, etc...

### DIFF
--- a/app/assets/javascripts/common.js
+++ b/app/assets/javascripts/common.js
@@ -236,6 +236,7 @@ $(function() {
       $('#user_admin_subjects').val(admin_subjects);
       $('#admin_subjects-selected').remove("#admin-subject-" + subject);
     });
+    $(".print-btn").on("click", function() { window.print(); });
   }
   //###################################
   //# ADD EVENT BINDINGS

--- a/app/assets/javascripts/sequence.js
+++ b/app/assets/javascripts/sequence.js
@@ -4,6 +4,23 @@
 
 $(function() {
   /**
+   * Update cookies for the connections page so that
+   * the selected columns/gradebands are remembered
+   * when the page is refreshed.
+  **/
+  set_connections_page_cookie = function () {
+    var arr = [];
+    $(".subj-checkbox").each(function () {
+      var s_input = $(this).find(">input");
+      if (s_input.is(":checked")){arr.push(s_input.attr("id"));}
+      $(this).find(".gradebands-list input").each(function () {
+        if ($(this).is(":checked")){arr.push($(this).attr("id"));}
+      });
+    });
+    document.cookie = "connect_cols_settings=" + encodeURIComponent(JSON.stringify(arr));
+  }
+
+  /**
    * Hide or show a subject column when the corresponding
    * checkbox is checked or unchecked.
    * @param  {String} subj_abbr Abbreviation for a subject.
@@ -31,6 +48,7 @@ $(function() {
     $(".sequence-page .sequence-grid").addClass(
       "cols-" + $(".subj-checkbox>input:checked").length
     );
+    set_connections_page_cookie();
   };
 
   /**
@@ -81,6 +99,7 @@ $(function() {
       }
     }
     if (subj_arr.length > 0) gradeband_visibility(subj_arr, gb_arr, multi);
+    set_connections_page_cookie();
   };
 
   /**

--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -48,6 +48,20 @@ body {
       }
     }
   }
+.colorful-header {
+  text-align: left;
+  min-height: 40px;
+  &.colorful-header-0 { background-color: #d2ccf5; }
+  &.colorful-header-1 { background-color: #ffedc1; }
+  &.colorful-header-2 { background-color: #ffcaca; }
+  &.colorful-header-3 { background-color: #c8e5ff; }
+}
+.sequence-item:not(.colorful-header) + .sequence-item.colorful-header {
+ margin-top:4vh;
+}
+/*********************************************************************
+Start Treeview styles- deprecated. These are for the old Curriculum Tree page.
+************************************************************************/
 
   /**treeview items that are not at LO depth**/
   .node-tree[style*="background-color:#"] {height:50px;border:none !important;margin-top:5px;}
@@ -63,6 +77,9 @@ body {
 
   .treeview .list-group-item {display: inline-flex;}
 
+/*********************************************************************
+End Treeview styles- deprecated. These are for the old Curriculum Tree page.
+************************************************************************/
 
   .spotlight-new {
     animation: fadewhite 5s ease-out;

--- a/app/assets/stylesheets/header.scss
+++ b/app/assets/stylesheets/header.scss
@@ -2,7 +2,7 @@
 #pageHeader {
   #pageHeaderLogo {
      margin-left: 0px;
-     min-width: 100px;
+     min-width: 160px;
      .logoImage {
        /* background-image: url(asset_path('logo.png'));*/
        /* background-repeat: no-repeat; */
@@ -48,11 +48,13 @@ nav#topNav {
 }
 
 
-
+ .navbar-expand-sm, .flexContainer {flex-flow: wrap !important;}
 @media only screen and (max-width: 767px) {
-  #pageHeaderTitle {
-    display: none;
+  #pageHeaderTitle--mobile {
+    margin-right: 25px;
+    h1 {font-size: 1.5rem;}
   }
+  #pageHeaderTitle {display:none;}
   #pageSubHeaderTitle {
     margin: 0 auto;
     max-width: 300px;
@@ -64,6 +66,7 @@ nav#topNav {
 }
 
 @media only screen and (min-width: 768px) {
+  #pageHeaderTitle--mobile {display:none;}
   #pageSubHeaderTitle {
     display: none;
   }

--- a/app/assets/stylesheets/trees.scss
+++ b/app/assets/stylesheets/trees.scss
@@ -138,6 +138,7 @@
       padding: 0;
       border-left: 1px solid black;
       border-right: 1px solid black;
+      &.list-group.maint-column {border:none;}
     }
 
     .sequence-header, .dimension-header {

--- a/app/controllers/trees_controller.rb
+++ b/app/controllers/trees_controller.rb
@@ -358,6 +358,7 @@ class TreesController < ApplicationController
 
   def sequence
     index_prep
+    @page_settings = JSON.parse(cookies[:connect_cols_settings]) if cookies[:connect_cols_settings]
     @max_subjects = 6
     @s_o_hash = Hash.new  { |h, k| h[k] = [] }
     @indicator_hash = Hash.new { |h, k| h[k] = [] }

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -61,7 +61,7 @@ module ApplicationHelper
   end
 
   def can_edit_type?(type)
-    teachers_can_edit = [] #['miscon', 'sector', 'connect', 'resource']
+    teachers_can_edit = [] #['tree-detail-page','miscon', 'sector', 'connect', 'resource']
     return current_is_admin? || (current_is_teacher? && teachers_can_edit.include?(type)) ||
       (current_is_counselor? && teachers_can_edit.include?(type)) ||
       (current_is_supervisor? && teachers_can_edit.include?(type))

--- a/app/models/base_rec.rb
+++ b/app/models/base_rec.rb
@@ -48,6 +48,9 @@ class BaseRec < ActiveRecord::Base
     'ear', #Earth Science
     'geo', #Geology
     'tech', #Technology
+    'adv', #advisory
+    'ara', #Arabic
+    'art', #Art
   ]
 
   # BASE_PRACTICES = [

--- a/app/models/dimension.rb
+++ b/app/models/dimension.rb
@@ -21,6 +21,7 @@ class Dimension < BaseRec
     'link',
     'distractor',
     'question_bank',
+    'third_subj',
   ]
 
   validate :valid_dim_type

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -90,6 +90,10 @@ class User < BaseRec
     where("roles = ''")
   }
 
+  def active_for_authentication?
+    super && roles.length > 0
+  end
+
   def role_names
     ret = []
     roles_array = get_roles_array

--- a/app/views/dimensions/show.html.erb
+++ b/app/views/dimensions/show.html.erb
@@ -31,6 +31,7 @@
 	    <%= link_to("Edit #{dimTypeTitle}", dimension_path(@dimension.id, editMe: true) ) if can_edit_type?(@dimension.dim_code)
 	     %>
 	  <% end %>
+    <button class="btn btn-primary print-btn"><span class="fa fa-print"></span> <%= I18n.translate("app.labels.print")%></button>
 	</div>
   <div class="dimension-grid cols-2">
   	<% @dimDisplayHash[@dimension.dim_code].each do |resource| %>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -146,13 +146,6 @@
           <li class="nav-item" role='menuitem'>
             <a class="nav-link btn btn-primary" href=<%= sectors_path %>><%= @sectorName %></a>
           </li>
-          <li class="nav-item active" role='menuitem'>
-          <a class="nav-link btn btn-primary" href="#">
-            <%= translate('nav_bar.concepts.name') %></a>
-          </li>
-          <li class="nav-item" role='menuitem'>
-          <a class="nav-link btn btn-primary" href="#"><%= translate('nav_bar.standards.name') %></a>
-          </li>
         </ul>
     </li>
     <% if current_user.present? && current_user.is_admin?

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -1,72 +1,79 @@
-<header id='pageHeader' class='d-flex flex-row justify-content-between'>
-  <a id='pageHeaderLogo' class='' href='#'>
-    <div class='logoImage'></div>
-  </a>
-  <div id='pageHeaderTitle' class=''>
-    <h1 class='text-center'><%= @appTitle if current_user.present? %></h1>
-  </div>
-  <% if current_user.present? %>
-    <div id='pageHeaderCurriculumSelect'>
-      <select id='selectCurriculumDropdown' name='tree_type[type_and_version_id]' onchange="selectCurriculum('<%= request.env['PATH_INFO'] %>', <%= current_user.present? ? current_user.id : '' %>)">
-        <% @versionsHash.each_value do |arr| %>
-          <% arr.each do |cur| %>
-            <% selected_curriculum = (cur[:tree_type_id] == @treeTypeRec.id && cur[:version_id] == @versionRec.id) %>
-            <option value="<%= [cur[:tree_type_id], cur[:version_id]].to_s %>"<%= selected_curriculum ? " selected" : "" %>>
-              <%=
-              "#{cur[:str]}"
-              # "[#{cur[:working] ? translate('app.labels.working_version') : translate('app.labels.final_version')}]"
-              %>
-            </option>
-          <% end %>
-        <% end %>
-      </select>
+<header id='pageHeader' class='d-flex flex-row navbar justify-content-between'>
+  <div class="col-12 navbar navbar-expand-sm flexContainer">
+    <a id='pageHeaderLogo' class='' href='#'>
+      <div class='logoImage nav-item'></div>
+    </a>
+    <div id='pageHeaderTitle--mobile' class='nav-item'>
+      <h1 class='text-center'><%= @appTitle if current_user.present? %></h1>
     </div>
-  <% end %>
-  <div id='pageHeaderFontSize' class='font-size-select'>
-    <span class='smallest-text'>A</span>
-    <span class='smaller-text'>A</span>
-    <span class='medium-text'>A</span>
-    <span class='larger-text'>A</span>
-    <span class='largest-text'>A</span>
-  </div>
-  <div id='pageHeaderShowNav' class=''>
-    <ul id='locale-select'>
-      <% @locale_codes.each do |lc| %>
-        <% if lc == 'tr'%>
-          <% if @locale_code == 'tr' %>
-            <li class='cur-locale'>
-              <span>Türkçe</span>
-            </li>
-          <% else %>
-            <li class='locale-opt'>
-              <a href='/users/lang/tr<%= "?dim_type=#{@dim_type}" if @dim_type %>'>Türkçe</a>
-            </li>
+    <div class="pull-left nav-item"><%= I18n.translate("nav_bar.welcome", name: current_user.given_name) if current_user.present? %></div>
+    <div id='pageHeaderTitle' class='nav-item'>
+      <h1 class='text-center'><%= @appTitle if current_user.present? %></h1>
+    </div>
+    <% if current_user.present? %>
+      <div id='pageHeaderCurriculumSelect' class='nav-item'>
+        <select id='selectCurriculumDropdown' name='tree_type[type_and_version_id]' onchange="selectCurriculum('<%= request.env['PATH_INFO'] %>', <%= current_user.present? ? current_user.id : '' %>)">
+          <% @versionsHash.each_value do |arr| %>
+            <% arr.each do |cur| %>
+              <% selected_curriculum = (cur[:tree_type_id] == @treeTypeRec.id && cur[:version_id] == @versionRec.id) %>
+              <option value="<%= [cur[:tree_type_id], cur[:version_id]].to_s %>"<%= selected_curriculum ? " selected" : "" %>>
+                <%=
+                "#{cur[:str]}"
+                # "[#{cur[:working] ? translate('app.labels.working_version') : translate('app.labels.final_version')}]"
+                %>
+              </option>
+            <% end %>
+          <% end %>
+        </select>
+      </div>
+    <% end %>
+    <div id='pageHeaderFontSize' class='font-size-select nav-item'>
+      <span class='smallest-text'>A</span>
+      <span class='smaller-text'>A</span>
+      <span class='medium-text'>A</span>
+      <span class='larger-text'>A</span>
+      <span class='largest-text'>A</span>
+    </div>
+
+    <div id='pageHeaderShowNav' class='nav-item'>
+      <ul id='locale-select'>
+        <% @locale_codes.each do |lc| %>
+          <% if lc == 'tr'%>
+            <% if @locale_code == 'tr' %>
+              <li class='cur-locale'>
+                <span>Türkçe</span>
+              </li>
+            <% else %>
+              <li class='locale-opt'>
+                <a href='/users/lang/tr<%= "?dim_type=#{@dim_type}" if @dim_type %>'>Türkçe</a>
+              </li>
+            <% end %>
+          <% end %>
+          <% if lc == 'en'%>
+            <% if @locale_code == 'en' %>
+              <li class='cur-locale'>
+                <span>English</span>
+              </li>
+            <% else %>
+              <li class='locale-opt'>
+                <a href='/users/lang/en<%= "?dim_type=#{@dim_type}" if @dim_type %>'>English</a>
+              </li>
+            <% end %>
+          <% end %>
+          <% if lc == 'ar_EG'%>
+            <% if @locale_code == 'ar_EG' %>
+              <li class='cur-locale'>
+                <span>عربي مصري</span>
+              </li>
+            <% else %>
+              <li class='locale-opt'>
+                <a href='/users/lang/ar_EG<%= "?dim_type=#{@dim_type}" if @dim_type %>'>عربي مصري</a>
+              </li>
+            <% end %>
           <% end %>
         <% end %>
-        <% if lc == 'en'%>
-          <% if @locale_code == 'en' %>
-            <li class='cur-locale'>
-              <span>English</span>
-            </li>
-          <% else %>
-            <li class='locale-opt'>
-              <a href='/users/lang/en<%= "?dim_type=#{@dim_type}" if @dim_type %>'>English</a>
-            </li>
-          <% end %>
-        <% end %>
-        <% if lc == 'ar_EG'%>
-          <% if @locale_code == 'ar_EG' %>
-            <li class='cur-locale'>
-              <span>عربي مصري</span>
-            </li>
-          <% else %>
-            <li class='locale-opt'>
-              <a href='/users/lang/ar_EG<%= "?dim_type=#{@dim_type}" if @dim_type %>'>عربي مصري</a>
-            </li>
-          <% end %>
-        <% end %>
-      <% end %>
-    </ul>
+      </ul>
+    </div>
   </div>
 </header>
 <% if current_user.present? %>
@@ -83,24 +90,14 @@
         </li>
       <%
       end
-      if controller.controller_name == 'trees' && action_name == 'index' %>
-        <li class="nav-item active" aria-selected='true'>
-          <a class="nav-link btn btn-primary" href=<%= trees_path %>><%= translate('nav_bar.curriculum.name') %></a>
-        </li>
-      <% else %>
-        <li class="nav-item" role='menuitem'>
-          <a class="nav-link btn btn-primary" href=<%= trees_path %>><%= translate('nav_bar.curriculum.name') %></a>
-        </li>
-      <%
-      end
       if controller.controller_name == 'trees' && action_name == 'outcomes' %>
         <li class="nav-item active" aria-selected='true'>
-          <a class="nav-link btn btn-primary" href=<%= maint_trees_path() %>><%= @hierarchies[@treeTypeRec[:outcome_depth]].pluralize %></a>
+          <a class="nav-link btn btn-primary" href=<%= maint_trees_path() %>><%= translate('nav_bar.curriculum.name') %></a>
         </li>
       <%
       else %>
         <li class="nav-item" role='menuitem'>
-          <a class="nav-link btn btn-primary" href=<%= maint_trees_path() %>><%= @hierarchies[@treeTypeRec[:outcome_depth]].pluralize %></a>
+          <a class="nav-link btn btn-primary" href=<%= maint_trees_path() %>><%= translate('nav_bar.curriculum.name') %></a>
         </li>
       <%
       end

--- a/app/views/trees/_competencies_column.html.erb
+++ b/app/views/trees/_competencies_column.html.erb
@@ -3,7 +3,7 @@
   <li>
     <%= render partial: "maint_filter", locals: {col: "tree"} %>
   </li>
-  <li class="maint-header indent-0"><%= @subjectByCode[@subject_code] ? @subjectByCode[@subject_code][:name] : @subject_code %></li>
+  <li class="colorful-header colorful-header-0 indent-0"><%= @subjectByCode[@subject_code] ? @subjectByCode[@subject_code][:name] : @subject_code %></li>
   <%
    @treeByParents.each do |tkey, codeh| %>
     <% codeh.each do |code, h| %>
@@ -51,7 +51,7 @@
       <!-- TO DO: Find a different workaround for hiding indicator-level items -->
       <% elsif h[:depth] > @treeTypeRec.outcome_depth+1 %>
       <% else %>
-        <li id="<%= h[:subj_code] %>_tree_<%= h[:id] %>" class="sequence-item maint-sub-header list-group-item indent-<%= h[:depth]-1 %> <%= h[:selectors_by_parent] %> level-<%= h[:depth] - 1 %>" data-treeid="<%= h[:id] %>">
+        <li id="<%= h[:subj_code] %>_tree_<%= h[:id] %>" class="sequence-item list-group-item indent-<%= h[:depth]-1 %> <%= h[:selectors_by_parent] %> level-<%= h[:depth] - 1 %> colorful-header colorful-header-<%= h[:depth] %>" data-treeid="<%= h[:id] %>">
           <a class="" onclick="toggle_visibility('.child-of-<%= code.split(".").join("-") %>', '#trigger-<%= code.split(".").join("-") %>')">
             <i id="trigger-<%= code.split(".").join("-") %>" class="fa fa-compress pull-left option-selected link-blue accordion" title="collapse"></i>
           </a>

--- a/app/views/trees/_competency_grids_column.html.erb
+++ b/app/views/trees/_competency_grids_column.html.erb
@@ -2,7 +2,7 @@
   <li>
     <%= render partial: "maint_filter", locals: {col: "tree"} %>
   </li>
-  <li class="maint-header indent-0"><%= @subjectByCode[@subject_code]? @subjectByCode[@subject_code][:name] : @subject_code %></li>
+  <li class="colorful-header colorful-header-0 indent-0"><%= @subjectByCode[@subject_code]? @subjectByCode[@subject_code][:name] : @subject_code %></li>
   <%
    @treeByParents.each do |tkey, codeh| %>
     <% codeh.each do |code, h| %>
@@ -16,7 +16,7 @@
            }
          end
        %>
-      <li id="<%= h[:subj_code] %>_lo_<%= h[:id] %>" class="maint-item indent-3 <%= h[:selectors_by_parent] %> list-group-item level-<%= h[:depth] - 1 %>" data-loid="<%= h[:id] %>">
+      <li id="<%= h[:subj_code] %>_lo_<%= h[:id] %>" class="maint-item indent-3 <%= h[:selectors_by_parent] %> list-group-item level-<%= h[:depth] - 1 %> sequence-item" data-loid="<%= h[:id] %>">
         <% if true %>
           <% h[:dimtrees].each do |dt|
              dim = dt.dimension
@@ -84,7 +84,7 @@
       <!-- TO DO: Find a different workaround for hiding indicator-level items -->
       <% elsif h[:depth] > @treeTypeRec.outcome_depth+1 %>
       <% else %>
-        <li class="maint-sub-header indent-<%= h[:depth]-1 %> <%= h[:selectors_by_parent] %> level-<%= h[:depth] - 1 %>">
+        <li class="indent-<%= h[:depth]-1 %> <%= h[:selectors_by_parent] %> level-<%= h[:depth] - 1 %> colorful-header colorful-header-<%= h[:depth] %> sequence-item">
           <a class="" onclick="toggle_visibility('.child-of-<%= code.split(".").join("-") %>', '#trigger-<%= code.split(".").join("-") %>')">
             <i id="trigger-<%= code.split(".").join("-") %>" class="fa fa-compress pull-left option-selected link-blue accordion" title="collapse"></i>
           </a>

--- a/app/views/trees/_dim_column.html.erb
+++ b/app/views/trees/_dim_column.html.erb
@@ -2,7 +2,7 @@
   <li>
     <%= render partial: "maint_filter", locals: {col: dim_type } %>
   </li>
-  <li class="maint-header"><%= "#{dim_subj_name} - #{dim_title} (#{grades_str}: #{@dim_filters[dim_type][:gb][:min_grade]} - #{@dim_filters[dim_type][:gb][:max_grade]})" %>
+  <li class="colorful-header colorful-header-0"><%= "#{dim_subj_name} - #{dim_title} (#{grades_str}: #{@dim_filters[dim_type][:gb][:min_grade]} - #{@dim_filters[dim_type][:gb][:max_grade]})" %>
     <% if @editing && can_edit %>
       <%= link_to(fa_icon("plus"), dimension_form_trees_path( dimension: { dim_type: dim_type }), {:remote => true, 'data-toggle' =>  "modal", 'data-target' => '#modal_popup'}) %>
     <% end %>

--- a/app/views/trees/_dim_column.html.erb
+++ b/app/views/trees/_dim_column.html.erb
@@ -17,7 +17,7 @@
             <span class='pull-left'><strong><%= "#{grades_str}: " %></strong> <%= "#{dim.min_grade} - #{dim.max_grade}" %></span>
 
           <br/>
-          <span class='pull-left left-justify'><strong><%= "#{dim_title.singularize}: " %></strong>
+          <div class='pull-left left-justify'><strong><%= "#{dim_title.singularize}: " %></strong>
             <% if dim_link %>
               <a href="<%= dim_link %>">
               <%= @translations[dim.dim_name_key].html_safe %>
@@ -25,7 +25,7 @@
             <% else %>
               <%= @translations[dim.dim_name_key].html_safe %>
             <% end %>
-          </span>
+          </div>
           <br/>
 
           <% if can_edit && @editing%>

--- a/app/views/trees/sequence.html.erb
+++ b/app/views/trees/sequence.html.erb
@@ -1,6 +1,7 @@
 <% content_for(:title_code, 'trees.index.name') %>
 <% content_for(:page_class, 'trees') %>
 
+<% subj_cols_count = 0 %>
 <br>
 <div class='text-center sequence-page'>
   <h2 id="sequencing-header"><%= translate('nav_bar.relations.name') %></h2>
@@ -38,9 +39,13 @@
     <% subj_counter = 0 %>
     <% subj_default_count = 3 %>
     <% @s_o_hash.keys.each do |i| %>
-      <% subj_counter += 1 %>
+      <%
+        subj_counter += 1
+        subj_checked = @page_settings ? @page_settings.include?("check-#{i}") : (subj_counter <= subj_default_count)
+        subj_cols_count += 1 if subj_checked
+      %>
       <div class='subj-checkbox'>
-        <input id="check-<%= i %>" type="checkbox" onchange='subject_visibility("<%= i %>", <%= @max_subjects %>, "<%= I18n.t('app.errors.max_subj_display_count', num: @max_subjects) %>");' <%= subj_counter <= subj_default_count ? "checked" : "" %>></input>
+        <input id="check-<%= i %>" type="checkbox" onchange='subject_visibility("<%= i %>", <%= @max_subjects %>, "<%= I18n.t('app.errors.max_subj_display_count', num: @max_subjects) %>");' <%= subj_checked ? "checked" : "" %>></input>
         <label for="check-<%= i %>">
           <%= @subjectByCode[i][:abbr] %>
         </label>
@@ -49,9 +54,10 @@
           <ul id="<%= i %>-gradebands-list" class="gradebands-list hidden">
             <%
             @subj_gradebands[i].each do |gb_code|
+              gb_checked = @page_settings ? @page_settings.include?("#{i}-gb-check-#{gb_code}") : true
             %>
               <li>
-              <input id="<%= i %>-gb-check-<%= gb_code %>" type="checkbox" onchange='gradeband_visibility(["<%= i %>"], ["<%= gb_code %>"]);' checked></input>
+              <input id="<%= i %>-gb-check-<%= gb_code %>" type="checkbox" onchange='gradeband_visibility(["<%= i %>"], ["<%= gb_code %>"]);'<%= gb_checked ? " checked" : "" %>></input>
               <label for="<%= i %>-gb-check-<%= gb_code %>">
                 <%= I18n.t('app.labels.grade_band_num', num: gb_code) %>
               </label>
@@ -65,14 +71,20 @@
 </div>
 <% subj_counter = 0 %>
 <div id="trees" class="sequence-page">
-  <div class="sequence-grid cols-<%= subj_default_count %>">
+  <div class="sequence-grid cols-<%= subj_cols_count %>">
 	<% @s_o_hash.each do |i, j| %>
-    <% subj_counter += 1 %>
-    <div id="<%=i%>-column" class="sequence-item subject-column<%= subj_counter > subj_default_count ? " hidden" : "" %>">
+    <% subj_counter += 1
+      subj_checked = @page_settings ? @page_settings.include?("check-#{i}") : (subj_counter <= subj_default_count)
+    %>
+
+    <div id="<%=i%>-column" class="sequence-item subject-column<%= subj_checked ? "" : " hidden" %>">
       <ul class="list-group">
         <li class="sequence-header"><%= @subjects[i].get_name(@locale_code) %></li>
         <% j.each do |k| %>
-          <li id="lo_<%= k[:id] %>" class="sequence-item sequence-item--collapsable list-group-item lo_gb_code_<%= k[:gb_code] %>" data-lo-id="<%= k[:id] %>">
+          <%
+            gb_checked = @page_settings ? @page_settings.include?("#{i}-gb-check-#{k[:gb_code]}") : true
+          %>
+          <li id="lo_<%= k[:id] %>" class="sequence-item sequence-item--collapsable list-group-item lo_gb_code_<%= k[:gb_code] %><%= gb_checked ? "" : " hidden" %>" data-lo-id="<%= k[:id] %>">
             <a class="truncate-if-collapsed" href="<%= tree_path(k[:id])%>" title="<%= k[:text] %>"><%= k[:text] %></a>
             <% if @indicator_hash[k[:code]].length > 0 %>
               <div class="indicators-container hidden hide-if-collapsed"><strong>

--- a/app/views/trees/sequence.html.erb
+++ b/app/views/trees/sequence.html.erb
@@ -3,7 +3,7 @@
 
 <br>
 <div class='text-center sequence-page'>
-  <h2 id="sequencing-header"><%= translate('trees.sequencing.title') %></h2>
+  <h2 id="sequencing-header"><%= translate('nav_bar.relations.name') %></h2>
   <div id="controls">
     <div>
       <% if @indicator_name %>

--- a/app/views/trees/show.html.erb
+++ b/app/views/trees/show.html.erb
@@ -78,6 +78,7 @@
             <%= link_to("Edit #{@hierarchies[@treeTypeRec[:outcome_depth]]}", tree_path(@tree.id, editme: @tree.id) ) if current_user.present? && (current_is_admin? || current_is_teacher?) %>
             <!-- # %= link_to("Edit LO", edit_tree_path(@tree.id), {:remote => true, 'data-toggle' =>  "modal", 'data-target' => '#modal_popup'}) % -->
           <% end %>
+          <button class="btn btn-primary print-btn"><span class="fa fa-print"></span> <%= I18n.translate("app.labels.print")%></button>
         </div>
 
 

--- a/app/views/trees/show.html.erb
+++ b/app/views/trees/show.html.erb
@@ -75,7 +75,7 @@
           <% if @editMe %>
             <span class='font-weight-bold'>Editing (<%= link_to("#{I18n.t('app.labels.leave_edit_mode')}", tree_path(@tree.id) ) %>)</span>
           <% else %>
-            <%= link_to("Edit #{@hierarchies[@treeTypeRec[:outcome_depth]]}", tree_path(@tree.id, editme: @tree.id) ) if current_user.present? && (current_is_admin? || current_is_teacher?) %>
+            <%= link_to("Edit #{@hierarchies[@treeTypeRec[:outcome_depth]]}", tree_path(@tree.id, editme: @tree.id) ) if current_user.present? && (current_is_admin? || can_edit_type?('tree-detail-page')) %>
             <!-- # %= link_to("Edit LO", edit_tree_path(@tree.id), {:remote => true, 'data-toggle' =>  "modal", 'data-target' => '#modal_popup'}) % -->
           <% end %>
           <button class="btn btn-primary print-btn"><span class="fa fa-print"></span> <%= I18n.translate("app.labels.print")%></button>

--- a/config/locales/pages.ar_EG.yml
+++ b/config/locales/pages.ar_EG.yml
@@ -59,6 +59,7 @@ ar_EG:
       connect_form_title: "حفظ الاتصال؟"
       show_details: "اظهر التفاصيل"
       last_updated: "Last updated at: %{time}"
+      print: "طباعة"
     roles:
       name: 'الأدوار'
       admin:

--- a/config/locales/pages.ar_EG.yml
+++ b/config/locales/pages.ar_EG.yml
@@ -118,8 +118,8 @@ ar_EG:
       name: "التحرير"
       hover: "صفحة تحرير عناصر المناهج"
     connections:
-      name: "آخر"
-      hover: "اتصالات أخرى"
+      name: "الآراء"
+      hover: "الآراء"
     bigidea:
       name: "أفكار كبيرة"
       hover: "أفكار كبيرة"

--- a/config/locales/pages.ar_EG.yml
+++ b/config/locales/pages.ar_EG.yml
@@ -40,7 +40,7 @@ ar_EG:
       code: "الشفرة"
       description: 'وصف'
       message: "رسالة"
-      gen_list: "إنشاء قائمة"
+      gen_list: "تبين"
       sector: "التحدي الكبير"
       upload_summary: 'تحميل تقرير ملخص'
       upload_new: 'إضافة وتحميل'

--- a/config/locales/pages.ar_EG.yml
+++ b/config/locales/pages.ar_EG.yml
@@ -105,6 +105,7 @@ ar_EG:
     home:
       name: "الصفحة الرئيسية"
       hover: "الصفحة الرئيسية STEM في مصر"
+    welcome: "!%{name} مرحبًا"
     curriculum:
       name: "شجرة المناهج"
       hover: "يعرض شجرة المناهج"

--- a/config/locales/pages.en.yml
+++ b/config/locales/pages.en.yml
@@ -108,15 +108,16 @@ en:
     home:
       name: "Home"
       hover: "Mektebim STEM Home Page"
+    welcome: "Welcome, %{name}!"
     curriculum:
-      name: "Curriculum Tree"
+      name: "Curriculum"
       hover: "Displays the Curriculum Tree"
     sectors:
       name: "Sectors"
       hover: "Displays the Curriculum by Sectors"
     relations:
-      name: "Relations"
-      hover: "Display the Relations between Curriculum Items"
+      name: "Connections"
+      hover: "Display the Connections between Curriculum Items"
     maint:
       name: "Editing"
       hover: "Page for Editing of Curriculum Items"

--- a/config/locales/pages.en.yml
+++ b/config/locales/pages.en.yml
@@ -43,7 +43,7 @@ en:
       code: "Code"
       description: 'Description'
       message: "Message"
-      gen_list: "Generate List"
+      gen_list: "Show"
       sector: "Sector"
       upload_summary: 'Uploads Summary Report'
       upload_new: 'Add and Do Upload'

--- a/config/locales/pages.en.yml
+++ b/config/locales/pages.en.yml
@@ -62,6 +62,7 @@ en:
       connect_form_title: "Save Connection?"
       show_details: "Show Details"
       last_updated: "Last updated at: %{time}"
+      print: "Print"
     roles:
       name: 'Roles'
       admin:

--- a/config/locales/pages.en.yml
+++ b/config/locales/pages.en.yml
@@ -121,8 +121,8 @@ en:
       name: "Editing"
       hover: "Page for Editing of Curriculum Items"
     connections:
-      name: "Other"
-      hover: "Other Connections"
+      name: "Views"
+      hover: "Views"
     bigidea:
       name: "Big Ideas"
       hover: "Big Ideas"

--- a/config/locales/pages.tr.yml
+++ b/config/locales/pages.tr.yml
@@ -51,8 +51,8 @@ tr:
       name: "Gelecek Sektörler"
       hover: "Gelecekteki Sektörlere Göre Müfredatı görüntüler"
     connections:
-      name: "Bağlantılar"
-      hover: "açılır"
+      name: "Görüntüleme"
+      hover: "Görüntüleme"
     big_ideas:
       name: "Büyük Fikirler"
       hover: ""

--- a/config/locales/pages.tr.yml
+++ b/config/locales/pages.tr.yml
@@ -44,6 +44,7 @@ tr:
     home:
       name: "Ev"
       hover: "Mektebim STEM Ana Sayfa"
+    welcome: "Hoş geldiniz, %{name}!"
     curriculum:
       name: "Gelecek Müfredat"
       hover: "Müfredat Ağacı'nı görüntüler"

--- a/config/locales/pages.tr.yml
+++ b/config/locales/pages.tr.yml
@@ -37,6 +37,7 @@ tr:
       explanation: "Açıklama"
       sector_num: "Sektör %{num}"
       last_updated: "Last updated at: %{time}"
+      print: "Yazdır"
       errors:
         max_subj_display_count: "Bir defada en fazla %{num} konu görüntülenebilir."
   nav_bar:

--- a/lib/tasks/seed_stessa_1.rake
+++ b/lib/tasks/seed_stessa_1.rake
@@ -58,7 +58,7 @@ namespace :seed_eg_stem do
       #Display codes are zero-relative indexes in Dimension::RESOURCE_TYPES
       #Dimensions must appear in this string to have a show page
       #E.g., dim_display: 'miscon#0#1#2#3,bigidea#4#5#8,concept#1',
-      dim_display: 'miscon#0#1#2#3#4#5#6#7',
+      dim_display: 'miscon#0#8#1#2#3#4#5#6#7',
       #user_form_config:
       #_form_other: list fields that should be included in the user form
         #dropdown selection fields should have the number of selection options
@@ -373,7 +373,7 @@ namespace :seed_eg_stem do
     ]
 
     dim_resource_types_arr = [
-      ['Second Subject', 'الموضوع الثاني'],
+      ['Second Category', 'الفئة الثانية'],
       ['Correct Understanding', 'الفهم الصحيح'],
       ['Possible Source of Misconception', 'مصدر محتمل للفهم الخاطئ'],
       ['Compiler/Source'],
@@ -381,6 +381,7 @@ namespace :seed_eg_stem do
       ['Website Link References', 'مراجع رابط الموقع'],
       ['Test Distractor Percent', 'اختبار نسبة تشتيت الانتباه'],
       ['Link to Question Item Bank', 'رابط إلى بنك عناصر السؤال'],
+      ['Third Category', 'الفئة الثالثة'],
     ]
     dim_translations_arr.each do |dim|
       dim_name_key = Dimension.get_dim_type_key(

--- a/lib/tasks/seed_stessa_1.rake
+++ b/lib/tasks/seed_stessa_1.rake
@@ -26,7 +26,7 @@ namespace :seed_eg_stem do
       code: 'egstemuniv',
       hierarchy_codes: 'grade,sem,unit,lo,indicator',
       valid_locales: BaseRec::LOCALE_EN+','+BaseRec::LOCALE_AR_EG,
-      sector_set_code: 'gr_chall',
+      sector_set_code: 'gr_chall,hide',
       sector_set_name_key: 'sector.set.gr_chal.name',
       curriculum_title_key: 'curriculum.egstemuniv.title', #'Egypt STEM Teacher Prep Curriculum'
       outcome_depth: 3,

--- a/lib/tasks/seed_stessa_2.rake
+++ b/lib/tasks/seed_stessa_2.rake
@@ -31,7 +31,7 @@ namespace :seed_stessa_2 do
       code: @curriculumCode,
       hierarchy_codes: 'grade,sem,unit,lo',
       valid_locales: BaseRec::LOCALE_EN+','+BaseRec::LOCALE_AR_EG,
-      sector_set_code: 'gr_chall',
+      sector_set_code: 'gr_chall,hide',
       sector_set_name_key: 'sector.set.gr_chal.name',
       curriculum_title_key: 'curriculum.egstem.title', # 'Egypt STEM Curriculum - deprecated - see treeType.title_key'
       outcome_depth: 3,

--- a/lib/tasks/seed_stessa_2.rake
+++ b/lib/tasks/seed_stessa_2.rake
@@ -64,7 +64,7 @@ namespace :seed_stessa_2 do
       #Display codes are zero-relative indexes in Dimension::RESOURCE_TYPES
       #Dimensions must appear in this string to have a show page
       #E.g., dim_display: 'miscon#0#1#2#3,bigidea#4#5#8,concept#1',
-      dim_display: 'miscon#0#1#2#3#4#5#6#7',
+      dim_display: 'miscon#0#8#1#2#3#4#5#6#7',
       #user_form_config:
       #_form_other: list fields that should be included in the user form
         #dropdown selection fields should have the number of selection options
@@ -401,7 +401,7 @@ namespace :seed_stessa_2 do
     ]
 
     dim_resource_types_arr = [
-      ['Second Subject', 'الموضوع الثاني'],
+      ['Second Category', 'الفئة الثانية'],
       ['Correct Understanding', 'الفهم الصحيح'],
       ['Possible Source of Misconception', 'مصدر محتمل للفهم الخاطئ'],
       ['Compiler/Source'],
@@ -409,6 +409,7 @@ namespace :seed_stessa_2 do
       ['Website Link References', 'مراجع رابط الموقع'],
       ['Test Distractor Percent', 'اختبار نسبة تشتيت الانتباه'],
       ['Link to Question Item Bank', 'رابط إلى بنك عناصر السؤال'],
+      ['Third Category', 'الفئة الثالثة'],
     ]
     dim_translations_arr.each do |dim|
       dim_name_key = Dimension.get_dim_type_key(

--- a/lib/tasks/seed_stessa_2.rake
+++ b/lib/tasks/seed_stessa_2.rake
@@ -37,7 +37,7 @@ namespace :seed_stessa_2 do
       outcome_depth: 3,
       version_id: @ver.id,
       working_status: true,
-      dim_codes: 'bigidea,essq,concept,skill,miscon,standardus,standardeg',
+      dim_codes: 'caps,bigidea,essq,concept,skill,miscon,standardus,standardeg',
       tree_code_format: 'subject,grade,lo',
       # To Do: Write documentation on obtaining translation keys
       # - for dimension translation use dim.get_dim_resource_key
@@ -59,7 +59,7 @@ namespace :seed_stessa_2 do
       #                  Outcome::RESOURCE_TYPES array.
       #   tableItem_tableItem_... - up to 4 columns table items allowed in one row.
       #   To Do: standards header on top RIGHT of the show page.
-      detail_headers: 'grade,sem,unit,lo,weeks,hours,{resource#6},<sector>_[bigidea]_[essq],{sem#3}_{grade#0}_{unit#2},[miscon#2#1],[concept]_[skill],{resource#7},{resource#8},[standardeg],+treetree+,{resources#12#3#2#11#10#9}',
+      detail_headers: 'grade,sem,unit,lo,weeks,hours,{resource#6},<sector>_[bigidea]_[essq],{sem#3}_{grade#0}_{unit#2},[miscon#2#1],[concept]_[skill],{resource#7},[caps],{resource#8},[standardeg],+treetree+,{resources#12#3#2#11#10#9}',
       grid_headers: 'grade,unit,lo,[bigidea],[essq],[concept],[skill],[miscon]',
       #Display codes are zero-relative indexes in Dimension::RESOURCE_TYPES
       #Dimensions must appear in this string to have a show page
@@ -231,7 +231,10 @@ namespace :seed_stessa_2 do
       sci: {abbr: 'sci', inCurric: false, engName: 'Science', locAbbr: 'علم', locName: 'علم'},
       ear: {abbr: 'Ear', inCurric: false, engName: 'Earth Science', locAbbr: 'علوم الأرض', locName: 'علوم الأرض'},
       geo: {abbr: 'geo', inCurric: false, engName: 'Geology', locAbbr: 'جيولوجيا', locName: 'جيولوجيا'},
-      tech: {abbr: 'tech', inCurric: false, engName: 'Tech Engineering', locAbbr: 'هندسة التكنولوجيا', locName: 'هندسة التكنولوجيا'}
+      tech: {abbr: 'tech', inCurric: false, engName: 'Tech Engineering', locAbbr: 'هندسة التكنولوجيا', locName: 'هندسة التكنولوجيا'},
+      adv: {abbr: 'adv', inCurric: true, engName: 'Advisory', locAbbr: 'استشاري', locName: 'استشاري'},
+      ara: {abbr: 'ara', inCurric: true, engName: 'Arabic', locAbbr: 'عربى', locName: 'عربى'},
+      art: {abbr: 'art', inCurric: true, engName: 'Art', locAbbr: 'فن', locName: 'فن'},
     }
 
     @subjectsHash.each do |key, subjHash|
@@ -387,6 +390,7 @@ namespace :seed_stessa_2 do
   desc "create translations for dimension types"
   task dimension_translations: :environment do
     dim_translations_arr = [
+      ['caps', 'Capstone Challenge', 'تحدي كابستون'],
       ['bigidea', 'Big Idea', 'فكرة هامة'],
       ['essq', 'Essential Question', 'السؤال الجوهري'],
       ['concept', 'Concept', 'مفهوم'],

--- a/lib/tasks/seed_turkey_v02.rake
+++ b/lib/tasks/seed_turkey_v02.rake
@@ -62,7 +62,7 @@ namespace :seed_turkey_v02 do
       # [item] - grid column, may have multiple connected items
       # {item} - grid column, single item
       grid_headers: 'grade,unit,subunit,comp,[essq],[bigidea],[pract],{explain},[miscon]',
-      dim_display: 'miscon#0#1#2#3#4#5#6#7',
+      dim_display: 'miscon#0#8#1#2#3#4#5#6#7', #To Do: update on server
     }
     if myTreeTypes.count < 1
       TreeType.create(myTreeTypeValues)
@@ -324,9 +324,9 @@ namespace :seed_turkey_v02 do
       ['pract', 'Associated Practice', 'İlişkili Uygulama'],
       ['miscon', 'Misconception', 'Yanlış kanı'],
     ]
-
+    #TO DO: update on server
     dim_resource_types_arr = [
-      ['Second Subject', 'İkinci Konu'],
+      ['Second Category', 'İkinci Kategori'],
       ['Correct Understanding', 'Doğru Anlama'],
       ['Possible Source of Misconception', 'Yanlış Anlaşmanın Olası Kaynağı'],
       ['Compiler/Source'],
@@ -334,6 +334,7 @@ namespace :seed_turkey_v02 do
       ['Website Link References', 'Web Sitesi Bağlantı Referansları'],
       ['Test Distractor Percent', 'Test Distraktör Yüzdesi'],
       ['Link to Question Item Bank', 'Soru Bağlantısı Bankası'],
+      ['Third Category', 'Üçüncü Kategori'],
     ]
     dim_translations_arr.each do |dim|
       dim_name_key = Dimension.get_dim_type_key(


### PR DESCRIPTION
Connections
- Remember settings on the connections page

Dimensions 
- Add "third_subj" to dimension resources array. 
- Update translations of second and third_subj resources in egstem rake files 

Security
- Lock out users unless they have a role in the app 

Buttons/Labels/Menus/Display
- change 'generate list' button to 'show'
- Add print button to Detail Pages
- Move Sectors page link to 'Views' dropdown menu in egstem curriculum (via a flag in the treetype rec)
- Welcome the current user in the top-nav
- Colorful headers on the Curriculum and Editing pages. Space out units.

Bugfix
- Make dimensions columns more robust on editing page (html errors in curriculum upload sheet were breaking the layout of the page)