### PR TITLE
Parent resources moved to header on the Tree Detail page, "subject teaching" dropdowns in user add/edit form

### DIFF
--- a/app/assets/javascripts/common.js
+++ b/app/assets/javascripts/common.js
@@ -212,6 +212,10 @@ $(function() {
         $(this).data("outcome_depth"));
       show_maint_details(true, ($(this).data("resize")));
     })
+    $(".js-show-hide-control").on("click", function() {
+      $($(this).data("showSelector")).show();
+      $($(this).data("hideSelector")).hide();
+    });
   }
 
   init_admin_subjects_editing = function () {

--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -59,6 +59,7 @@ body {
 .sequence-item:not(.colorful-header) + .sequence-item.colorful-header {
  margin-top:4vh;
 }
+.block {display: block;}
 /*********************************************************************
 Start Treeview styles- deprecated. These are for the old Curriculum Tree page.
 ************************************************************************/

--- a/app/assets/stylesheets/trees.scss
+++ b/app/assets/stylesheets/trees.scss
@@ -356,7 +356,7 @@
 
     .connections-grid {
       display: grid;
-      grid-template-columns: 10% 10% 13% 67%;
+      grid-template-columns: 10% 10% 13% 30% 37%;
       /* margin-left: -15px;
       margin-right: -15px; */
       border-top: 1px solid black;

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -60,6 +60,7 @@ class ApplicationController < ActionController::Base
     def getSubjectCode
       subp = params['subject'].to_s
       subc = cookies['subject'].to_s
+      subu = current_user.subject1 if current_user.present?
       @subject_code = ''
       validSubjects = []
       Subject.where(:tree_type_id => @treeTypeRec.id).each do |s|
@@ -74,12 +75,15 @@ class ApplicationController < ActionController::Base
         # next default Subject to cookie:
         Rails.logger.debug("app cookie set subject code: param: #{subp} cookie: #{subc}")
         @subject_code = subc
+      elsif validSubjects.include?(subu)
+        Rails.logger.debug("User subject1 set subject code: current_user.subject1: #{subu}")
+        @subject_code = subu
       else
         @subject_code = validSubjects.first
         Rails.logger.debug("app no set subject code: param: #{subp} cookie: #{subc}")
       end
       Rails.logger.debug "app @subject_code: #{@subject_code.inspect}"
-      cookies[:subject] = @subject_code
+      cookies[:subject] = @subject_code if current_user.present?
       Rails.logger.debug "app cookies[:subject]: #{cookies[:subject].inspect}"
     end
 

--- a/app/controllers/trees_controller.rb
+++ b/app/controllers/trees_controller.rb
@@ -879,7 +879,7 @@ class TreesController < ApplicationController
         t.getAllParents.each do |p|
           @parents_by_depth[t.id][p[:depth]] = p if p
           @parents_by_depth["p#{p.id}"]["dims"] = p.dimensions.includes(:dim_trees).group_by(&:dim_code) if (p && p[:depth] != @treeTypeRec[:outcome_depth])
-          @parents_by_depth["p#{p.id}"]["dims"].each { |k,arr| arr.map { |rec| treeKeys << rec.dim_name_key}} if @parents_by_depth["p#{p.id}"]["dims"]
+          @parents_by_depth["p#{p.id}"]["dims"].each { |k,arr| arr.map { |rec| treeKeys << rec.dim_name_key}} if (p && @parents_by_depth["p#{p.id}"]["dims"])
         end
         # get translation key for this item
         treeKeys << t.buildNameKey

--- a/app/controllers/trees_controller.rb
+++ b/app/controllers/trees_controller.rb
@@ -875,6 +875,12 @@ class TreesController < ApplicationController
       end
       Rails.logger.debug("*** treeKeys: #{treeKeys.inspect}")
       @trees.each do |t|
+        @parents_by_depth = Hash.new { |hash, key| hash[key] = {} }
+        t.getAllParents.each do |p|
+          @parents_by_depth[t.id][p[:depth]] = p if p
+          @parents_by_depth["p#{p.id}"]["dims"] = p.dimensions.includes(:dim_trees).group_by(&:dim_code) if (p && p[:depth] != @treeTypeRec[:outcome_depth])
+          @parents_by_depth["p#{p.id}"]["dims"].each { |k,arr| arr.map { |rec| treeKeys << rec.dim_name_key}} if @parents_by_depth["p#{p.id}"]["dims"]
+        end
         # get translation key for this item
         treeKeys << t.buildNameKey
         # get translation key for each sector, big idea and misconception for this item

--- a/app/helpers/translations_helper.rb
+++ b/app/helpers/translations_helper.rb
@@ -11,4 +11,8 @@ module TranslationsHelper
 			return I18n.translate('translations.errors.missing_translation_for_item')
 		end
 	end
+
+	def etcetera(str)
+    return I18n.translate('translations.add_etc', str: str)
+	end
 end

--- a/app/models/tree.rb
+++ b/app/models/tree.rb
@@ -44,7 +44,7 @@ class Tree < BaseRec
   has_many :sector_trees
   has_many :sectors, through: :sector_trees
 
-  has_many :dim_trees
+  has_many :dim_trees, -> {where active: true}
   has_many :dimensions, through: :dim_trees
 
   # does not seem to be working ?

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -12,7 +12,7 @@ class User < BaseRec
   validates :institute_type, presence: true
   validates :institute_name_loc, presence: true
   validates :position_type, presence: true
-  validates :subject1, presence: true
+  # validates :subject1, presence: true
   # validates :subject2, presence: true
   validates :gender, presence: true
   validates :education_level, presence: true

--- a/app/views/trees/_competency_grids_column.html.erb
+++ b/app/views/trees/_competency_grids_column.html.erb
@@ -1,4 +1,4 @@
-<ul class="list-group maint-column">
+<ul class="list-group maint-column col-lg-7 col-auto">
   <li>
     <%= render partial: "maint_filter", locals: {col: "tree"} %>
   </li>
@@ -26,9 +26,9 @@
           end # h[:dimtrees].each do |dt|
           %>
           <div class="related-items-table">
-            <div class="row">
+            <div class="row hide-children">
               <!-- Build competency column -->
-              <div class="col-lg-2 col-11 col-sm-11 comp-col">
+              <div class="col-11 col-sm-11 comp-col">
                 <a href="<%= tree_path(h[:id])%>" title="<%= h[:text] %>"><%= h[:depth_name] %>:
                 <strong><em><%= h[:formatted_code] %></em></strong>
                 </a>

--- a/app/views/trees/show.html.erb
+++ b/app/views/trees/show.html.erb
@@ -8,6 +8,7 @@
   area = component.present? ? component.getParentRec : nil
   active_dim_trees = @tree.dim_trees.where(:active => true)
 %>
+
 <div class='container'>
   <!--  loop through all tree items to display (to display multimle LOs when asked to display detail for higher Level tree item) -->
   <% @tree_items_to_display.each do |tree| %>
@@ -28,19 +29,21 @@
       end
     %>
     <div class='detail-page'>
-      <% parents_by_depth = {}
-        tree.getAllParents.map { |t| parents_by_depth[t.depth - 1] = t if t }
-        parents_by_depth[@treeTypeRec[:outcome_depth]] = tree
+      <%
+        @parents_by_depth[tree.id][@treeTypeRec[:outcome_depth]] = tree
       %>
 
       <!-- Display the translated descriptions of all parents for this item (Grade, Unit, Chapter, Outcome)  -->
-      <% @detail_headers.each do |h| %>
-        <% rec = @parents_by_depth[tree.id][h[:depth]] %>
-        <% if rec %>
+      <% @detailTables.each_with_index do |h,ix| %>
+        <% rec = @parents_by_depth[tree.id][h[:depth]] if h[:type] == 'header' %>
+        <% if rec
+            name_translation = html_safe_translations(@translations[rec.buildNameKey])
+            code_is_transl = name_translation.delete('0-9').length == 0
+          %>
           <div class='row subject-<%= h[:name] %>-row'>
             <div class='col col-6 text-left'>
               <strong>
-              <%= "#{@subjectByCode[tree.subject.code][:name] if h[:depth] == 0 }#{" #{@hierarchies[h[:depth]]} #{rec.codeArray.last}:" if h[:depth] > 0}" %>
+              <%= "#{@subjectByCode[tree.subject.code][:name] if h[:depth] == 0 }#{" #{@hierarchies[h[:depth]]}#{" #{rec.codeArray.last}" if !code_is_transl}:" if h[:depth] > 0}" %>
               <% if h[:depth] > 0 %>
                 </strong>
               <% end %>
@@ -55,35 +58,6 @@
               <% end %>
             </div>
           </div>
-          <% if rec[:depth] < @treeTypeRec[:outcome_depth]
-              parent_dims = @parents_by_depth["p#{rec.id}"]["dims"]
-              # rec.dimensions.includes(:dim_trees).group_by(&:dim_code)
-              if !parent_dims.blank?
-                parent_dims.each do|dim_code, dim_recs|
-                  if dim_code == 'caps'
-          %>
-            <button class="margin-left btn btn-link block show-btn <%= "#{dim_code}-#{rec[:depth]}" %> js-show-hide-control" data-show-selector='.related-items-table.<%= "#{dim_code}-#{rec[:depth]}" %>' data-hide-selector='.show-btn.<%= "#{dim_code}-#{rec[:depth]}" %>'>[  <%= I18n.translate('app.labels.show_indicators', name: @dimTypeTitleByCode[dim_code]) %>]</button>
-            <div class='related-items-table col-8 <%= "#{dim_code}-#{rec[:depth]}" %> hidden' data-parent-resource-depth='<%= rec[:depth] %>'>
-              <div class='row dark-border colorful-header colorful-header-<%= rec[:depth] %> generic-grid generic-grid--cols-1'>
-                <div class='padding-right padding-left'>
-                  <%= "#{@hierarchies[rec[:depth]]} - #{@dimTypeTitleByCode[dim_code]} " %>
-                  <button class="btn btn-link hide-btn pull-right js-show-hide-control" data-hide-selector='.related-items-table.<%= "#{dim_code}-#{rec[:depth]}" %>' data-show-selector='.show-btn.<%= "#{dim_code}-#{rec[:depth]}" %>'>[  <%= I18n.translate('app.labels.hide_indicators', name: @dimTypeTitleByCode[dim_code]) %>]</button>
-                </div>
-              </div>
-                <% dim_recs.each do |drec|
-                    dt = drec.dim_trees.group_by(&:tree_id)[rec.id][0]
-                %>
-                <%= render partial: "trees/show/dimtree", locals: {
-                    details: dt,
-                    can_edit: can_edit_type?(dim_code) || current_user.subject_admin?(@subject_code),
-                    category_codes: nil
-                } %>
-            <% end # dim_recs.each do |drec| %>
-               </div>
-          <%   end #if dim_code == 'caps'
-              end # parent_dims.each do|dim_code, dim_recs|
-            end # if !parent_dims.blank?
-          end # if rec[:depth] < @treeTypeRec[:outcome_depth] %>
         <% elsif h[:name] == 'weeks' || h[:name] == 'hours' %>
           <div class='row subject-<%= h[:name] %>-row'>
             <div class='col col-6 text-left'>
@@ -97,6 +71,25 @@
               <%= link_to(fa_icon("edit"), edit_tree_path(tree.id, tree: { edit_type: h[:name]}), {:remote => true, 'data-toggle' =>  "modal", 'data-target' => '#modal_popup'}) if @editMe && (can_edit_type?(h[:name]) || current_user.subject_admin?(@subject_code)) %>
             </div>
           </div>
+        <% elsif h[:type] == 'parent_detail'
+            title, code, type, action, cats = h[:title_code_type_action_catsArr][0]
+        %>
+          <%=
+            render partial: "trees/show/#{h[:partial]}", locals: {
+              num_cols: h[:num_cols],
+              num_rows: h[:num_rows],
+              title_code_type_action_catsArr: h[:title_code_type_action_catsArr],
+              detailsHash: @detailsHash,
+              can_edit: can_edit_type?(type) || current_user.subject_admin?(@subject_code),
+              detail_title: title,
+              tree: @tree,
+              indicator: h[:indicator],
+              resource_codes: cats,
+              parents: (h[:depth] ? [@parents_by_depth[tree.id][h[:depth]]] : nil) ,
+              table_depth: h[:depth],
+              table_code: "table#{ix}"
+            }
+          %>
         <% end #if rec %>
       <% end #@detail_headers.each_with_index do |h, i| %>
 
@@ -112,7 +105,8 @@
 
 
         <% @detailTables.each do |table|
-          title, code, type, action, cats = table[:title_code_type_action_catsArr][0]
+          title, code, type, action, cats = table[:title_code_type_action_catsArr][0] if table[:type] == 'tree_detail'
+          puts "tableINSPECT: #{table.inspect}"
           %>
           <%=
             render partial: "trees/show/#{table[:partial]}", locals: {
@@ -125,8 +119,10 @@
               tree: @tree,
               indicator: table[:indicator],
               resource_codes: cats,
-              parents: (table[:depths].length > 0 ? table[:depths].map { |d| parents_by_depth[d]} : nil) ,
-            }
+              parents: (table[:depths].length > 0 ? table[:depths].map { |d| @parents_by_depth[tree.id][d]} : nil) ,
+              table_depth: table[:depth],
+              table_code: nil
+            } if table[:type] == 'tree_detail'
           %>
         <% end %>
 

--- a/app/views/trees/show.html.erb
+++ b/app/views/trees/show.html.erb
@@ -35,7 +35,7 @@
 
       <!-- Display the translated descriptions of all parents for this item (Grade, Unit, Chapter, Outcome)  -->
       <% @detail_headers.each do |h| %>
-        <% rec = parents_by_depth[h[:depth]] %>
+        <% rec = @parents_by_depth[tree.id][h[:depth]] %>
         <% if rec %>
           <div class='row subject-<%= h[:name] %>-row'>
             <div class='col col-6 text-left'>
@@ -55,6 +55,35 @@
               <% end %>
             </div>
           </div>
+          <% if rec[:depth] < @treeTypeRec[:outcome_depth]
+              parent_dims = @parents_by_depth["p#{rec.id}"]["dims"]
+              # rec.dimensions.includes(:dim_trees).group_by(&:dim_code)
+              if !parent_dims.blank?
+                parent_dims.each do|dim_code, dim_recs|
+                  if dim_code == 'caps'
+          %>
+            <button class="margin-left btn btn-link block show-btn <%= "#{dim_code}-#{rec[:depth]}" %> js-show-hide-control" data-show-selector='.related-items-table.<%= "#{dim_code}-#{rec[:depth]}" %>' data-hide-selector='.show-btn.<%= "#{dim_code}-#{rec[:depth]}" %>'>[  <%= I18n.translate('app.labels.show_indicators', name: @dimTypeTitleByCode[dim_code]) %>]</button>
+            <div class='related-items-table col-8 <%= "#{dim_code}-#{rec[:depth]}" %> hidden' data-parent-resource-depth='<%= rec[:depth] %>'>
+              <div class='row dark-border colorful-header colorful-header-<%= rec[:depth] %> generic-grid generic-grid--cols-1'>
+                <div class='padding-right padding-left'>
+                  <%= "#{@hierarchies[rec[:depth]]} - #{@dimTypeTitleByCode[dim_code]} " %>
+                  <button class="btn btn-link hide-btn pull-right js-show-hide-control" data-hide-selector='.related-items-table.<%= "#{dim_code}-#{rec[:depth]}" %>' data-show-selector='.show-btn.<%= "#{dim_code}-#{rec[:depth]}" %>'>[  <%= I18n.translate('app.labels.hide_indicators', name: @dimTypeTitleByCode[dim_code]) %>]</button>
+                </div>
+              </div>
+                <% dim_recs.each do |drec|
+                    dt = drec.dim_trees.group_by(&:tree_id)[rec.id][0]
+                %>
+                <%= render partial: "trees/show/dimtree", locals: {
+                    details: dt,
+                    can_edit: can_edit_type?(dim_code) || current_user.subject_admin?(@subject_code),
+                    category_codes: nil
+                } %>
+            <% end # dim_recs.each do |drec| %>
+               </div>
+          <%   end #if dim_code == 'caps'
+              end # parent_dims.each do|dim_code, dim_recs|
+            end # if !parent_dims.blank?
+          end # if rec[:depth] < @treeTypeRec[:outcome_depth] %>
         <% elsif h[:name] == 'weeks' || h[:name] == 'hours' %>
           <div class='row subject-<%= h[:name] %>-row'>
             <div class='col col-6 text-left'>

--- a/app/views/trees/show/_dimtree.html.erb
+++ b/app/views/trees/show/_dimtree.html.erb
@@ -1,6 +1,6 @@
 <!-- Dimensions Table (e.g., misconceptions, etc) -->
 <% dt = details
-   d = dt.dimension if dt
+   d = (dt.dimension || dt[:dimension]) if dt
 %>
 <div class="dark-border--left <%= @editMe && can_edit ? "generic-grid generic-grid--xl-xs" : "" %>">
   <div class="padding-left padding-right padding-top padding-bottom">

--- a/app/views/trees/show/_evenly_spaced_details.html.erb
+++ b/app/views/trees/show/_evenly_spaced_details.html.erb
@@ -1,6 +1,14 @@
 <% detail_order = [] %>
-<div class='related-items-table'>
-  <div class='row center-label-bold top-label generic-grid generic-grid--cols-<%= num_cols %>'>
+<% if table_depth
+  detail_title, detail_code, edit_type, action, category_arr = title_code_type_action_catsArr[0]
+  table_name = detail_title.length > 0 ? detail_title : get_category_title(category_arr[0], detail_code)
+  table_code = "#{table_name.downcase.gsub(" ", "")}-#{table_depth}"
+  table_name = "#{etcetera(table_name)}" if title_code_type_action_catsArr.length > 1
+%>
+   <button class="margin-left btn btn-link block show-btn <%= table_code %> js-show-hide-control" data-show-selector='.related-items-table.<%= table_code %>' data-hide-selector='.show-btn.<%= table_code %>'>[  <%= I18n.translate('app.labels.show_indicators', name: table_name) %>]</button>
+<% end %>
+<div class='related-items-table<%= table_name ? " hidden #{table_code} col-8" : "" %>'>
+  <div class='row <%= table_name ? "colorful-header colorful-header-#{table_depth}" : "center-label-bold top-label" %> generic-grid generic-grid--cols-<%= num_cols %>'>
     <% title_code_type_action_catsArr.each do |arr|
       detail_title, detail_code, edit_type, action, category_arr = arr
       detail_order << detail_code
@@ -10,34 +18,20 @@
         <%= detail_title %>
         <%= link_to(fa_icon("plus-square"), edit_tree_path(@tree.id, tree: { edit_type: edit_type, attr_id: 'new'}), {:remote => true, :class => "fa-lg pull-right", 'data-toggle' =>  "modal", 'data-target' => '#modal_popup'}) if @editMe && (action == 'create') && can_edit
          %>
+         <% if table_depth %>
+            <button class="margin-left btn btn-link hide-btn <%= table_code %> js-show-hide-control" data-hide-selector='.related-items-table.<%= table_code %>' data-show-selector='.show-btn.<%= table_code %>'>[  <%= I18n.translate('app.labels.hide_indicators', name: table_name) %>]</button>
+          <% end %>
       </div>
       <% end %>
       <% if category_arr
         category_arr.each do |cat|
-          category_title = Outcome.get_resource_name(
-            Outcome::RESOURCE_TYPES[cat.to_i],
-            @treeTypeRec.code,
-            @versionRec.code,
-            @locale_code) if @editTypes[detail_code][:name] == "resource"
-          category_title = Translation.find_translation_name(
-              @locale_code,
-              Tree.get_resource_type_key(
-                Tree::RESOURCE_TYPES[cat.to_i],
-                @treeTypeRec.code,
-                @versionRec.code
-              ),
-              Tree::RESOURCE_TYPES[cat.to_i]
-            )  if @editTypes[detail_code][:name] == "tree_resource"
-
-          category_title = Dimension.get_resource_name(
-            Dimension::RESOURCE_TYPES[cat.to_i],
-            @treeTypeRec.code,
-            @versionRec.code,
-            @locale_code,
-            Dimension::RESOURCE_TYPES[cat.to_i]) if @editTypes[detail_code][:name] == "dimtree"
+          category_title = get_category_title(cat, detail_code)
       %>
         <div class='dark-border--left padding-right padding-left'>
           <%= "#{detail_title.length > 0 ? "#{detail_title}: " : ""}#{category_title}" %>
+          <% if table_depth %>
+            <button class="margin-left btn btn-link hide-btn <%= table_code %> js-show-hide-control" data-hide-selector='.related-items-table.<%= table_code %>' data-show-selector='.show-btn.<%= table_code %>'>[  <%= I18n.translate('app.labels.hide_indicators', name: category_title) %>]</button>
+          <% end %>
         </div>
       <%  end # category_codes.each do |code|
          end # if category_codes %>
@@ -50,7 +44,9 @@
       <div class='dark-border generic-grid generic-grid--cols-<%= num_cols %>'>
         <% detail_order.each do |detail_code| %>
             <%
-              detail = @detailsHash[detail_code][ix] if detailsHash[detail_code]
+              parent = parents[ix]
+              detail = @detailsHash[detail_code][ix] if (detailsHash[detail_code] && !parent)
+              detail = @parents_by_depth["p#{parents[ix].id}"]["dims"][detail_code][0].dim_trees.group_by(&:tree_id)[parent.id][0] if parent && @parents_by_depth["p#{parents[ix].id}"]["dims"][detail_code]
               partial_path = "/trees/show/#{@editTypes[detail_code][:name]}"
             %>
             <%=

--- a/app/views/trees/show/_treetree.html.erb
+++ b/app/views/trees/show/_treetree.html.erb
@@ -31,6 +31,11 @@
         <%= I18n.t('app.labels.description') %>
       </div>
     </div>
+    <div class='connections-header'>
+      <div class='center-label sub-header-margin'>
+        <%= I18n.t('app.labels.alluvial') %>
+      </div>
+    </div>
   </div>
   <div class='connections-grid'>
     <% connectionsFound = 0 %>
@@ -60,6 +65,8 @@
         </div>
       <% end %>
     <% end %>
+    <div class='connections-item rel-sectors'>
+    </div>
     <% if connectionsFound == 0 %>
         <div class='connections-item rel-sectors'>
         </div>

--- a/app/views/users/_form_other.html.erb
+++ b/app/views/users/_form_other.html.erb
@@ -156,8 +156,12 @@
       <%= form.label :subject1 %>
     </span>
     <span class='col col-md-8 input-col'>
-      <span class='required'>*</span>
-      <%= form.text_field :subject1 %>
+      <span class='required'>&nbsp;</span>
+      <%=
+      form.select :subject1,
+        Subject.where(tree_type_id: @treeTypeRec.id).map { |rec| [rec.get_name(@locale_code), rec.code] },
+        { include_blank: true, :selected => @user.subject1 }
+      %>
       <% if @user.errors.present? && @user.errors[:subject1].present? %>
         <span class='ui-error'><%= @user.errors[:subject1].join(', ') %></span>
       <% end %>
@@ -174,7 +178,11 @@
     </span>
     <span class='col col-md-8 input-col'>
       <span class='required'>&nbsp;</span>
-      <%= form.text_field :subject2 %>
+      <%=
+      form.select :subject2,
+        Subject.where(tree_type_id: @treeTypeRec.id).map { |rec| [rec.get_name(@locale_code), rec.code] },
+        { include_blank: true, :selected => @user.subject2 }
+      %>
       <% if @user.errors.present? && @user.errors[:subject2].present? %>
         <span class='ui-error'><%= @user.errors[:subject2].join(', ') %></span>
       <% end %>

--- a/config/locales/pages.ar_EG.yml
+++ b/config/locales/pages.ar_EG.yml
@@ -8,6 +8,7 @@ ar_EG:
     title: "موقع المناهج"
     labels:
       all: "الكل"
+      alluvial: "مخطط رسوبي"
       save: "حفظ"
       cancel: "إلغاء"
       submit: "إرسال"

--- a/config/locales/pages.ar_EG.yml
+++ b/config/locales/pages.ar_EG.yml
@@ -57,7 +57,7 @@ ar_EG:
       working_version: "العمل"
       final_version: "نهائي"
       connect_form_title: "حفظ الاتصال؟"
-      show_details: "اظهر التفاصيل"
+      show_details: "اظهر الخطوط"
       last_updated: "Last updated at: %{time}"
       print: "طباعة"
     roles:

--- a/config/locales/pages.ar_EG.yml
+++ b/config/locales/pages.ar_EG.yml
@@ -182,6 +182,7 @@ ar_EG:
       locale: "لغة"
       key: "مفتاح"
       value: "القيمة"
+    add_etc: "%{str} وما إلى ذلك"
     errors:
       missing_translations_locale_code: "ترجمات مفقودة للغة: %{locale}، الرمز: %{code}"
       missing_translation_for_item: "ترجمة مفقودة للعنصر"

--- a/config/locales/pages.en.yml
+++ b/config/locales/pages.en.yml
@@ -60,7 +60,7 @@ en:
       working_version: "Working"
       final_version: "Final"
       connect_form_title: "Save Connection?"
-      show_details: "Show Details"
+      show_details: "Show Grid"
       last_updated: "Last updated at: %{time}"
       print: "Print"
     roles:

--- a/config/locales/pages.en.yml
+++ b/config/locales/pages.en.yml
@@ -9,6 +9,7 @@ en:
     title: "Curriculum Website"
     labels:
       all: "All"
+      alluvial: "Alluvial Diagram"
       save: "Save"
       cancel: "Cancel"
       submit: "Submit"

--- a/config/locales/pages.en.yml
+++ b/config/locales/pages.en.yml
@@ -185,6 +185,7 @@ en:
       locale: "Locale"
       key: "Key"
       value: "Value"
+    add_etc: "%{str} & etc."
     errors:
       missing_translations_locale_code: "missing translations for locale: %{locale}, code: %{code}"
       missing_translation_for_item: "missing translation for item"

--- a/config/locales/pages.tr.yml
+++ b/config/locales/pages.tr.yml
@@ -4,6 +4,7 @@ tr:
     title: "Mektebim STEM Ana Sayfa"
     labels:
       all: "Her Sey"
+      alluvial: "Alüvyal Diyagram"
       save: "Save"
       cancel: "Cancel"
       submit: "Submit"

--- a/config/locales/pages.tr.yml
+++ b/config/locales/pages.tr.yml
@@ -139,5 +139,6 @@ tr:
     labels:
       explanation: "Açıklama"
   translations:
+    add_etc: "%{str} & vb."
     errors:
       missing_translations_locale_code: "locale için eksik çeviriler: %{locale}, kod: %{code}"

--- a/config/locales/pages.tr.yml
+++ b/config/locales/pages.tr.yml
@@ -36,6 +36,7 @@ tr:
       upload_new: 'Yükleme Ekle ve Yap'
       explanation: "Açıklama"
       sector_num: "Sektör %{num}"
+      show_details: "Izgarayı göster"
       last_updated: "Last updated at: %{time}"
       print: "Yazdır"
       errors:

--- a/lib/tasks/seed_stessa_1.rake
+++ b/lib/tasks/seed_stessa_1.rake
@@ -41,11 +41,12 @@ namespace :seed_eg_stem do
       #
       # Detail headers notation key:
       #   item - HEADER
-      #   [item] - TABLE item, dimension.
-      #   {resource#n} - TABLE item, outcome resource translation
+      #   [r#item] - TABLE item, outcome level connected dimension.
+      #   {r#n} - TABLE item, outcome resource translation
       #   <item> - TABLE item, sectors
       #   +item+ - TABLE item, treetrees
-      #   {item#n#...} - TABLE item collection, multiple outcome resource translations
+      #   {depthCode#n#...} - TABLE item collection, multiple resource translations for tree at the given depth
+      #                     - depthCode should be 'o' for outcome resources
       #                     - unit#n =lookup in Tree::RESOURCE_TYPES, else lookup in Outcome::RESOURCE_TYPES
       #   {resources#n#...} - TABLE item, full width of table,
       #                  with numeric codes identifying which
@@ -53,7 +54,8 @@ namespace :seed_eg_stem do
       #                  e.g., may use indexes in the
       #                  Outcome::RESOURCE_TYPES array.
       #   tableItem_tableItem_... - up to 4 columns table items allowed in one row.
-      detail_headers: 'grade,sem,unit,lo,[bigidea],{resource#6},[miscon],<sector>,+treetree+,{resources#0#1#2#3#4#5}',
+      #   To Do: standards header on top RIGHT of the show page.
+      detail_headers: 'grade,sem,unit,lo,[o#bigidea],{o#6},[o#miscon],<sector>,+treetree+,{resources#0#1#2#3#4#5}',
       grid_headers: 'grade,unit,lo,[bigidea],[miscon]',
       #Display codes are zero-relative indexes in Dimension::RESOURCE_TYPES
       #Dimensions must appear in this string to have a show page

--- a/lib/tasks/seed_stessa_2.rake
+++ b/lib/tasks/seed_stessa_2.rake
@@ -46,11 +46,12 @@ namespace :seed_stessa_2 do
       #
       # Detail headers notation key:
       #   item - HEADER
-      #   [item] - TABLE item, dimension.
-      #   {resource#n} - TABLE item, outcome resource translation
+      #   [r#item] - TABLE item, outcome level connected dimension.
+      #   {r#n} - TABLE item, outcome resource translation
       #   <item> - TABLE item, sectors
       #   +item+ - TABLE item, treetrees
-      #   {item#n#...} - TABLE item collection, multiple outcome resource translations
+      #   {depthCode#n#...} - TABLE item collection, multiple resource translations for tree at the given depth
+      #                     - depthCode should be 'o' for outcome resources
       #                     - unit#n =lookup in Tree::RESOURCE_TYPES, else lookup in Outcome::RESOURCE_TYPES
       #   {resources#n#...} - TABLE item, full width of table,
       #                  with numeric codes identifying which
@@ -59,7 +60,7 @@ namespace :seed_stessa_2 do
       #                  Outcome::RESOURCE_TYPES array.
       #   tableItem_tableItem_... - up to 4 columns table items allowed in one row.
       #   To Do: standards header on top RIGHT of the show page.
-      detail_headers: 'grade,sem,unit,lo,weeks,hours,{resource#6},<sector>_[bigidea]_[essq],{sem#3}_{grade#0}_{unit#2},[miscon#2#1],[concept]_[skill],{resource#7},{resource#8},[standardeg],+treetree+,{resources#12#3#2#11#10#9}',
+      detail_headers: 'grade,{grade#0},sem,{sem#4}_{sem#3},[sem#caps],unit,{unit#2},lo,weeks,hours,{o#6},<sector>_[o#bigidea]_[o#essq],[o#miscon#2#1],[o#concept]_[o#skill],{o#7},{o#8},[o#standardeg],+treetree+,{resources#12#3#2#11#10#9}',
       grid_headers: 'grade,unit,lo,[bigidea],[essq],[concept],[skill],[miscon]',
       #Display codes are zero-relative indexes in Dimension::RESOURCE_TYPES
       #Dimensions must appear in this string to have a show page

--- a/lib/tasks/seed_stessa_2.rake
+++ b/lib/tasks/seed_stessa_2.rake
@@ -59,7 +59,7 @@ namespace :seed_stessa_2 do
       #                  Outcome::RESOURCE_TYPES array.
       #   tableItem_tableItem_... - up to 4 columns table items allowed in one row.
       #   To Do: standards header on top RIGHT of the show page.
-      detail_headers: 'grade,sem,unit,lo,weeks,hours,{resource#6},<sector>_[bigidea]_[essq],{sem#3}_{grade#0}_{unit#2},[miscon#2#1],[concept]_[skill],{resource#7},[caps],{resource#8},[standardeg],+treetree+,{resources#12#3#2#11#10#9}',
+      detail_headers: 'grade,sem,unit,lo,weeks,hours,{resource#6},<sector>_[bigidea]_[essq],{sem#3}_{grade#0}_{unit#2},[miscon#2#1],[concept]_[skill],{resource#7},{resource#8},[standardeg],+treetree+,{resources#12#3#2#11#10#9}',
       grid_headers: 'grade,unit,lo,[bigidea],[essq],[concept],[skill],[miscon]',
       #Display codes are zero-relative indexes in Dimension::RESOURCE_TYPES
       #Dimensions must appear in this string to have a show page

--- a/lib/tasks/seed_stessa_2.rake
+++ b/lib/tasks/seed_stessa_2.rake
@@ -60,7 +60,7 @@ namespace :seed_stessa_2 do
       #                  Outcome::RESOURCE_TYPES array.
       #   tableItem_tableItem_... - up to 4 columns table items allowed in one row.
       #   To Do: standards header on top RIGHT of the show page.
-      detail_headers: 'grade,{grade#0},sem,{sem#4}_{sem#3},[sem#caps],unit,{unit#2},lo,weeks,hours,{o#6},<sector>_[o#bigidea]_[o#essq],[o#miscon#2#1],[o#concept]_[o#skill],{o#7},{o#8},[o#standardeg],+treetree+,{resources#12#3#2#11#10#9}',
+      detail_headers: 'grade,{grade#0},sem,{sem#4},{sem#3},[sem#caps],unit,{unit#2},lo,weeks,hours,{o#6},<sector>_[o#bigidea]_[o#essq],[o#miscon#2#1],[o#concept]_[o#skill],{o#7},{o#8},[o#standardeg],+treetree+,{resources#12#3#2#11#10#9}',
       grid_headers: 'grade,unit,lo,[bigidea],[essq],[concept],[skill],[miscon]',
       #Display codes are zero-relative indexes in Dimension::RESOURCE_TYPES
       #Dimensions must appear in this string to have a show page

--- a/lib/tasks/seed_turkey_v02.rake
+++ b/lib/tasks/seed_turkey_v02.rake
@@ -40,23 +40,26 @@ namespace :seed_turkey_v02 do
       tree_code_format: 'subject,grade,unit,subunit,comp',
       # To Do: Write documentation on obtaining translation keys
       # - for dimension translation use dim.get_dim_resource_key
-      #
-      # Detail headers notation key:
       # NOTE: Please avoid underscores (_) and commas (,)
       #       in item names.
-      #   item - HEADER item
-      #   [item] - TABLE item, dimension.
-      #   {resource#n} - TABLE item, outcome resource translation
-      #   <item> - TABLE item, sector
-      #   +item+ - TABLE item, treetree
-      #   {item#n#...} - TABLE item collection, multiple outcome resource translations
+      #
+      # Detail headers notation key:
+      #   item - HEADER
+      #   [r#item] - TABLE item, outcome level connected dimension.
+      #   {r#n} - TABLE item, outcome resource translation
+      #   <item> - TABLE item, sectors
+      #   +item+ - TABLE item, treetrees
+      #   {depthCode#n#...} - TABLE item collection, multiple resource translations for tree at the given depth
+      #                     - depthCode should be 'o' for outcome resources
+      #                     - unit#n =lookup in Tree::RESOURCE_TYPES, else lookup in Outcome::RESOURCE_TYPES
       #   {resources#n#...} - TABLE item, full width of table,
       #                  with numeric codes identifying which
       #                  categories of this item to display.
       #                  e.g., may use indexes in the
       #                  Outcome::RESOURCE_TYPES array.
       #   tableItem_tableItem_... - up to 4 columns table items allowed in one row.
-      detail_headers: 'grade,unit,subunit,comp,[bigidea]_[essq],[pract],{resource#6},[miscon#2#1],<sector>,+treetree+,{resources#0#1#2#3#4#5}',
+      #   To Do: standards header on top RIGHT of the show page.
+      detail_headers: 'grade,unit,subunit,comp,[o#bigidea]_[o#essq],[o#pract],{o#6},[o#miscon#2#1],<sector>,+treetree+,{resources#0#1#2#3#4#5}',
       # Grid headers notation key:
       # item or (item) - Ignored for now
       # [item] - grid column, may have multiple connected items


### PR DESCRIPTION
- Default @subject_code should now be current_user.subject1, if defined. 
- Subject Teaching' fields are dropdowns in the user add/edit form.
- Show expandable/collapsable parent resources on the outcome detail page
- Show placeholder for alluvial diagram on the Tree Detail page (to be added to the treetree/connected outcomes table).