### PR TITLE
Fix Connectioned LOs Table Layout, and add plot.ly alluvial diagram

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -89,6 +89,8 @@ GEM
     coffee-script-source (1.12.2)
     concurrent-ruby (1.1.5)
     crass (1.0.5)
+    d3-rails (5.9.2)
+      railties (>= 3.1)
     devise (4.7.1)
       bcrypt (~> 3.0)
       orm_adapter (~> 0.1)
@@ -269,6 +271,7 @@ DEPENDENCIES
   chromedriver-helper
   ckeditor (= 5.1.0)
   coffee-rails (~> 4.2)
+  d3-rails
   devise (~> 4.7.1)
   devise-i18n
   factory_bot_rails

--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -330,3 +330,8 @@ form {
     margin: 0 auto;
   }
 }
+
+#js-alluvial-container {
+  width: 95%;
+  height: 95%;
+}

--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -331,7 +331,4 @@ form {
   }
 }
 
-#js-alluvial-container {
-  width: 95%;
-  height: 95%;
-}
+.min-alluvial-height { min-height: 300px; }

--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -349,4 +349,5 @@ form {
     .link:hover {
       stroke-opacity: .5;
     }
+    .modebar { display: none; }
 }

--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -330,24 +330,3 @@ form {
     margin: 0 auto;
   }
 }
-
-.js-alluvial {
-   .node rect {
-      cursor: move;
-      fill-opacity: .9;
-      shape-rendering: crispEdges;
-    }
-    .node text {
-      pointer-events: none;
-      text-shadow: 0 1px 0 #fff;
-    }
-    .link {
-      fill: none;
-      stroke: #000;
-      stroke-opacity: .2;
-    }
-    .link:hover {
-      stroke-opacity: .5;
-    }
-    .modebar { display: none; }
-}

--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -330,3 +330,23 @@ form {
     margin: 0 auto;
   }
 }
+
+.js-alluvial {
+   .node rect {
+      cursor: move;
+      fill-opacity: .9;
+      shape-rendering: crispEdges;
+    }
+    .node text {
+      pointer-events: none;
+      text-shadow: 0 1px 0 #fff;
+    }
+    .link {
+      fill: none;
+      stroke: #000;
+      stroke-opacity: .2;
+    }
+    .link:hover {
+      stroke-opacity: .5;
+    }
+}

--- a/app/assets/stylesheets/trees.scss
+++ b/app/assets/stylesheets/trees.scss
@@ -356,11 +356,16 @@
 
     .connections-grid {
       display: grid;
-      grid-template-columns: 10% 10% 13% 30% 37%;
+      width: 63%;
+      grid-template-columns: 16% 16% 12% 56%;
       /* margin-left: -15px;
       margin-right: -15px; */
       border-top: 1px solid black;
       border-right: 1px solid black;
+      &.connections-grid__diagram {
+        width: 37%;
+        grid-template-columns: 100%;
+      }
     }
     .connections-header {
       border-bottom: 1px solid black;

--- a/app/controllers/trees_controller.rb
+++ b/app/controllers/trees_controller.rb
@@ -909,6 +909,7 @@ class TreesController < ApplicationController
           @relatedBySubj[subCode] << {
             code: rTree.format_code(@locale_code),
             relationship: I18n.translate("trees.labels.relation_types.#{r.relationship}"),
+            rel_code: r.relationship,
             tkey: rTree.buildNameKey,
             subj: rTree.subject.get_name(@locale_code),
            # explanation: r.explanation_key,

--- a/app/controllers/trees_controller.rb
+++ b/app/controllers/trees_controller.rb
@@ -1,7 +1,7 @@
 class TreesController < ApplicationController
 
   before_action :authenticate_user!
-  before_action :find_tree, only: [:show, :show_outcome, :edit, :update]
+  before_action :find_tree, only: [:show, :show_outcome, :edit, :update, :deactivate]
   after_action -> {flash.discard}, only: [:maint]
 
   def index
@@ -1088,6 +1088,14 @@ class TreesController < ApplicationController
     )
     respond_to do |format|
       format.json {render json: {tree_codes_changed: tree_codes_changed}}
+    end
+  end
+
+  def deactivate
+    #puts "Tree to deactivate: #{@tree.inspect}"
+    @tree_codes_changed = @tree.deactivate_and_recode(@locale_code)
+    respond_to do |format|
+      format.js
     end
   end
 

--- a/app/controllers/trees_controller.rb
+++ b/app/controllers/trees_controller.rb
@@ -903,6 +903,7 @@ class TreesController < ApplicationController
         # get translation key for each related item for this item
         t.tree_referencers.each do |r|
           rTree = r.tree_referencee
+          rTreeSubj = rTree.subject
           treeKeys << rTree.buildNameKey
           treeKeys << r.explanation_key
           subCode = @subjById[rTree.subject_id]
@@ -910,8 +911,9 @@ class TreesController < ApplicationController
             code: rTree.format_code(@locale_code),
             relationship: I18n.translate("trees.labels.relation_types.#{r.relationship}"),
             rel_code: r.relationship,
+            subj_code: rTreeSubj.code,
             tkey: rTree.buildNameKey,
-            subj: rTree.subject.get_name(@locale_code),
+            subj: rTreeSubj.get_name(@locale_code),
            # explanation: r.explanation_key,
             tid: (rTree.depth < 2) ? 0 : rTree.id,
             ttid: r.id

--- a/app/controllers/uploads_controller.rb
+++ b/app/controllers/uploads_controller.rb
@@ -210,7 +210,7 @@ class UploadsController < ApplicationController
     # hash of the existing records for this TreeType (curriculum) and subject
     #
     @currentRecs = Hash.new{ |h, k| h[k] = {} }
-    currentCodeRecs = Tree.where(tree_type_id: @treeTypeRec.id, version_id: @versionRec.id, subject_id: @subjectRec.id)
+    currentCodeRecs = Tree.active.where(tree_type_id: @treeTypeRec.id, version_id: @versionRec.id, subject_id: @subjectRec.id)
     currentCodeRecs.each do |rec|
       transl_names = Translation.where(locale: @locale_code, key: "#{rec.base_key}.name")
       if transl_names.count > 0

--- a/app/models/base_rec.rb
+++ b/app/models/base_rec.rb
@@ -52,6 +52,24 @@ class BaseRec < ActiveRecord::Base
     'ara', #Arabic
     'art', #Art
   ]
+  SUBJECT_COLORS = [
+    '#E5FFDE',
+    '#009FFD',
+    '#FCAF58',
+    '#DBCBD8',
+    '#DBCBD8',
+    '#564787',
+    '#564787',
+    '#F26DF9',
+    '#F5EE9E',
+    '#A2E8DD',
+    '#A85751',
+    '#2CA58D',
+    '#9DC5BB',
+    '#414535',
+    '#EDD2E0',
+    '#6F9CEB'
+  ]
 
   # BASE_PRACTICES = [
   #   'stem', #Science And Engineering Practices
@@ -87,5 +105,8 @@ class BaseRec < ActiveRecord::Base
     return ret
   end
 
+  def self.subject_color(subject_code)
+    return SUBJECT_COLORS[BASE_SUBJECTS.index(subject_code)]
+  end
 
 end

--- a/app/models/tree.rb
+++ b/app/models/tree.rb
@@ -595,7 +595,8 @@ class Tree < BaseRec
       end
       last_tree_depth = t[:depth]
       code_arr = []
-      [*0..t[:depth]].each { |d| code_arr << (codes_counter_by_depth[d] == nil ? '' : format('%02d', codes_counter_by_depth[d])) }
+      code_arr << gb_by_id_and_min_grade["min#{codes_counter_by_depth[0]}"].code
+      [*1..t[:depth]].each { |d| code_arr << (codes_counter_by_depth[d] == nil ? '' : format('%02d', codes_counter_by_depth[d])) }
       new_code = code_arr.join(".")
       #puts "codes_counter_by_depth: #{codes_counter_by_depth.inspect}"
       ############

--- a/app/models/tree.rb
+++ b/app/models/tree.rb
@@ -683,21 +683,22 @@ class Tree < BaseRec
     end
   end
 
-  def deactivate_and_recode(locale_code = "en")
+  def deactivate_and_recode(localeCode = "en")
     translations_hash = {}
     translation_keys = []
     old_name_key = name_key
+    self.active = false
     #update tree code and base_key
-    code = "XtreeidX#{id}"
-    base_key = Tree.buildBaseKey(
-      tree_type_code,
+    self.code = "XtreeidX#{id}"
+    self.base_key = Tree.buildBaseKey(
+      tree_type.code,
       version.code,
       subject.code,
       code
     )
     #generate name key from new base_key
     new_name_key = name_key
-    active = false
+    translation_keys << old_name_key
     translations_hash[old_name_key] = new_name_key
     if outcome_id
       old_translation_keys = outcome.list_translation_keys
@@ -711,6 +712,7 @@ class Tree < BaseRec
     translationRecs = Translation.where(:key => translation_keys)
     translationRecs.each { |tr| tr.key = translations_hash[tr.key] }
 
+    #puts "trying to update, should have deactivated vals: #{inspect}"
     ##########################
     # Update deactivated tree, any associated outcome, and any
     # associated translations
@@ -719,8 +721,11 @@ class Tree < BaseRec
       outcome.save! if outcome_id
       translationRecs.each { |t| t.save! }
     end
+   # puts "tree updated: #{inspect}"
     idOrderArr = Tree.active.where(:subject_id => subject_id).order('sort_order').pluck('id')
-    Tree.update_code_sequence(idOrderArr, localeCode)
+    ret = Tree.update_code_sequence(idOrderArr, localeCode)
+   # puts "return obj: #{ret.inspect}"
+    return ret
   end
 
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -6,11 +6,9 @@
 
     <%= stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track': 'reload' %>
     <%= javascript_include_tag Ckeditor.cdn_url %>
-    <script src="https://code.highcharts.com/8.1.2/highcharts.js"></script>
-    <script src="https://code.highcharts.com/8.1.2/modules/sankey.js"></script>
-    <script src="https://code.highcharts.com/8.1.2/modules/exporting.js"></script>
-    <script src="https://code.highcharts.com/8.1.2/modules/export-data.js"></script>
-    <script src="https://code.highcharts.com/8.1.2/modules/accessibility.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/d3/3.5.6/d3.js"></script>
+    <script src="https://rawgit.com/d3/d3-plugins/master/sankey/sankey.js"></script>
+    <script src="https://cdn.plot.ly/plotly-1.54.3.min.js"></script>
     <%= javascript_include_tag 'application', 'data-turbolinks-track': 'reload' %>
     <meta name="viewport" content="width=device-width, initial-scale=1">
   </head>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -6,9 +6,8 @@
 
     <%= stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track': 'reload' %>
     <%= javascript_include_tag Ckeditor.cdn_url %>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/d3/3.5.6/d3.js"></script>
-    <script src="https://rawgit.com/d3/d3-plugins/master/sankey/sankey.js"></script>
-    <script src="https://cdn.plot.ly/plotly-1.54.3.min.js"></script>
+    <%= javascript_include_tag "https://cdn.plot.ly/plotly-1.54.3.min.js" %>
+
     <%= javascript_include_tag 'application', 'data-turbolinks-track': 'reload' %>
     <meta name="viewport" content="width=device-width, initial-scale=1">
   </head>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -6,6 +6,11 @@
 
     <%= stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track': 'reload' %>
     <%= javascript_include_tag Ckeditor.cdn_url %>
+    <script src="https://code.highcharts.com/8.1.2/highcharts.js"></script>
+    <script src="https://code.highcharts.com/8.1.2/modules/sankey.js"></script>
+    <script src="https://code.highcharts.com/8.1.2/modules/exporting.js"></script>
+    <script src="https://code.highcharts.com/8.1.2/modules/export-data.js"></script>
+    <script src="https://code.highcharts.com/8.1.2/modules/accessibility.js"></script>
     <%= javascript_include_tag 'application', 'data-turbolinks-track': 'reload' %>
     <meta name="viewport" content="width=device-width, initial-scale=1">
   </head>

--- a/app/views/trees/_competencies_column.html.erb
+++ b/app/views/trees/_competencies_column.html.erb
@@ -41,6 +41,7 @@
         <% if @editing %>
         <div class="pull-right">
           <!-- TO DO: Implement working resequence button and deactivate button -->
+          <%= link_to(fa_icon("times", class: "pull-right"), deactivate_trees_path(id: h[:id]), {'remote' => true, 'data-confirm' => I18n.t('app.labels.confirm_deactivate', item: "#{@hierarchies[@treeTypeRec[:outcome_depth]]} - #{h[:text].html_safe}"), method: :post}) %>
           <a class="" href="/<%= @locale_code %>/trees/<%= h[:id] %>?editme=<%= h[:id] %>">
             <i class="fa fa-edit pull-right" data-toggle="tooltip" title="<%= I18n.translate("trees.edit.tooltip", tree_depth_name: @hierarchies[@treeTypeRec[:outcome_depth]], tree_code: h[:formatted_code]) %>"></i>
           </a>

--- a/app/views/trees/_create.html.erb
+++ b/app/views/trees/_create.html.erb
@@ -6,6 +6,7 @@
   <%= @translation.value.html_safe %>
   <div class="pull-right">
     <!-- TO DO: Implement working resequence button and deactivate button -->
+    <%= link_to(fa_icon("times", class: "pull-right"), deactivate_trees_path(id: @tree.id), {'remote' => true, 'data-confirm' => I18n.t('app.labels.confirm_deactivate', item: "#{@hierarchies[@treeTypeRec[:outcome_depth]]} - #{@translation.value.html_safe}"), method: :post}) %>
     <a class="" href="/<%= @locale_code %>/trees/<%= @tree.id %>?editme=<%= @tree.id %>">
       <i class="fa fa-edit pull-right" data-toggle="tooltip" title="<%= I18n.translate("trees.edit.tooltip", tree_depth_name: @hierarchies[@treeTypeRec[:outcome_depth]], tree_code: formatted_code) %>"></i>
     </a>

--- a/app/views/trees/deactivate.js.erb
+++ b/app/views/trees/deactivate.js.erb
@@ -1,0 +1,12 @@
+var tree_codes_changed = JSON.parse('<%= @tree_codes_changed.to_json.html_safe %>');
+var subject_code = $("#subject_code_hidden").text();
+$("#"+subject_code+"_tree_<%= @tree.id%>").remove();
+tree_codes_changed.forEach(function (h) {
+  $("#"+subject_code+"_tree_"+h["tree_id"])
+    .find(".js-tree-code")
+    .html(
+      "<strong><em>"
+      +h["new_code"]
+      +"</em></strong>"
+    )
+});

--- a/app/views/trees/show.html.erb
+++ b/app/views/trees/show.html.erb
@@ -116,7 +116,7 @@
               detailsHash: @detailsHash,
               can_edit: can_edit_type?(type) || current_user.subject_admin?(@subject_code),
               detail_title: title,
-              tree: @tree,
+              tree: tree,
               indicator: table[:indicator],
               resource_codes: cats,
               parents: (table[:depths].length > 0 ? table[:depths].map { |d| @parents_by_depth[tree.id][d]} : nil) ,

--- a/app/views/trees/show/_alluvial.html.erb
+++ b/app/views/trees/show/_alluvial.html.erb
@@ -1,6 +1,3 @@
-<style type="text/css">
-  .js-alluvial .modebar { display: none; }
-</style>
 <script type="text/javascript">
 
   data = {
@@ -8,7 +5,6 @@
         {
           "type": "sankey",
           "arrangment": "fixed",
-          "showlegend": false,
           "domain": {
             "x": [
               0,
@@ -20,9 +16,7 @@
             ]
           },
           "node": {
-            "x": JSON.parse('<%= alluvial_nodes_xpos.to_json.html_safe %>'),
-            "y": JSON.parse('<%= alluvial_nodes_ypos.to_json.html_safe %>'),
-            "pad": 20,
+            "pad": 50,
             "thickness": 20,
             "line": {
               "color": "black",
@@ -34,29 +28,23 @@
           "link": JSON.parse('<%= alluvial_links.to_json.html_safe %>')
         }],
     "layout": {
-      "title": "<%= chart_name %>",
-      "width": Math.floor($("#js-alluvial-container").width()) - 10,
-      "height": (Math.floor($("#js-alluvial-container").height()) > 300 ? Math.floor($("#js-alluvial-container").height()) : 300),
+      // "title": "<%= chart_name %>",
+       // "width": Math.floor($("#js-alluvial-container").width() - 20),
+       // "height": 400,
+      "showlegend": false,
       "font": {
           "size": 10
       },
     }
   }
 
-  Plotly.plot('js-alluvial-container', data.data, data.layout);
+  var config = {
+    responsive: true,
+    displayModeBar: false,
+    locale: '<%= @locale_code %>',
+    displaylogo: false,
+  }
 
-
-  var resizeTimeout;
-$(window).resize(function() {
-    clearTimeout(resizeTimeout);
-    resizeTimeout = setTimeout(doneResizing, 500);
-});
-
-function doneResizing(){
-  console.log('resiz even')
-  data.layout["width"] = Math.floor($("#js-alluvial-container").width()) - 10;
-  data.layout["height"] = (Math.floor($("#js-alluvial-container").height()) > 300 ? Math.floor($("#js-alluvial-container").height()) : 300);
-    Plotly.plot(document.getElementById('js-alluvial-container'), data.data, data.layout);
-}
+  Plotly.plot('js-alluvial-container', data.data, data.layout, config);
 
 </script>

--- a/app/views/trees/show/_alluvial.html.erb
+++ b/app/views/trees/show/_alluvial.html.erb
@@ -1,40 +1,44 @@
 <script type="text/javascript">
-// Example data:
-// var data = [
-//       ['BI.1.01', 'CP.1.01', 1, 'BI.1.01 applies to CP.1.01'],
-//       ['BI.1.01', 'CP.1.05', 1, 'BI.1.01 applies to CP.1.05'],
-//       ['CH.1.01', null, 1, 'CH.1.01 akin to BI.1.01'],
-//       ['PH.1.01', 'BI.1.01', 1, 'BI.1.01 depends on PH.1.01']
-//     ];
 
-  Highcharts.chart('js-alluvial-container', {
-    title: {
-      text: '<%= chart_name %>'
-    },
-    accessibility: {
-      point: {
-        valueDescriptionFormat: '{index}. {point.from} to {point.to}, {point.tooltip}.'
-      }
-    },
-    series: [{
-      keys: ['from', 'to', 'weight', 'tooltip'],
-      data: JSON.parse('<%= data.to_json.html_safe %>'),
-      type: 'sankey',
-      name: '<%= chart_name %>',
-      tooltip: {
-              headerFormat: '',
-              pointFormat: '<b>{point.tooltip}</b>',
-              nodeFormatter: function() {
-                  var result = '';
-
-                  Highcharts.each(this.linksFrom, function(el) {
-                      result += (el.tooltip && result ? ',' : '') + el.tooltip;
-                  });
-
-                  return result;
-              }
+  data = {
+    "data": [
+        {
+          "type": "sankey",
+          "displayModeBar": false,
+          "arrangment": "fixed",
+          "showlegend": false,
+          "domain": {
+            "x": [
+              0,
+              1
+            ],
+            "y": [
+              0,
+              1
+            ]
           },
-    }],
-  });
+          "node": {
+            "pad": 20,
+            "thickness": 20,
+            "line": {
+              "color": "black",
+              "width": 0.5
+            },
+            "label": JSON.parse('<%= alluvial_nodes.to_json.html_safe %>'),
+            "color": JSON.parse('<%= alluvial_node_colors.to_json.html_safe %>'),
+          },
+          "link": JSON.parse('<%= alluvial_links.to_json.html_safe %>')
+        }],
+    "layout": {
+      "title": "<%= chart_name %>",
+      "width": Math.floor($("#js-alluvial-container").width()) - 10,
+      "height": (Math.floor($("#js-alluvial-container").height()) > 300 ? Math.floor($("#js-alluvial-container").height()) : 300),
+      "font": {
+          "size": 10
+      },
+    }
+  }
+
+  Plotly.plot('js-alluvial-container', data.data, data.layout);
 
 </script>

--- a/app/views/trees/show/_alluvial.html.erb
+++ b/app/views/trees/show/_alluvial.html.erb
@@ -4,7 +4,6 @@
     "data": [
         {
           "type": "sankey",
-          "arrangment": "fixed",
           "domain": {
             "x": [
               0,
@@ -16,7 +15,7 @@
             ]
           },
           "node": {
-            "pad": 50,
+            "pad": 20,
             "thickness": 20,
             "line": {
               "color": "black",
@@ -28,12 +27,17 @@
           "link": JSON.parse('<%= alluvial_links.to_json.html_safe %>')
         }],
     "layout": {
-      // "title": "<%= chart_name %>",
-       // "width": Math.floor($("#js-alluvial-container").width() - 20),
-       // "height": 400,
+       // "title": "<%= chart_name %>",
       "showlegend": false,
       "font": {
           "size": 10
+      },
+      "margin": {
+        "l": 5,
+        "r": 0,
+        "b": 50,
+        "t": 50,
+        "pad": 4
       },
     }
   }

--- a/app/views/trees/show/_alluvial.html.erb
+++ b/app/views/trees/show/_alluvial.html.erb
@@ -4,7 +4,6 @@
     "data": [
         {
           "type": "sankey",
-          "displayModeBar": false,
           "arrangment": "fixed",
           "showlegend": false,
           "domain": {
@@ -18,6 +17,8 @@
             ]
           },
           "node": {
+            "x": JSON.parse('<%= alluvial_nodes_xpos.to_json.html_safe %>'),
+            "y": JSON.parse('<%= alluvial_nodes_ypos.to_json.html_safe %>'),
             "pad": 20,
             "thickness": 20,
             "line": {
@@ -40,5 +41,19 @@
   }
 
   Plotly.plot('js-alluvial-container', data.data, data.layout);
+
+
+  var resizeTimeout;
+$(window).resize(function() {
+    clearTimeout(resizeTimeout);
+    resizeTimeout = setTimeout(doneResizing, 500);
+});
+
+function doneResizing(){
+  console.log('resiz even')
+  data.layout["width"] = Math.floor($("#js-alluvial-container").width()) - 10;
+  data.layout["height"] = (Math.floor($("#js-alluvial-container").height()) > 300 ? Math.floor($("#js-alluvial-container").height()) : 300);
+    Plotly.plot(document.getElementById('js-alluvial-container'), data.data, data.layout);
+}
 
 </script>

--- a/app/views/trees/show/_alluvial.html.erb
+++ b/app/views/trees/show/_alluvial.html.erb
@@ -1,3 +1,6 @@
+<style type="text/css">
+  .js-alluvial .modebar { display: none; }
+</style>
 <script type="text/javascript">
 
   data = {

--- a/app/views/trees/show/_alluvial.html.erb
+++ b/app/views/trees/show/_alluvial.html.erb
@@ -1,0 +1,40 @@
+<script type="text/javascript">
+// Example data:
+// var data = [
+//       ['BI.1.01', 'CP.1.01', 1, 'BI.1.01 applies to CP.1.01'],
+//       ['BI.1.01', 'CP.1.05', 1, 'BI.1.01 applies to CP.1.05'],
+//       ['CH.1.01', null, 1, 'CH.1.01 akin to BI.1.01'],
+//       ['PH.1.01', 'BI.1.01', 1, 'BI.1.01 depends on PH.1.01']
+//     ];
+
+  Highcharts.chart('js-alluvial-container', {
+    title: {
+      text: '<%= chart_name %>'
+    },
+    accessibility: {
+      point: {
+        valueDescriptionFormat: '{index}. {point.from} to {point.to}, {point.tooltip}.'
+      }
+    },
+    series: [{
+      keys: ['from', 'to', 'weight', 'tooltip'],
+      data: JSON.parse('<%= data.to_json.html_safe %>'),
+      type: 'sankey',
+      name: '<%= chart_name %>',
+      tooltip: {
+              headerFormat: '',
+              pointFormat: '<b>{point.tooltip}</b>',
+              nodeFormatter: function() {
+                  var result = '';
+
+                  Highcharts.each(this.linksFrom, function(el) {
+                      result += (el.tooltip && result ? ',' : '') + el.tooltip;
+                  });
+
+                  return result;
+              }
+          },
+    }],
+  });
+
+</script>

--- a/app/views/trees/show/_alluvial.html.erb
+++ b/app/views/trees/show/_alluvial.html.erb
@@ -23,6 +23,7 @@
             },
             "label": JSON.parse('<%= alluvial_nodes.to_json.html_safe %>'),
             "color": JSON.parse('<%= alluvial_node_colors.to_json.html_safe %>'),
+            "hovertemplate": '<b>%{label}</b>',
           },
           "link": JSON.parse('<%= alluvial_links.to_json.html_safe %>')
         }],

--- a/app/views/trees/show/_treetree.html.erb
+++ b/app/views/trees/show/_treetree.html.erb
@@ -45,20 +45,41 @@
     <div class='connections-grid'>
       <%
         connectionsFound = 0
-        alluvial_data = []
+        alluvial_nodes = [tree.format_code(@locale_code)]
+        alluvial_node_colors = [BaseRec.subject_color(tree.subject.code)]
+        alluvial_links =  {
+              "hoverInfo": "label",
+              "source": [],
+              "target": [],
+              "value": [],
+              "color": [],
+              "label": []
+            }
         tree_code = tree.format_code(@locale_code)
       %>
       <% @relatedBySubj.each do |subj, rel|%>
         <% rel.each do |r|
            connectionsFound += 1
+           alluvial_nodes << r[:code]
+           alluvial_node_colors << BaseRec.subject_color(r[:subj_code])
            case r[:rel_code]
               when TreeTree::DEPENDS_KEY
-                alluvial_data << [r[:code], tree_code, 1, "#{tree_code} #{r[:relationship]} #{r[:code]}"]
+                alluvial_links[:source] << connectionsFound
+                alluvial_links[:target] << 0
+                alluvial_links[:color] << "rgb(255, 201, 181)"
+                alluvial_links[:label] << "#{tree_code} #{r[:relationship]} #{r[:code]}"
               when TreeTree::APPLIES_KEY
-                alluvial_data << [tree_code, r[:code], 1, "#{tree_code} #{r[:relationship]} #{r[:code]}"]
+                alluvial_links[:source] << 0
+                alluvial_links[:target] << connectionsFound
+                alluvial_links[:color] << "rgb(255, 253, 181)"
+                alluvial_links[:label] << "#{tree_code} #{r[:relationship]} #{r[:code]}"
               else
-                alluvial_data << [r[:code], nil, 1, "#{tree_code} #{r[:relationship]} #{r[:code]}"]
+                alluvial_links[:source] << connectionsFound
+                alluvial_links[:target] << 0
+                alluvial_links[:color] << "white"
+                alluvial_links[:label] << "#{tree_code} #{r[:relationship]} #{r[:code]}"
            end
+           alluvial_links[:value] << 1
         %>
           <div class='connections-item'>
             <%= r[:relationship] %>
@@ -100,8 +121,10 @@
   </div>
 </div>
 <%= render partial: "trees/show/alluvial", locals: {
-    data: alluvial_data,
+    alluvial_nodes: alluvial_nodes,
+    alluvial_node_colors: alluvial_node_colors,
+    alluvial_links: alluvial_links,
     chart_name: detail_title
-  } if alluvial_data.length > 0
+  } if connectionsFound > 0
 %>
 

--- a/app/views/trees/show/_treetree.html.erb
+++ b/app/views/trees/show/_treetree.html.erb
@@ -114,7 +114,7 @@
           </div>
       <% end %>
     </div>
-    <div class="connections-grid connections-grid__diagram">
+    <div class="connections-grid connections-grid__diagram <%= "min-alluvial-height" if connectionsFound > 0 %>">
       <div class='js-alluvial connections-item rel-sectors'>
         <div id='js-alluvial-container'></div>
       </div>

--- a/app/views/trees/show/_treetree.html.erb
+++ b/app/views/trees/show/_treetree.html.erb
@@ -46,6 +46,10 @@
       <%
         connectionsFound = 0
         alluvial_nodes = [tree.format_code(@locale_code)]
+        alluvial_node_pos = {:x => [0.5], :y => [0]}
+        leftNodes = 0
+        midNodes = 1
+        rightNodes = 0
         alluvial_node_colors = [BaseRec.subject_color(tree.subject.code)]
         alluvial_links =  {
               "hoverInfo": "label",
@@ -65,16 +69,25 @@
            case r[:rel_code]
               when TreeTree::DEPENDS_KEY
                 alluvial_links[:source] << connectionsFound
+                leftNodes += 1
+                alluvial_node_pos[:x] << -0.2
+                alluvial_node_pos[:y] << leftNodes
                 alluvial_links[:target] << 0
                 alluvial_links[:color] << "rgb(255, 201, 181)"
                 alluvial_links[:label] << "#{tree_code} #{r[:relationship]} #{r[:code]}"
               when TreeTree::APPLIES_KEY
                 alluvial_links[:source] << 0
+                rightNodes += 1
+                alluvial_node_pos[:x] << 1.2
+                alluvial_node_pos[:y] << rightNodes
                 alluvial_links[:target] << connectionsFound
                 alluvial_links[:color] << "rgb(255, 253, 181)"
                 alluvial_links[:label] << "#{tree_code} #{r[:relationship]} #{r[:code]}"
               else
                 alluvial_links[:source] << connectionsFound
+                leftNodes += 1
+                alluvial_node_pos[:x] << -0.2
+                alluvial_node_pos[:y] << leftNodes
                 alluvial_links[:target] << 0
                 alluvial_links[:color] << "white"
                 alluvial_links[:label] << "#{tree_code} #{r[:relationship]} #{r[:code]}"
@@ -122,6 +135,8 @@
 </div>
 <%= render partial: "trees/show/alluvial", locals: {
     alluvial_nodes: alluvial_nodes,
+    alluvial_nodes_xpos: alluvial_node_pos[:x],
+    alluvial_nodes_ypos: alluvial_node_pos[:y].map { |pos| (pos/[leftNodes,rightNodes].max) },
     alluvial_node_colors: alluvial_node_colors,
     alluvial_links: alluvial_links,
     chart_name: detail_title

--- a/app/views/trees/show/_treetree.html.erb
+++ b/app/views/trees/show/_treetree.html.erb
@@ -43,10 +43,22 @@
   </div>
   <div class="row">
     <div class='connections-grid'>
-      <% connectionsFound = 0 %>
+      <%
+        connectionsFound = 0
+        alluvial_data = []
+        tree_code = tree.format_code(@locale_code)
+      %>
       <% @relatedBySubj.each do |subj, rel|%>
         <% rel.each do |r|
            connectionsFound += 1
+           case r[:rel_code]
+              when TreeTree::DEPENDS_KEY
+                alluvial_data << [r[:code], tree_code, 1, "#{tree_code} #{r[:relationship]} #{r[:code]}"]
+              when TreeTree::APPLIES_KEY
+                alluvial_data << [tree_code, r[:code], 1, "#{tree_code} #{r[:relationship]} #{r[:code]}"]
+              else
+                alluvial_data << [r[:code], nil, 1, "#{tree_code} #{r[:relationship]} #{r[:code]}"]
+           end
         %>
           <div class='connections-item'>
             <%= r[:relationship] %>
@@ -82,8 +94,14 @@
       <% end %>
     </div>
     <div class="connections-grid connections-grid__diagram">
-      <div class='connections-item rel-sectors'>
+      <div id='js-alluvial-container' class='js-alluvial connections-item rel-sectors'>
       </div>
     </div>
   </div>
 </div>
+<%= render partial: "trees/show/alluvial", locals: {
+    data: alluvial_data,
+    chart_name: detail_title
+  } if alluvial_data.length > 0
+%>
+

--- a/app/views/trees/show/_treetree.html.erb
+++ b/app/views/trees/show/_treetree.html.erb
@@ -48,7 +48,7 @@
         alluvial_nodes = [tree.format_code(@locale_code)]
         alluvial_node_colors = [BaseRec.subject_color(tree.subject.code)]
         alluvial_links =  {
-              "hoverInfo": "label",
+              "hovertemplate": '<b>%{label}</b>',
               "source": [],
               "target": [],
               "value": [],
@@ -67,17 +67,17 @@
                 alluvial_links[:source] << connectionsFound
                 alluvial_links[:target] << 0
                 alluvial_links[:color] << "rgb(255, 201, 181)"
-                alluvial_links[:label] << "#{tree_code} #{r[:relationship].downcase} #{r[:code]}"
+                alluvial_links[:label] << "#{tree_code}<br>#{r[:relationship].downcase}<br>#{r[:code]}"
               when TreeTree::APPLIES_KEY
                 alluvial_links[:source] << 0
                 alluvial_links[:target] << connectionsFound
                 alluvial_links[:color] << "rgb(255, 253, 181)"
-                alluvial_links[:label] << "#{tree_code} #{r[:relationship].downcase} #{r[:code]}"
+                alluvial_links[:label] << "#{tree_code}<br>#{r[:relationship].downcase}<br>#{r[:code]}"
               else
                 alluvial_links[:source] << connectionsFound
                 alluvial_links[:target] << 0
                 alluvial_links[:color] << "white"
-                alluvial_links[:label] << "#{tree_code} #{r[:relationship].downcase} #{r[:code]}"
+                alluvial_links[:label] << "#{tree_code}<br>#{r[:relationship].downcase}<br>#{r[:code]}"
            end
            alluvial_links[:value] << 1
         %>

--- a/app/views/trees/show/_treetree.html.erb
+++ b/app/views/trees/show/_treetree.html.erb
@@ -46,10 +46,6 @@
       <%
         connectionsFound = 0
         alluvial_nodes = [tree.format_code(@locale_code)]
-        alluvial_node_pos = {:x => [0.5], :y => [0]}
-        leftNodes = 0
-        midNodes = 1
-        rightNodes = 0
         alluvial_node_colors = [BaseRec.subject_color(tree.subject.code)]
         alluvial_links =  {
               "hoverInfo": "label",
@@ -69,28 +65,19 @@
            case r[:rel_code]
               when TreeTree::DEPENDS_KEY
                 alluvial_links[:source] << connectionsFound
-                leftNodes += 1
-                alluvial_node_pos[:x] << -0.2
-                alluvial_node_pos[:y] << leftNodes
                 alluvial_links[:target] << 0
                 alluvial_links[:color] << "rgb(255, 201, 181)"
-                alluvial_links[:label] << "#{tree_code} #{r[:relationship]} #{r[:code]}"
+                alluvial_links[:label] << "#{tree_code} #{r[:relationship].downcase} #{r[:code]}"
               when TreeTree::APPLIES_KEY
                 alluvial_links[:source] << 0
-                rightNodes += 1
-                alluvial_node_pos[:x] << 1.2
-                alluvial_node_pos[:y] << rightNodes
                 alluvial_links[:target] << connectionsFound
                 alluvial_links[:color] << "rgb(255, 253, 181)"
-                alluvial_links[:label] << "#{tree_code} #{r[:relationship]} #{r[:code]}"
+                alluvial_links[:label] << "#{tree_code} #{r[:relationship].downcase} #{r[:code]}"
               else
                 alluvial_links[:source] << connectionsFound
-                leftNodes += 1
-                alluvial_node_pos[:x] << -0.2
-                alluvial_node_pos[:y] << leftNodes
                 alluvial_links[:target] << 0
                 alluvial_links[:color] << "white"
-                alluvial_links[:label] << "#{tree_code} #{r[:relationship]} #{r[:code]}"
+                alluvial_links[:label] << "#{tree_code} #{r[:relationship].downcase} #{r[:code]}"
            end
            alluvial_links[:value] << 1
         %>
@@ -128,15 +115,14 @@
       <% end %>
     </div>
     <div class="connections-grid connections-grid__diagram">
-      <div id='js-alluvial-container' class='js-alluvial connections-item rel-sectors'>
+      <div class='js-alluvial connections-item rel-sectors'>
+        <div id='js-alluvial-container'></div>
       </div>
     </div>
   </div>
 </div>
 <%= render partial: "trees/show/alluvial", locals: {
     alluvial_nodes: alluvial_nodes,
-    alluvial_nodes_xpos: alluvial_node_pos[:x],
-    alluvial_nodes_ypos: alluvial_node_pos[:y].map { |pos| (pos/[leftNodes,rightNodes].max) },
     alluvial_node_colors: alluvial_node_colors,
     alluvial_links: alluvial_links,
     chart_name: detail_title

--- a/app/views/trees/show/_treetree.html.erb
+++ b/app/views/trees/show/_treetree.html.erb
@@ -10,72 +10,80 @@
         <% end %>
     </div>
   </div>
-  <div class='connections-grid'>
-    <div class='connections-header'>
-      <div class='center-label sub-header-margin'>
-        <%= I18n.t('trees.labels.relation') %>
+  <div class="row">
+    <div class='connections-grid'>
+      <div class='connections-header'>
+        <div class='center-label sub-header-margin'>
+          <%= I18n.t('trees.labels.relation') %>
+        </div>
+      </div>
+      <div class='connections-header'>
+        <div class='center-label sub-header-margin'>
+          <%= I18n.t('app.labels.subject') %>
+        </div>
+      </div>
+      <div class='connections-header'>
+        <div class='center-label sub-header-margin'>
+          <%= I18n.t('app.labels.code') %>
+        </div>
+      </div>
+      <div class='connections-header'>
+        <div class='center-label sub-header-margin'>
+          <%= I18n.t('app.labels.description') %>
+        </div>
       </div>
     </div>
-    <div class='connections-header'>
-      <div class='center-label sub-header-margin'>
-        <%= I18n.t('app.labels.subject') %>
-      </div>
-    </div>
-    <div class='connections-header'>
-      <div class='center-label sub-header-margin'>
-        <%= I18n.t('app.labels.code') %>
-      </div>
-    </div>
-    <div class='connections-header'>
-      <div class='center-label sub-header-margin'>
-        <%= I18n.t('app.labels.description') %>
-      </div>
-    </div>
-    <div class='connections-header'>
-      <div class='center-label sub-header-margin'>
-        <%= I18n.t('app.labels.alluvial') %>
+    <div class="connections-grid connections-grid__diagram">
+      <div class='connections-header'>
+        <div class='center-label sub-header-margin'>
+          <%= I18n.t('app.labels.alluvial') %>
+        </div>
       </div>
     </div>
   </div>
-  <div class='connections-grid'>
-    <% connectionsFound = 0 %>
-    <% @relatedBySubj.each do |subj, rel|%>
-      <% rel.each do |r|
-         connectionsFound += 1
-      %>
-        <div class='connections-item'>
-          <%= r[:relationship] %>
-        </div>
-        <div class='connections-item'>
-          <%= r[:subj] %>
-        </div>
-        <div class='connections-item'>
-          <%= r[:code] %>
-        </div>
-        <div class='connections-item'>
-          <% if r[:tid] == 0 %>
-            <%= @translations[r[:tkey]] %>
-          <% else %>
-            <a href='/<%= @locale_code %>/trees/<%= r[:tid] %>'><%= @translations[r[:tkey]] %></a>
-          <% end %>
-          <% if @editMe && can_edit %>
-            <%= link_to(fa_icon("times"), tree_path(@tree.id, tree: { edit_type: 'treetree', attr_id: r[:ttid], active: false}, tree_tree: {active: false}), {:class => "fa-lg pull-right", 'data-confirm' => I18n.t('app.labels.confirm_deactivate', item: I18n.t("trees.labels.#{subj}") + ": " + r[:code]), method: :patch}) if @editMe && can_edit %>
-            <%= link_to(fa_icon("edit"), edit_tree_path(@tree.id, tree: { edit_type: 'treetree', attr_id: r[:ttid]}), {:remote => true, :class => "fa-lg pull-right", 'data-toggle' =>  "modal", 'data-target' => '#modal_popup'}) if @editMe && can_edit %>
-          <% end %>
-        </div>
+  <div class="row">
+    <div class='connections-grid'>
+      <% connectionsFound = 0 %>
+      <% @relatedBySubj.each do |subj, rel|%>
+        <% rel.each do |r|
+           connectionsFound += 1
+        %>
+          <div class='connections-item'>
+            <%= r[:relationship] %>
+          </div>
+          <div class='connections-item'>
+            <%= r[:subj] %>
+          </div>
+          <div class='connections-item'>
+            <%= r[:code] %>
+          </div>
+          <div class='connections-item'>
+            <% if r[:tid] == 0 %>
+              <%= @translations[r[:tkey]] %>
+            <% else %>
+              <a href='/<%= @locale_code %>/trees/<%= r[:tid] %>'><%= @translations[r[:tkey]] %></a>
+            <% end %>
+            <% if @editMe && can_edit %>
+              <%= link_to(fa_icon("times"), tree_path(@tree.id, tree: { edit_type: 'treetree', attr_id: r[:ttid], active: false}, tree_tree: {active: false}), {:class => "fa-lg pull-right", 'data-confirm' => I18n.t('app.labels.confirm_deactivate', item: I18n.t("trees.labels.#{subj}") + ": " + r[:code]), method: :patch}) if @editMe && can_edit %>
+              <%= link_to(fa_icon("edit"), edit_tree_path(@tree.id, tree: { edit_type: 'treetree', attr_id: r[:ttid]}), {:remote => true, :class => "fa-lg pull-right", 'data-toggle' =>  "modal", 'data-target' => '#modal_popup'}) if @editMe && can_edit %>
+            <% end %>
+          </div>
+        <% end %>
       <% end %>
-    <% end %>
-    <div class='connections-item rel-sectors'>
+      <% if connectionsFound == 0 %>
+          <div class='connections-item rel-sectors'>
+          </div>
+          <div class='connections-item rel-sectors'>
+          </div>
+          <div class='connections-item rel-sectors'>
+          </div>
+          <div class='connections-item rel-sectors'>
+          </div>
+      <% end %>
     </div>
-    <% if connectionsFound == 0 %>
-        <div class='connections-item rel-sectors'>
-        </div>
-        <div class='connections-item rel-sectors'>
-        </div>
-        <div class='connections-item rel-sectors'>
-        </div>
-        <div class='connections-item rel-sectors'>
-        </div>
-    <% end %>
+    <div class="connections-grid connections-grid__diagram">
+      <div class='connections-item rel-sectors'>
+      </div>
+    </div>
   </div>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -43,6 +43,7 @@ scope "(:locale)", locale: /tr|en|ar_EG/ do
       post 'create_dim_tree'
       patch 'update_dim_tree'
       get 'maint'
+      post 'deactivate'
     end
   end
   match '/dim_tree', :to => "trees#dim_tree_add_edit", :as => :dim_tree_path, :via => [:post, :patch, :put]


### PR DESCRIPTION
**Connections to Other Outcomes (Tree Detail Page)**
- fix layout of connections grid (was broken for trees with multiple connections after adding the alluvial diagram column)
- Add plot.ly sankey/alluvial diagram to the placeholder. Currently getting the library from a version-locked cdn.  

**Deactivate LOs (Editing Page)**
- Make it possible to deactivate Learning Outcomes. 
  - NOTE: Once outcomes have been manually added on the editing page, re-running an upload in the same subject will create duplicate records for all of the original upload trees. This happens regardless of whether the manually added trees have been deactivated before re-running the upload.